### PR TITLE
Fix file creation on SD and SDFS

### DIFF
--- a/libraries/SDFS/src/SDFS.h
+++ b/libraries/SDFS/src/SDFS.h
@@ -234,8 +234,8 @@ protected:
     }
 
 
-    static uint8_t _getFlags(OpenMode openMode, AccessMode accessMode) {
-        uint8_t mode = 0;
+    static int _getFlags(OpenMode openMode, AccessMode accessMode) {
+        int mode = 0;
         if (openMode & OM_CREATE) {
             mode |= O_CREAT;
         }


### PR DESCRIPTION
The O_CREAT/etc. flags on the Pico are a full 32-bits in size, but the
core was generating a flag for SdFat using an 8-bit type, so all the
O_CREAT, O_TRUNC, O_APPEND, etc. flags got cut off.

Fix the flag size.

Fixes #214