### PR TITLE
Fix over/underclock support

### DIFF
--- a/cores/rp2040/main.cpp
+++ b/cores/rp2040/main.cpp
@@ -20,6 +20,7 @@
 
 #include <Arduino.h>
 #include "RP2040USB.h"
+#include <pico/stdlib.h>
 #include <pico/multicore.h>
 
 RP2040 rp2040;


### PR DESCRIPTION
Removed needed header from main.cpp during prior cleanup.  Re-add.

Fixes #146