### PR TITLE
Remove hack sync__synchronize from main.cpp

### DIFF
--- a/cores/rp2040/main.cpp
+++ b/cores/rp2040/main.cpp
@@ -232,5 +232,3 @@ extern "C" int _wait (int  *status) {
     errno = ENOSYS;
     return -1;
 }
-
-extern "C" void __sync_synchronize() { /* noop */ }


### PR DESCRIPTION
Was required before due to C++ internals, but is not needed anymore thanks
to #137