### PR TITLE
Add stdlib_noniso.h to Arduino.h

### DIFF
--- a/cores/rp2040/Arduino.h
+++ b/cores/rp2040/Arduino.h
@@ -24,9 +24,12 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
+// Wacky deprecated AVR compatibilty functions
+#include "stdlib_noniso.h"
 
 #include "api/ArduinoAPI.h"
 #include <pins_arduino.h>
+
 
 // Required for the port*Register macros
 #include "hardware/gpio.h"


### PR DESCRIPTION
Per #130 request, the dtostrf() definition and others were not visible.