### PR TITLE
correct analogReadTemp KEYWORD

### DIFF
--- a/libraries/rp2040/keywords.txt
+++ b/libraries/rp2040/keywords.txt
@@ -1,2 +1,2 @@
 BOOTSEL	KEYWORD1
-readAnalogTemp	KEYWORD1
+analogReadTemp	KEYWORD1


### PR DESCRIPTION
reference: cores/rp2040/wiring_analog.cpp:108:extern "C" float analogReadTemp()