### PR TITLE
Fix SPI default pinouts to SPI0, not SPI1 pins

### DIFF
--- a/variants/generic/common.h
+++ b/variants/generic/common.h
@@ -44,7 +44,7 @@ static const uint8_t A1 = (27u);
 static const uint8_t A2 = (28u);
 static const uint8_t A3 = (29u);
 
-static const uint8_t SS = PIN_SPI1_SS;
-static const uint8_t MOSI = PIN_SPI1_MOSI;
-static const uint8_t MISO = PIN_SPI1_MISO;
-static const uint8_t SCK = PIN_SPI1_SCK;
+static const uint8_t SS = PIN_SPI0_SS;
+static const uint8_t MOSI = PIN_SPI0_MOSI;
+static const uint8_t MISO = PIN_SPI0_MISO;
+static const uint8_t SCK = PIN_SPI0_SCK;


### PR DESCRIPTION
Should fix #134 .  The SPI pin macros were set using the SPI1 set, not
the SPI0 set of pins it should have been using.