### PR TITLE
Add multicore support with setup1/loop1

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -34,6 +34,8 @@ For the latest version, always check https://github.com/earlephilhower/arduino-p
 
    Ported/Optimized Libraries <libraries>
 
+   Multicore Processing <multicore>
+
    Using Pico-SDK <sdk>
 
    Licenses <license>

--- a/docs/multicore.rst
+++ b/docs/multicore.rst
@@ -1,0 +1,13 @@
+Multicore Processing
+====================
+
+The RP2040 chip has 2 cores that can run independently of each other, sharing
+peripherals and memory with each other.  Arduino code will normally execute
+only on core 0, with the 2nd core sitting idle in a low power state.
+
+By adding a ``setup1()`` and ``loop1()`` function to your sketch you can make
+use of the second core.  Anything called from within the ``setup1()`` or
+``loop1()`` routines will execute on the second core.
+
+See the ``Multicore.ino`` example in the ``rp2040`` example directory for a
+quick introduction.

--- a/libraries/rp2040/examples/Multicore/Multicore.ino
+++ b/libraries/rp2040/examples/Multicore/Multicore.ino
@@ -1,0 +1,40 @@
+// Demonstrates a simple use of the setup1()/loop1() functions
+// for a multiprocessor run.
+
+// Will output something like, where C0 is running on core 0 and
+// C1 is on core 1, in parallel.
+
+// 11:23:07.507 -> C0: Blue leader standing by...
+// 11:23:07.507 -> C1: Red leader standing by...
+// 11:23:07.507 -> C1: Stay on target...
+// 11:23:08.008 -> C1: Stay on target...
+// 11:23:08.505 -> C0: Blue leader standing by...
+// 11:23:08.505 -> C1: Stay on target...
+// 11:23:09.007 -> C1: Stay on target...
+// 11:23:09.511 -> C0: Blue leader standing by...
+// 11:23:09.511 -> C1: Stay on target...
+// 11:23:10.015 -> C1: Stay on target...
+
+// Released to the public domain
+
+// The normal, core0 setup
+void setup() {
+  Serial.begin();
+  delay(5000);
+}
+
+void loop() {
+  Serial.printf("C0: Blue leader standing by...\n");
+  delay(1000);
+}
+
+// Running on core1
+void setup1() {
+  delay(5000);
+  Serial.printf("C1: Red leader standing by...\n");
+}
+
+void loop1() {
+  Serial.printf("C1: Stay on target...\n");
+  delay(500);
+}


### PR DESCRIPTION
Support running code on the second core by adding a setup1() and/or
a loop1() routine to a sketch.  These functions operate exactly like
the normal Arduino ones, and anything they call will be run on
the second core automatically.

Add a simple multicore example.