### PR TITLE
Add TinyUSB include to all libs

### DIFF
--- a/libraries/EEPROM/EEPROM.cpp
+++ b/libraries/EEPROM/EEPROM.cpp
@@ -25,6 +25,15 @@
 #include <hardware/flash.h>
 #include <hardware/sync.h>
 
+#ifdef USE_TINYUSB
+// For Serial when selecting TinyUSB.  Can't include in the core because Arduino IDE
+// will not link in libraries called from the core.  Instead, add the header to all
+// the standard libraries in the hope it will still catch some user cases where they
+// use these libraries.
+// See https://github.com/earlephilhower/arduino-pico/issues/167#issuecomment-848622174
+#include <Adafruit_TinyUSB.h>
+#endif
+
 extern "C" uint8_t _EEPROM_start;
 
 EEPROMClass::EEPROMClass(void)

--- a/libraries/I2S/src/I2S.cpp
+++ b/libraries/I2S/src/I2S.cpp
@@ -21,6 +21,15 @@
 #include <Arduino.h>
 #include "I2S.h"
 
+#ifdef USE_TINYUSB
+// For Serial when selecting TinyUSB.  Can't include in the core because Arduino IDE
+// will not link in libraries called from the core.  Instead, add the header to all
+// the standard libraries in the hope it will still catch some user cases where they
+// use these libraries.
+// See https://github.com/earlephilhower/arduino-pico/issues/167#issuecomment-848622174
+#include <Adafruit_TinyUSB.h>
+#endif
+
 I2SClass::I2SClass() {
     _running = false;
     _pool = nullptr;

--- a/libraries/LittleFS/src/LittleFS.cpp
+++ b/libraries/LittleFS/src/LittleFS.cpp
@@ -27,6 +27,15 @@
 #include <hardware/flash.h>
 #include <hardware/sync.h>
 
+#ifdef USE_TINYUSB
+// For Serial when selecting TinyUSB.  Can't include in the core because Arduino IDE
+// will not link in libraries called from the core.  Instead, add the header to all
+// the standard libraries in the hope it will still catch some user cases where they
+// use these libraries.
+// See https://github.com/earlephilhower/arduino-pico/issues/167#issuecomment-848622174
+#include <Adafruit_TinyUSB.h>
+#endif
+
 extern uint8_t _FS_start;
 extern uint8_t _FS_end;
 

--- a/libraries/SD/src/SD.cpp
+++ b/libraries/SD/src/SD.cpp
@@ -1,5 +1,14 @@
 #include "SD.h"
 
+#ifdef USE_TINYUSB
+// For Serial when selecting TinyUSB.  Can't include in the core because Arduino IDE
+// will not link in libraries called from the core.  Instead, add the header to all
+// the standard libraries in the hope it will still catch some user cases where they
+// use these libraries.
+// See https://github.com/earlephilhower/arduino-pico/issues/167#issuecomment-848622174
+#include <Adafruit_TinyUSB.h>
+#endif
+
 #if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_SD)
 SDClass SD;
 #endif

--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -22,6 +22,15 @@
 #include <hardware/spi.h>
 #include <hardware/gpio.h>
 
+#ifdef USE_TINYUSB
+// For Serial when selecting TinyUSB.  Can't include in the core because Arduino IDE
+// will not link in libraries called from the core.  Instead, add the header to all
+// the standard libraries in the hope it will still catch some user cases where they
+// use these libraries.
+// See https://github.com/earlephilhower/arduino-pico/issues/167#issuecomment-848622174
+#include <Adafruit_TinyUSB.h>
+#endif
+
 SPIClassRP2040::SPIClassRP2040(spi_inst_t *spi, pin_size_t rx, pin_size_t cs, pin_size_t sck, pin_size_t tx) {
     _spi = spi;
     _running = false;

--- a/libraries/Servo/src/Servo.cpp
+++ b/libraries/Servo/src/Servo.cpp
@@ -24,6 +24,15 @@
 #include <hardware/clocks.h>
 #include <hardware/pio.h>
 
+#ifdef USE_TINYUSB
+// For Serial when selecting TinyUSB.  Can't include in the core because Arduino IDE
+// will not link in libraries called from the core.  Instead, add the header to all
+// the standard libraries in the hope it will still catch some user cases where they
+// use these libraries.
+// See https://github.com/earlephilhower/arduino-pico/issues/167#issuecomment-848622174
+#include <Adafruit_TinyUSB.h>
+#endif
+
 #include "servo.pio.h"
 static PIOProgram _servoPgm(&servo_program);
 

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -28,6 +28,15 @@
 #include <hardware/regs/intctrl.h>
 #include "Wire.h"
 
+#ifdef USE_TINYUSB
+// For Serial when selecting TinyUSB.  Can't include in the core because Arduino IDE
+// will not link in libraries called from the core.  Instead, add the header to all
+// the standard libraries in the hope it will still catch some user cases where they
+// use these libraries.
+// See https://github.com/earlephilhower/arduino-pico/issues/167#issuecomment-848622174
+#include <Adafruit_TinyUSB.h>
+#endif
+
 TwoWire::TwoWire(i2c_inst_t *i2c, pin_size_t sda, pin_size_t scl) {
     _sda = sda;
     _scl = scl;


### PR DESCRIPTION
Fixes #167

For Serial when selecting TinyUSB.  Can't include in the core because Arduino IDE
will not link in libraries called from the core.  Instead, add the header to all
the standard libraries in the hope it will still catch some user cases where they
use these libraries.

See https://github.com/earlephilhower/arduino-pico/issues/167#issuecomment-848622174