### PR TITLE
PANIC on attempting an invalid setXXX pin

### DIFF
--- a/cores/rp2040/SerialUART.cpp
+++ b/cores/rp2040/SerialUART.cpp
@@ -31,36 +31,38 @@
 extern void serialEvent1() __attribute__((weak));
 extern void serialEvent2() __attribute__((weak));
 
-bool SerialUART::setRX(pin_size_t rx) {
+bool SerialUART::setRX(pin_size_t pin) {
     constexpr uint32_t valid[2] = { __bitset({1, 13, 17, 29}) /* UART0 */,
                                     __bitset({5, 9, 21, 25})  /* UART1 */
                                   };
-    if (_running) {
-        DEBUGCORE("ERROR: SerialUART setRX while running\n");
-        return false;
-    } else if ((1 << rx) & valid[uart_get_index(_uart)]) {
-        _rx = rx;
+    if ((!_running) && ((1 << pin) & valid[uart_get_index(_uart)])) {
+        _rx = pin;
         return true;
-    } else {
-        DEBUGCORE("ERROR: SerialUART setRX illegal pin (%d)\n", rx);
-        return false;
     }
+
+    if (_running) {
+        panic("FATAL: Attempting to set Serial%d.RX while running", uart_get_index(_uart) + 1);
+    } else {
+        panic("FATAL: Attempting to set Serial%d.RX to illegal pin %d", uart_get_index(_uart) + 1, pin);
+    }
+    return false;
 }
 
-bool SerialUART::setTX(pin_size_t tx) {
+bool SerialUART::setTX(pin_size_t pin) {
     constexpr uint32_t valid[2] = { __bitset({0, 12, 16, 28}) /* UART0 */,
                                     __bitset({4, 8, 20, 24})  /* UART1 */
                                   };
-    if (_running) {
-        DEBUGCORE("ERROR: SerialUART setTX while running\n");
-        return false;
-    } else if ((1 << tx) & valid[uart_get_index(_uart)]) {
-        _tx = tx;
+    if ((!_running) && ((1 << pin) & valid[uart_get_index(_uart)])) {
+        _tx = pin;
         return true;
-    } else {
-        DEBUGCORE("ERROR: SerialUART setTX illegal pin (%d)\n", tx);
-        return false;
     }
+
+    if (_running) {
+        panic("FATAL: Attempting to set Serial%d.TX while running", uart_get_index(_uart) + 1);
+    } else {
+        panic("FATAL: Attempting to set Serial%d.TX to illegal pin %d", uart_get_index(_uart) + 1, pin);
+    }
+    return false;
 }
 
 SerialUART::SerialUART(uart_inst_t *uart, pin_size_t tx, pin_size_t rx) {

--- a/libraries/SPI/SPI.cpp
+++ b/libraries/SPI/SPI.cpp
@@ -202,56 +202,68 @@ bool SPIClassRP2040::setRX(pin_size_t pin) {
     constexpr uint32_t valid[2] = { __bitset({0, 4, 16, 20}) /* SPI0 */,
                                     __bitset({8, 12, 24, 28})  /* SPI1 */
                                   };
-    if (_running) {
-        return false;
-    } else if ((1 << pin) & valid[spi_get_index(_spi)]) {
+    if ((!_running) && ((1 << pin) & valid[spi_get_index(_spi)])) {
         _RX = pin;
         return true;
-    } else {
-        return false;
     }
+
+    if (_running) {
+        panic("FATAL: Attempting to set SPI%s.RX while running", spi_get_index(_spi) ? "1" : "");
+    } else {
+        panic("FATAL: Attempting to set SPI%s.RX to illegal pin %d", spi_get_index(_spi) ? "1" : "", pin);
+    }
+    return false;
 }
 
 bool SPIClassRP2040::setCS(pin_size_t pin) {
     constexpr uint32_t valid[2] = { __bitset({1, 5, 17, 21}) /* SPI0 */,
                                     __bitset({9, 13, 25, 29})  /* SPI1 */
                                   };
-    if (_running) {
-        return false;
-    } else if ((1 << pin) & valid[spi_get_index(_spi)]) {
+    if ((!_running) && ((1 << pin) & valid[spi_get_index(_spi)])) {
         _CS = pin;
         return true;
-    } else {
-        return false;
     }
+
+    if (_running) {
+        panic("FATAL: Attempting to set SPI%s.CS while running", spi_get_index(_spi) ? "1" : "");
+    } else {
+        panic("FATAL: Attempting to set SPI%s.CS to illegal pin %d", spi_get_index(_spi) ? "1" : "", pin);
+    }
+    return false;
 }
 
 bool SPIClassRP2040::setSCK(pin_size_t pin) {
     constexpr uint32_t valid[2] = { __bitset({2, 6, 18, 22}) /* SPI0 */,
                                     __bitset({10, 14, 26})  /* SPI1 */
                                   };
-    if (_running) {
-        return false;
-    } else if ((1 << pin) & valid[spi_get_index(_spi)]) {
+    if ((!_running) && ((1 << pin) & valid[spi_get_index(_spi)])) {
         _SCK = pin;
         return true;
-    } else {
-        return false;
     }
+
+    if (_running) {
+        panic("FATAL: Attempting to set SPI%s.SCK while running", spi_get_index(_spi) ? "1" : "");
+    } else {
+        panic("FATAL: Attempting to set SPI%s.SCK to illegal pin %d", spi_get_index(_spi) ? "1" : "", pin);
+    }
+    return false;
 }
 
 bool SPIClassRP2040::setTX(pin_size_t pin) {
     constexpr uint32_t valid[2] = { __bitset({3, 7, 19, 23}) /* SPI0 */,
                                     __bitset({11, 15, 27})  /* SPI1 */
                                   };
-    if (_running) {
-        return false;
-    } else if ((1 << pin) & valid[spi_get_index(_spi)]) {
+    if ((!_running) && ((1 << pin) & valid[spi_get_index(_spi)])) {
         _TX = pin;
         return true;
-    } else {
-        return false;
     }
+
+    if (_running) {
+        panic("FATAL: Attempting to set SPI%s.TX while running", spi_get_index(_spi) ? "1" : "");
+    } else {
+        panic("FATAL: Attempting to set SPI%s.TX to illegal pin %d", spi_get_index(_spi) ? "1" : "", pin);
+    }
+    return false;
 }
 
 void SPIClassRP2040::begin(bool hwCS) {

--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -51,28 +51,34 @@ bool TwoWire::setSDA(pin_size_t pin) {
     constexpr uint32_t valid[2] = { __bitset({0, 4, 8, 12, 16, 20, 24, 28}) /* I2C0 */,
                                     __bitset({2, 6, 10, 14, 18, 22, 26})  /* I2C1 */
                                   };
-    if (_running) {
-        return false;
-    } else if ((1 << pin) & valid[i2c_hw_index(_i2c)]) {
+    if ((!_running) && ((1 << pin) & valid[i2c_hw_index(_i2c)])) {
         _sda = pin;
         return true;
-    } else {
-        return false;
     }
+
+    if (_running) {
+        panic("FATAL: Attempting to set Wire%s.SDA while running", i2c_hw_index(_i2c) ? "1" : "");
+    } else {
+        panic("FATAL: Attempting to set Wire%s.SDA to illegal pin %d", i2c_hw_index(_i2c) ? "1" : "", pin);
+    }
+    return false;
 }
 
 bool TwoWire::setSCL(pin_size_t pin) {
     constexpr uint32_t valid[2] = { __bitset({1, 5, 9, 13, 17, 21, 25, 29}) /* I2C0 */,
                                     __bitset({3, 7, 11, 15, 19, 23, 27})  /* I2C1 */
                                   };
-    if (_running) {
-        return false;
-    } else if ((1 << pin) & valid[i2c_hw_index(_i2c)]) {
+    if ((!_running) && ((1 << pin) & valid[i2c_hw_index(_i2c)])) {
         _scl = pin;
         return true;
-    } else {
-        return false;
     }
+
+    if (_running) {
+        panic("FATAL: Attempting to set Wire%s.SCL while running", i2c_hw_index(_i2c) ? "1" : "");
+    } else {
+        panic("FATAL: Attempting to set Wire%s.SCL to illegal pin %d", i2c_hw_index(_i2c) ? "1" : "", pin);
+    }
+    return false;
 }
 
 void TwoWire::setClock(uint32_t hz) {


### PR DESCRIPTION
Fixes #169

Trying to change pinout while running, or to an illegal configuration,
will now immediately panic() with an error message.  Such an attempt
is a pretty big problem since pinouts are hardware related/static.

Prior code would fail silently and return false, but nobody checked
the setXXX return values, anyway.