### PR TITLE
Obey timeout value on SerialUART.read/.peek

### DIFF
--- a/cores/rp2040/SerialUART.cpp
+++ b/cores/rp2040/SerialUART.cpp
@@ -115,7 +115,11 @@ int SerialUART::peek() {
     if (_peek >= 0) {
         return _peek;
     }
-    _peek = uart_getc(_uart);
+    if (uart_is_readable_within_us(_uart, _timeout * 1000)) {
+        _peek = uart_getc(_uart);
+    } else {
+        _peek = -1; // Timeout
+    }
     return _peek;
 }
 
@@ -129,7 +133,11 @@ int SerialUART::read() {
         _peek = -1;
         return ret;
     }
-    return uart_getc(_uart);
+    if (uart_is_readable_within_us(_uart, _timeout * 1000)) {
+        return uart_getc(_uart);
+    } else {
+        return -1; // Timeout
+    }
 }
 
 int SerialUART::available() {


### PR DESCRIPTION
Fixes a hang when reading from the Serial UART ports because before the
core would pause indefinitely for the next character.

Now, wait up to Serial.setTimeout() milliseconds and if it times out
return -1 to the app.

Fixes #210