### PR TITLE
Add defs for compatibility

### DIFF
--- a/cores/rp2040/Arduino.h
+++ b/cores/rp2040/Arduino.h
@@ -40,6 +40,11 @@
 extern "C"{
 #endif // __cplusplus
 
+// For compatibility to many platforms and libraries
+#define clockCyclesPerMicrosecond() ( F_CPU / 1000000L )
+#define clockCyclesToMicroseconds(a) ( (a) / clockCyclesPerMicrosecond() )
+#define microsecondsToClockCycles(a) ( (a) * clockCyclesPerMicrosecond() )
+
 // Disable/reenable all interrupts.  Safely handles nested disables
 void interrupts();
 void noInterrupts();


### PR DESCRIPTION
Add to `Arduino.h` definitions for compatibility to many platforms and libraries
- clockCyclesPerMicrosecond()
- clockCyclesToMicroseconds(a)
- microsecondsToClockCycles(a)
---

All other platforms (see attached list) provide those macros. Without these definitions, we'll get compiler errors when using many libraries.

```
hardware/samd/1.6.8/cores/arduino/Arduino.h:#define microsecondsToClockCycles(a) ( (a) * (SystemCoreClock / 1000000L) )
adafruit/hardware/nrf52/0.21.0/cores/nRF5/Arduino.h:#define microsecondsToClockCycles(a) ( (a) * (SystemCoreClock / 1000000L) )
arduino/hardware/samd/1.8.11/cores/arduino/Arduino.h:#define microsecondsToClockCycles(a) ( (a) * (SystemCoreClock / 1000000L) )
arduino/hardware/avr/1.8.3/cores/arduino/Arduino.h:#define microsecondsToClockCycles(a) ( (a) * clockCyclesPerMicrosecond() )
arduino/hardware/nrf52/1.0.2/cores/arduino/Arduino.h:#define microsecondsToClockCycles(a) ( (a) * (SystemCoreClock / 1000000L) )
arduino/hardware/samd_beta/1.6.25/cores/arduino/Arduino.h:#define microsecondsToClockCycles(a) ( (a) * (SystemCoreClock / 1000000L) )
arduino/hardware/sam/1.6.12/cores/arduino/Arduino.h:#define microsecondsToClockCycles(a) ( (a) * (SystemCoreClock / 1000000L) )
CubeCell/hardware/CubeCell/1.2.0/cores/asr650x/Arduino.h:#define microsecondsToClockCycles(a) ( (a) * clockCyclesPerMicrosecond() )
esp32/hardware/esp32/1.0.6/cores/esp32/Arduino.h:#define microsecondsToClockCycles(a) ( (a) * clockCyclesPerMicrosecond() )
esp8266/hardware/esp8266/2.7.4/cores/esp8266/Arduino.h:#define microsecondsToClockCycles(a) ( (a) * clockCyclesPerMicrosecond() )
esp8266/hardware/esp8266/2.7.4/tests/host/common/Arduino.h:#define microsecondsToClockCycles(a) ( (a) * clockCyclesPerMicrosecond() )
Maixduino/hardware/k210/0.3.11/cores/arduino/Arduino.h:#define microsecondsToClockCycles(a) ( (a) * (SystemCoreClock / 1000000L) )
realtek/hardware/Ameba1/2.0.10/cores/arduino/Arduino.h:#define microsecondsToClockCycles(a) ( (a) * (SystemCoreClock / 1000000L) )
realtek/hardware/AmebaD/3.0.5/cores/arduino/Arduino.h:#define microsecondsToClockCycles(a) ((a) * (SystemCoreClock / 1000000L))
realtek/hardware/ArduinoCore-ambd/cores/arduino/Arduino.h:#define microsecondsToClockCycles(a) ((a) * (SystemCoreClock / 1000000L))
rp2040/hardware/rp2040/1.4.0/cores/rp2040/Arduino.h:#define microsecondsToClockCycles(a) ( (a) * clockCyclesPerMicrosecond() )
Seeeduino/hardware/samd/1.8.1/cores/arduino/Arduino.h:#define microsecondsToClockCycles(a) ( (a) * (SystemCoreClock / 1000000L) )
SparkFun/hardware/samd/1.8.3/cores/arduino51/Arduino.h:#define microsecondsToClockCycles(a) ( (a) * (SystemCoreClock / 1000000L) )
SparkFun/hardware/samd/1.8.3/cores/LilyMini/Arduino.h:#define microsecondsToClockCycles(a) ( (a) * (SystemCoreClock / 1000000L) )
SparkFun/hardware/samd/1.8.3/cores/arduino/Arduino.h:#define microsecondsToClockCycles(a) ( (a) * (SystemCoreClock / 1000000L) )
STM32/hardware/stm32/1.9.0/cores/arduino/wiring.h:#define microsecondsToClockCycles(a) ( (a) * (SystemCoreClock / 1000000L) )
STMicroelectronics/hardware/stm32/2.0.0/cores/arduino/wiring.h:#define microsecondsToClockCycles(a) ( (a) * (SystemCoreClock / 1000000L) )
```

---

For example [DHTtester example](https://github.com/adafruit/DHT-sensor-library/tree/master/examples/DHTtester) of [Adafruit DHT-sensor-library](https://github.com/adafruit/DHT-sensor-library)

```
/home/kh/Arduino/libraries/DHT_sensor_library/DHT.cpp: In constructor 'DHT::DHT(uint8_t, uint8_t, uint8_t)':
/home/kh/Arduino/libraries/DHT_sensor_library/DHT.cpp:51:7: error: 'microsecondsToClockCycles' was not declared in this scope
   51 |       microsecondsToClockCycles(1000); // 1 millisecond timeout for
      |       ^~~~~~~~~~~~~~~~~~~~~~~~~
Multiple libraries were found for "DHT.h"
 Used: /home/kh/Arduino/libraries/DHT_sensor_library
 Not used: /home/kh/Arduino/libraries/arduino_783797
 Not used: /home/kh/Arduino/libraries/arduino_533340
 Not used: /home/kh/Arduino/libraries/arduino-DHT-master
Multiple libraries were found for "Adafruit_Sensor.h"
 Used: /home/kh/Arduino/libraries/Adafruit_Sensor-master
 Not used: /home/kh/Arduino/libraries/Adafruit_Unified_Sensor
exit status 1
Error compiling for board Raspberry Pi Pico.
```

with the added definitions, there is no compiler error.