### PR TITLE
fix: make the package manager JSON arduino-cli friendly

### DIFF
--- a/package/build_boards_manager_package.sh
+++ b/package/build_boards_manager_package.sh
@@ -130,7 +130,7 @@ jq_arg=".packages[0].platforms[0].version = \"$visiblever\" | \
 
 if [ -z "$is_nightly" ]; then
     jq_arg="$jq_arg |\
-        .packages[0].platforms[0].size = \"$size\" |\
+        .packages[0].platforms[0].size = \"${size-0}\" |\
         .packages[0].platforms[0].checksum = \"SHA-256:$sha\""
 fi
 


### PR DESCRIPTION
The Arduino CLI chokes when trying to install the current version. It spits the following error:

```
Error updating core and libraries index: invalid package index in https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json: json: invalid number literal, trying to unmarshal "\"\"" into Number
```

You can reproduce it by installing the arduino CLI, then adding the URL to your `arduino-cli.yaml` file:

```yaml
board_manager:
  additional_urls:
  - https://github.com/earlephilhower/arduino-pico/releases/download/global/package_rp2040_index.json: json
```

It seems like it gets confused by several files which has size set to "" (an empty string). 

This PR sets size to "0" in case it's empty, making the Arduino CLI accept the JSON file. Not sure why the size was empty in the first place - perhaps there's a deeper bug that hides here, but I wasn't able to get the `build_boards_manager_package.sh` script to run locally, so I couldn't investigate further.

p.s. thanks for making this Pico Core for Arduino! 

I'm planning to talk about it next week in a [live stream where I code an emulator for the pico](https://hackaday.io/project/177082-raspberry-pi-pico-emulator)