### PR TITLE
Use CI to build draft releases on a tag push

### DIFF
--- a/.github/workflows/tag-to-draft-release.yml
+++ b/.github/workflows/tag-to-draft-release.yml
@@ -1,0 +1,43 @@
+# Whenever a tag of the form #.xxxx is pushed against master, generate a
+# draft release and upload the ZIP and JSON file to it.  Maintainers then
+# will manually add the changelist and publish it.
+
+name: Arduino-Pico Draft Release
+
+on:
+  push:
+    tags:
+      # Run for tags of the x.x.x* form (i.e. 3.0.0, 3.0.0-beta, etc.).
+      - '[0-9]+.[0-9]+.[0-9]+*'
+
+jobs:
+  package:
+    name: Package
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        submodules: true
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Set GIT tag name
+      run: |
+        # Sets an environment variable used in the next steps
+        echo "::set-env name=TRAVIS_TAG::$(git describe --exact-match --tags)"
+    - name: Build package JSON
+      env:
+        TRAVIS_BUILD_DIR: ${{ github.workspace }}
+        BUILD_TYPE: package
+        CI_GITHUB_API_KEY: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+           bash ./tests/ci/build_package.sh
+           pip3 install PyGithub
+           # Create a draft release and upload the ZIP and JSON files.
+           # This draft is not visible to normal users and needs to be
+           # updated manually with release notes and published from the
+           # GitHub web interface.
+           json=$(find ./package/versions -name package_rp2040_index.json)
+           log=$(find ./package/versions  -name package_rp2040_index.log)
+           zip=$(find ./package/versions  -name rp2040*zip)
+           python3 ./package/upload_release.py --user "$GITHUB_ACTOR" --repo "$GITHUB_REPOSITORY" --token "$CI_GITHUB_API_KEY" --tag "$TRAVIS_TAG" --name "Release $TRAVIS_TAG" --msg "@$json" "$zip" "$json"

--- a/package/build_boards_manager_package.sh
+++ b/package/build_boards_manager_package.sh
@@ -174,6 +174,7 @@ echo "Downloading base package: $base_ver"
 old_json=package_rp2040_index_stable.json
 curl -L -o $old_json "https://github.com/earlephilhower/arduino-pico/releases/download/${base_ver}/package_rp2040_index.json"
 new_json=package_rp2040_index.json
+new_log=package_rp2040_index.log
 
 set +e
 # Merge the old and new
@@ -194,6 +195,8 @@ mv tmp $new_json
 # Verify the JSON file can be read, fail if it's not OK
 set -e
 cat $new_json | jq empty
+
+git log $base_ver..HEAD --oneline | sed 's/\b / * /' | cut -f2- -d" " > $new_log
 
 popd
 popd

--- a/package/upload_release.py
+++ b/package/upload_release.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+
+#from github import Github
+import argparse
+
+parser = argparse.ArgumentParser(description='Upload a set of files to a new draft release')
+parser.add_argument('--user', help="Github username", type=str, required=True)
+parser.add_argument('--token', help="Github Personal Access Token (PAT)", type=str, required=True)
+parser.add_argument('--repo', help="Repository", type=str, required=True)
+parser.add_argument('--tag', help="Release tag", type=str, required=True)
+parser.add_argument('--name', help="Release name", type=str, required=True)
+parser.add_argument('--msg', help="Release message", type=str, required=True)
+parser.add_argument('files', nargs=argparse.REMAINDER)
+args = parser.parse_args()
+
+if len(args.files) == 0:
+    print("ERROR:  No files specified")
+    quit()
+
+if args.msg[0] == '@':
+    with open(args.msg[1:], 'r') as f:
+        args.msg = f.read()
+
+gh = Github(login_or_token=args.token)
+repo = gh.get_repo(str(args.repo))
+release = repo.create_git_release(args.tag, args.name, args.msg, draft=True)
+for fn in args.files:
+    print("Uploading file: " + fn)
+    release.upload_asset(fn)


### PR DESCRIPTION
Ensure no stray files get sucked into the release ZIP by using a clean CI
image to build the package and JSON file.  Auto-populate the draft with
the git commits since the last release.