### PR TITLE
SF_printable_fix

### DIFF
--- a/cores/rp2040/Printable.h
+++ b/cores/rp2040/Printable.h
@@ -1,0 +1,1 @@
+#include "api/Printable.h"


### PR DESCRIPTION
User requested SafeString library support be added for this project.
https://forum.arduino.cc/t/libraries-updated-to-support-new-rp2040-based-boards-raspberry-pi-pico-etc/860353/3
Current SafeString library works for Arduino Mbed OS RP2040 V2.0.0 board install

This pull request fixes missing Printable.h file
But in order to complete adding the support need a unique define (-D... = .. ) that can be detected by SafeString.h so that the
necessary 
namespace arduino {
can be set
 Arduino Mbed OS RP2040 V2.0.0 has a -DARDUINO_ARCH_MBED_RP2040  define

Can you add a -D to your compile line (and when Arduino detects libraries)
Also dtostrf( ) declaration not found by SafeString library (works with Arduino pico, fixed by an extern ... in SafeString.h )