### PR TITLE
Allow misaligned pgm_read_XXX macro reads

### DIFF
--- a/cores/rp2040/Arduino.h
+++ b/cores/rp2040/Arduino.h
@@ -68,6 +68,7 @@ float analogReadTemp();  // Returns core temp in Centigrade
 // PWM
 void analogWrite(pin_size_t pinNumber, int value);
 
+// Timing
 void delay(unsigned long);
 void delayMicroseconds(unsigned int us);
 unsigned long millis();


### PR DESCRIPTION
Update the ArduinoAPI with new macros/inlines that allow accessing
values that are not naturally aligned (i.e. an int at address 0x0001).

Fixes #79