### PR TITLE
Set default pins for peripherals per datasheet

### DIFF
--- a/cores/rp2040/SerialUART.cpp
+++ b/cores/rp2040/SerialUART.cpp
@@ -179,8 +179,8 @@ SerialUART::operator bool() {
     return _running;
 }
 
-SerialUART Serial1(uart0, 0, 1);
-SerialUART Serial2(uart1, 4, 5);
+SerialUART Serial1(uart0, PIN_SERIAL1_TX, PIN_SERIAL1_RX);
+SerialUART Serial2(uart1, PIN_SERIAL2_TX, PIN_SERIAL2_RX);
 
 void arduino::serialEvent1Run(void) {
     if (serialEvent1 && Serial1.available()) {

--- a/cores/rp2040/SerialUART.h
+++ b/cores/rp2040/SerialUART.h
@@ -18,8 +18,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#ifndef __SERIALUART_H__
-#define __SERIALUART_H__
+#pragma once
 
 #include <Arduino.h>
 #include "api/HardwareSerial.h"
@@ -67,5 +66,3 @@ namespace arduino {
     extern void serialEvent1Run(void) __attribute__((weak));
     extern void serialEvent2Run(void) __attribute__((weak));
 };
-
-#endif

--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -232,5 +232,5 @@ void SPIClassRP2040::setClockDivider(uint8_t uc_div) {
   (void) uc_div; // no-op
 }
 
-SPIClassRP2040 SPI(spi0, 0, 1, 2, 3);
-SPIClassRP2040 SPI1(spi1, 8, 9, 10, 11);
+SPIClassRP2040 SPI(spi0, PIN_SPI0_MISO, PIN_SPI0_SS, PIN_SPI0_SCK, PIN_SPI0_MOSI);
+SPIClassRP2040 SPI1(spi1, PIN_SPI1_MISO, PIN_SPI1_SS, PIN_SPI1_SCK, PIN_SPI1_MOSI);

--- a/libraries/SPI/SPI.h
+++ b/libraries/SPI/SPI.h
@@ -18,8 +18,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#ifndef _SPI_H_INCLUDED
-#define _SPI_H_INCLUDED
+#pragma once
 
 #include <Arduino.h>
 #include <api/HardwareSPI.h>
@@ -79,6 +78,3 @@ private:
 
 extern SPIClassRP2040 SPI;
 extern SPIClassRP2040 SPI1;
-
-#endif
-

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -335,5 +335,5 @@ void TwoWire::onRequest(void(*function)(void))
     _onRequestCallback = function;
 }
 
-TwoWire Wire(i2c0, 0, 1);
-TwoWire Wire1(i2c1, 2, 3);
+TwoWire Wire(i2c0, PIN_WIRE0_SDA, PIN_WIRE0_SCL);
+TwoWire Wire1(i2c1, PIN_WIRE1_SDA, PIN_WIRE1_SCL);

--- a/libraries/Wire/Wire.h
+++ b/libraries/Wire/Wire.h
@@ -21,8 +21,7 @@
  * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
  */
 
-#ifndef TwoWire_h
-#define TwoWire_h
+#pragma once
 
 #include <Arduino.h>
 #include "api/HardwareI2C.h"
@@ -105,6 +104,3 @@ private:
 
 extern TwoWire Wire;
 extern TwoWire Wire1;
-
-#endif
-

--- a/libraries/Wire/examples/TalkingToMyself/TalkingToMyself.ino
+++ b/libraries/Wire/examples/TalkingToMyself/TalkingToMyself.ino
@@ -11,7 +11,11 @@
 void setup() {
     Serial.begin(115200);
     delay(5000);
+    Wire.setSDA(0);
+    Wire.setSCL(1);
     Wire.begin();
+    Wire1.setSDA(2);
+    Wire1.setSCL(3);
     Wire1.begin(0x30);
     Wire1.onReceive(recv);
     Wire1.onRequest(req);

--- a/variants/adafruitfeather/pins_arduino.h
+++ b/variants/adafruitfeather/pins_arduino.h
@@ -1,8 +1,41 @@
-#ifndef __rpipico_pins_arduino_h__
-#define __rpipico_pins_arduino_h__
+#pragma once
 
-#define LED_BUILTIN 13
+// Pin definitions taken from:
+//    https://learn.adafruit.com/assets/100337
+
+// LEDs
+#define PIN_LED        (13u)
+
+// Serial
+#define PIN_SERIAL1_TX (0u)
+#define PIN_SERIAL1_RX (1u)
+
+// Not pinned out
+#define PIN_SERIAL2_TX (31u)
+#define PIN_SERIAL2_RX (31u)
+
+// SPI
+#define PIN_SPI0_MISO  (20u)
+#define PIN_SPI0_MOSI  (19u)
+#define PIN_SPI0_SCK   (18u)
+#define PIN_SPI0_SS    (17u)
+
+// Not pinned out
+#define PIN_SPI1_MISO  (31u)
+#define PIN_SPI1_MOSI  (31u)
+#define PIN_SPI1_SCK   (31u)
+#define PIN_SPI1_SS    (31u)
+
+// Wire
+#define PIN_WIRE0_SDA  (2u)
+#define PIN_WIRE0_SCL  (3u)
+
+// Not pinned out
+#define PIN_WIRE1_SDA  (31u)
+#define PIN_WIRE1_SCL  (31u)
+
+#define SERIAL_HOWMANY (2u)
+#define SPI_HOWMANY    (1u)
+#define WIRE_HOWMANY   (1u)
 
 #include "../generic/common.h"
-
-#endif

--- a/variants/generic/common.h
+++ b/variants/generic/common.h
@@ -1,63 +1,50 @@
-#ifndef __generic_common_h__
-#define __generic_common_h__
+#pragma once
 
-#include <Arduino.h>
+#define PINS_COUNT          (30u)
+#define NUM_DIGITAL_PINS    (30u)
+#define NUM_ANALOG_INPUTS   (4u)
+#define NUM_ANALOG_OUTPUTS  (0u)
+#define ADC_RESOLUTION      (12u)
 
-static const pin_size_t D0 = 0;
-static const pin_size_t D1 = 1;
-static const pin_size_t D2 = 2;
-static const pin_size_t D3 = 3;
-static const pin_size_t D4 = 4;
-static const pin_size_t D5 = 5;
-static const pin_size_t D6 = 6;
-static const pin_size_t D7 = 7;
-static const pin_size_t D8 = 8;
-static const pin_size_t D9 = 9;
-static const pin_size_t D10 = 10;
-static const pin_size_t D11 = 11;
-static const pin_size_t D12 = 12;
-static const pin_size_t D13 = 13;
-static const pin_size_t D14 = 14;
-static const pin_size_t D15 = 15;
-static const pin_size_t D16 = 16;
-static const pin_size_t D17 = 17;
-static const pin_size_t D18 = 18;
-static const pin_size_t D19 = 19;
-static const pin_size_t D20 = 20;
-static const pin_size_t D21 = 21;
-static const pin_size_t D22 = 22;
-static const pin_size_t D23 = 23;
-static const pin_size_t D24 = 24;
-static const pin_size_t D25 = 25;
-static const pin_size_t D26 = 26;
-static const pin_size_t D27 = 27;
-static const pin_size_t D28 = 28;
-static const pin_size_t D29 = 29;
+#define LED_BUILTIN PIN_LED
 
-static const pin_size_t A0 = 26;
-static const pin_size_t A1 = 27;
-static const pin_size_t A2 = 28;
-static const pin_size_t A3 = 29;
+static const uint8_t D0 = (0u);
+static const uint8_t D1 = (1u);
+static const uint8_t D2 = (2u);
+static const uint8_t D3 = (3u);
+static const uint8_t D4 = (4u);
+static const uint8_t D5 = (5u);
+static const uint8_t D6 = (6u);
+static const uint8_t D7 = (7u);
+static const uint8_t D8 = (8u);
+static const uint8_t D9 = (9u);
+static const uint8_t D10 = (10u);
+static const uint8_t D11 = (11u);
+static const uint8_t D12 = (12u);
+static const uint8_t D13 = (13u);
+static const uint8_t D14 = (14u);
+static const uint8_t D15 = (15u);
+static const uint8_t D16 = (16u);
+static const uint8_t D17 = (17u);
+static const uint8_t D18 = (18u);
+static const uint8_t D19 = (19u);
+static const uint8_t D20 = (20u);
+static const uint8_t D21 = (21u);
+static const uint8_t D22 = (22u);
+static const uint8_t D23 = (23u);
+static const uint8_t D24 = (24u);
+static const uint8_t D25 = (25u);
+static const uint8_t D26 = (26u);
+static const uint8_t D27 = (27u);
+static const uint8_t D28 = (28u);
+static const uint8_t D29 = (29u);
 
+static const uint8_t A0 = (26u);
+static const uint8_t A1 = (27u);
+static const uint8_t A2 = (28u);
+static const uint8_t A3 = (29u);
 
-#ifndef PIN_SPI_SS
-#define PIN_SPI_SS   (1)
-#endif
-#ifndef PIN_SPI_MOSI
-#define PIN_SPI_MOSI (3)
-#endif
-#ifndef PIN_SPI_MISO
-#define PIN_SPI_MISO (0)
-#endif
-#ifndef PIN_SPI_SCK
-#define PIN_SPI_SCK  (2)
-#endif
-
-static const pin_size_t SS = PIN_SPI_SS;
-static const pin_size_t MOSI = PIN_SPI_MOSI;
-static const pin_size_t MISO = PIN_SPI_MISO;
-static const pin_size_t SCK = PIN_SPI_SCK;
-
-
-#endif
-
+static const uint8_t SS = PIN_SPI1_SS;
+static const uint8_t MOSI = PIN_SPI1_MOSI;
+static const uint8_t MISO = PIN_SPI1_MISO;
+static const uint8_t SCK = PIN_SPI1_SCK;

--- a/variants/generic/pins_arduino.h
+++ b/variants/generic/pins_arduino.h
@@ -1,1 +1,39 @@
-#include "common.h"
+#pragma once
+
+// Pin definitions taken from:
+//    https://datasheets.raspberrypi.org/pico/pico-datasheet.pdf
+
+
+// LEDs
+#define PIN_LED        (25u)
+
+// Serial
+#define PIN_SERIAL1_TX (0u)
+#define PIN_SERIAL1_RX (1u)
+
+#define PIN_SERIAL2_TX (8u)
+#define PIN_SERIAL2_RX (9u)
+
+// SPI
+#define PIN_SPI0_MISO  (16u)
+#define PIN_SPI0_MOSI  (19u)
+#define PIN_SPI0_SCK   (18u)
+#define PIN_SPI0_SS    (17u)
+
+#define PIN_SPI1_MISO  (12u)
+#define PIN_SPI1_MOSI  (15u)
+#define PIN_SPI1_SCK   (14u)
+#define PIN_SPI1_SS    (13u)
+
+// Wire
+#define PIN_WIRE0_SDA  (4u)
+#define PIN_WIRE0_SCL  (5u)
+
+#define PIN_WIRE1_SDA  (26u)
+#define PIN_WIRE1_SCL  (27u)
+
+#define SERIAL_HOWMANY (3u)
+#define SPI_HOWMANY    (2u)
+#define WIRE_HOWMANY   (2u)
+
+#include "../generic/common.h"

--- a/variants/rpipico/pins_arduino.h
+++ b/variants/rpipico/pins_arduino.h
@@ -1,8 +1,39 @@
-#ifndef __rpipico_pins_arduino_h__
-#define __rpipico_pins_arduino_h__
+#pragma once
 
-#define LED_BUILTIN 25
+// Pin definitions taken from:
+//    https://datasheets.raspberrypi.org/pico/pico-datasheet.pdf
+
+
+// LEDs
+#define PIN_LED        (25u)
+
+// Serial
+#define PIN_SERIAL1_TX (0u)
+#define PIN_SERIAL1_RX (1u)
+
+#define PIN_SERIAL2_TX (8u)
+#define PIN_SERIAL2_RX (9u)
+
+// SPI
+#define PIN_SPI0_MISO  (16u)
+#define PIN_SPI0_MOSI  (19u)
+#define PIN_SPI0_SCK   (18u)
+#define PIN_SPI0_SS    (17u)
+
+#define PIN_SPI1_MISO  (12u)
+#define PIN_SPI1_MOSI  (15u)
+#define PIN_SPI1_SCK   (14u)
+#define PIN_SPI1_SS    (13u)
+
+// Wire
+#define PIN_WIRE0_SDA  (4u)
+#define PIN_WIRE0_SCL  (5u)
+
+#define PIN_WIRE1_SDA  (26u)
+#define PIN_WIRE1_SCL  (27u)
+
+#define SERIAL_HOWMANY (3u)
+#define SPI_HOWMANY    (2u)
+#define WIRE_HOWMANY   (2u)
 
 #include "../generic/common.h"
-
-#endif


### PR DESCRIPTION
Using the official Raspberry Pi Pico datasheet and the Adafruit Feather
RP2040 schematic, set the default pins for peripherals to match.

Fixes #92