### PR TITLE
Recognize /dev/cu in args.serial

### DIFF
--- a/tools/uf2conv.py
+++ b/tools/uf2conv.py
@@ -311,7 +311,7 @@ def main():
             error("Family ID needs to be a number or one of: " + ", ".join(families.keys()))
 
     if args.serial:
-        if str(args.serial).startswith("/dev/tty") or str(args.serial).startswith("COM"):
+        if str(args.serial).startswith("/dev/tty") or str(args.serial).startswith("COM") or str(args.serial).startswith("/dev/cu"):
             try:
                 print("Resetting "+str(args.serial))
                 try:


### PR DESCRIPTION
Sketch upload to serial port fails on macos because the Arduino IDE uses the callout device "/dev/cu". Adding recognition of "/dev/cu" to uf2conv.py makes the sketch upload work.

Addresses #46 