### PR TITLE
More multicore safety plumbing, IRQs, analogXXX

### DIFF
--- a/cores/rp2040/CoreMutex.h
+++ b/cores/rp2040/CoreMutex.h
@@ -33,6 +33,7 @@ public:
         _acquired = false;
         if (!mutex_try_enter(_mutex, &owner)) {
             if (owner == get_core_num()) { // Deadlock!
+                DEBUGCORE("CoreMutex - Deadlock detected!\n");
                 return;
             }
             mutex_enter_blocking(_mutex);


### PR DESCRIPTION
Keep a per-core IRQ stack for noInterrupts since each core has its own
enable/disable.

Make analogRead/analogWrite multicore safe