### PR TITLE
Add options to not enable USB or USB Serial

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -115,6 +115,12 @@ rpipico.menu.usbstack.picosdk=Pico SDK
 rpipico.menu.usbstack.picosdk.build.usbstack_flags="-I{runtime.platform.path}/tools/libpico"
 rpipico.menu.usbstack.tinyusb=Adafruit TinyUSB
 rpipico.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+rpipico.menu.usbstack.picosdknoser=Pico SDK (No Serial)
+rpipico.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
+rpipico.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
+rpipico.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+rpipico.menu.usbstack.nousb=No USB
+rpipico.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
 # -----------------------------------
 # Raspberry Pi Pico (Picoprobe)
@@ -225,6 +231,12 @@ rpipicopicoprobe.menu.usbstack.picosdk=Pico SDK
 rpipicopicoprobe.menu.usbstack.picosdk.build.usbstack_flags="-I{runtime.platform.path}/tools/libpico"
 rpipicopicoprobe.menu.usbstack.tinyusb=Adafruit TinyUSB
 rpipicopicoprobe.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+rpipicopicoprobe.menu.usbstack.picosdknoser=Pico SDK (No Serial)
+rpipicopicoprobe.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
+rpipicopicoprobe.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
+rpipicopicoprobe.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+rpipicopicoprobe.menu.usbstack.nousb=No USB
+rpipicopicoprobe.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
 # -----------------------------------
 # Adafruit Feather RP2040
@@ -371,6 +383,12 @@ adafruit_feather.menu.usbstack.picosdk=Pico SDK
 adafruit_feather.menu.usbstack.picosdk.build.usbstack_flags="-I{runtime.platform.path}/tools/libpico"
 adafruit_feather.menu.usbstack.tinyusb=Adafruit TinyUSB
 adafruit_feather.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+adafruit_feather.menu.usbstack.picosdknoser=Pico SDK (No Serial)
+adafruit_feather.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
+adafruit_feather.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
+adafruit_feather.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+adafruit_feather.menu.usbstack.nousb=No USB
+adafruit_feather.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
 # -----------------------------------
 # Adafruit Feather RP2040 (Picoprobe)
@@ -517,6 +535,12 @@ adafruit_featherpicoprobe.menu.usbstack.picosdk=Pico SDK
 adafruit_featherpicoprobe.menu.usbstack.picosdk.build.usbstack_flags="-I{runtime.platform.path}/tools/libpico"
 adafruit_featherpicoprobe.menu.usbstack.tinyusb=Adafruit TinyUSB
 adafruit_featherpicoprobe.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+adafruit_featherpicoprobe.menu.usbstack.picosdknoser=Pico SDK (No Serial)
+adafruit_featherpicoprobe.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
+adafruit_featherpicoprobe.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
+adafruit_featherpicoprobe.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+adafruit_featherpicoprobe.menu.usbstack.nousb=No USB
+adafruit_featherpicoprobe.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
 # -----------------------------------
 # Adafruit ItsyBitsy RP2040
@@ -663,6 +687,12 @@ adafruit_itsybitsy.menu.usbstack.picosdk=Pico SDK
 adafruit_itsybitsy.menu.usbstack.picosdk.build.usbstack_flags="-I{runtime.platform.path}/tools/libpico"
 adafruit_itsybitsy.menu.usbstack.tinyusb=Adafruit TinyUSB
 adafruit_itsybitsy.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+adafruit_itsybitsy.menu.usbstack.picosdknoser=Pico SDK (No Serial)
+adafruit_itsybitsy.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
+adafruit_itsybitsy.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
+adafruit_itsybitsy.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+adafruit_itsybitsy.menu.usbstack.nousb=No USB
+adafruit_itsybitsy.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
 # -----------------------------------
 # Adafruit ItsyBitsy RP2040 (Picoprobe)
@@ -809,6 +839,12 @@ adafruit_itsybitsypicoprobe.menu.usbstack.picosdk=Pico SDK
 adafruit_itsybitsypicoprobe.menu.usbstack.picosdk.build.usbstack_flags="-I{runtime.platform.path}/tools/libpico"
 adafruit_itsybitsypicoprobe.menu.usbstack.tinyusb=Adafruit TinyUSB
 adafruit_itsybitsypicoprobe.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+adafruit_itsybitsypicoprobe.menu.usbstack.picosdknoser=Pico SDK (No Serial)
+adafruit_itsybitsypicoprobe.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
+adafruit_itsybitsypicoprobe.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
+adafruit_itsybitsypicoprobe.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+adafruit_itsybitsypicoprobe.menu.usbstack.nousb=No USB
+adafruit_itsybitsypicoprobe.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
 # -----------------------------------
 # Adafruit QT Py RP2040
@@ -955,6 +991,12 @@ adafruit_qtpy.menu.usbstack.picosdk=Pico SDK
 adafruit_qtpy.menu.usbstack.picosdk.build.usbstack_flags="-I{runtime.platform.path}/tools/libpico"
 adafruit_qtpy.menu.usbstack.tinyusb=Adafruit TinyUSB
 adafruit_qtpy.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+adafruit_qtpy.menu.usbstack.picosdknoser=Pico SDK (No Serial)
+adafruit_qtpy.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
+adafruit_qtpy.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
+adafruit_qtpy.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+adafruit_qtpy.menu.usbstack.nousb=No USB
+adafruit_qtpy.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
 # -----------------------------------
 # Adafruit QT Py RP2040 (Picoprobe)
@@ -1101,6 +1143,12 @@ adafruit_qtpypicoprobe.menu.usbstack.picosdk=Pico SDK
 adafruit_qtpypicoprobe.menu.usbstack.picosdk.build.usbstack_flags="-I{runtime.platform.path}/tools/libpico"
 adafruit_qtpypicoprobe.menu.usbstack.tinyusb=Adafruit TinyUSB
 adafruit_qtpypicoprobe.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+adafruit_qtpypicoprobe.menu.usbstack.picosdknoser=Pico SDK (No Serial)
+adafruit_qtpypicoprobe.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
+adafruit_qtpypicoprobe.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
+adafruit_qtpypicoprobe.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+adafruit_qtpypicoprobe.menu.usbstack.nousb=No USB
+adafruit_qtpypicoprobe.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
 # -----------------------------------
 # Adafruit STEMMA Friend RP2040
@@ -1247,6 +1295,12 @@ adafruit_stemmafriend.menu.usbstack.picosdk=Pico SDK
 adafruit_stemmafriend.menu.usbstack.picosdk.build.usbstack_flags="-I{runtime.platform.path}/tools/libpico"
 adafruit_stemmafriend.menu.usbstack.tinyusb=Adafruit TinyUSB
 adafruit_stemmafriend.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+adafruit_stemmafriend.menu.usbstack.picosdknoser=Pico SDK (No Serial)
+adafruit_stemmafriend.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
+adafruit_stemmafriend.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
+adafruit_stemmafriend.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+adafruit_stemmafriend.menu.usbstack.nousb=No USB
+adafruit_stemmafriend.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
 # -----------------------------------
 # Adafruit STEMMA Friend RP2040 (Picoprobe)
@@ -1393,6 +1447,12 @@ adafruit_stemmafriendpicoprobe.menu.usbstack.picosdk=Pico SDK
 adafruit_stemmafriendpicoprobe.menu.usbstack.picosdk.build.usbstack_flags="-I{runtime.platform.path}/tools/libpico"
 adafruit_stemmafriendpicoprobe.menu.usbstack.tinyusb=Adafruit TinyUSB
 adafruit_stemmafriendpicoprobe.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+adafruit_stemmafriendpicoprobe.menu.usbstack.picosdknoser=Pico SDK (No Serial)
+adafruit_stemmafriendpicoprobe.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
+adafruit_stemmafriendpicoprobe.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
+adafruit_stemmafriendpicoprobe.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+adafruit_stemmafriendpicoprobe.menu.usbstack.nousb=No USB
+adafruit_stemmafriendpicoprobe.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
 # -----------------------------------
 # Adafruit Trinkey RP2040 QT
@@ -1539,6 +1599,12 @@ adafruit_trinkeyrp2040qt.menu.usbstack.picosdk=Pico SDK
 adafruit_trinkeyrp2040qt.menu.usbstack.picosdk.build.usbstack_flags="-I{runtime.platform.path}/tools/libpico"
 adafruit_trinkeyrp2040qt.menu.usbstack.tinyusb=Adafruit TinyUSB
 adafruit_trinkeyrp2040qt.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+adafruit_trinkeyrp2040qt.menu.usbstack.picosdknoser=Pico SDK (No Serial)
+adafruit_trinkeyrp2040qt.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
+adafruit_trinkeyrp2040qt.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
+adafruit_trinkeyrp2040qt.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+adafruit_trinkeyrp2040qt.menu.usbstack.nousb=No USB
+adafruit_trinkeyrp2040qt.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
 # -----------------------------------
 # Adafruit Trinkey RP2040 QT (Picoprobe)
@@ -1685,6 +1751,12 @@ adafruit_trinkeyrp2040qtpicoprobe.menu.usbstack.picosdk=Pico SDK
 adafruit_trinkeyrp2040qtpicoprobe.menu.usbstack.picosdk.build.usbstack_flags="-I{runtime.platform.path}/tools/libpico"
 adafruit_trinkeyrp2040qtpicoprobe.menu.usbstack.tinyusb=Adafruit TinyUSB
 adafruit_trinkeyrp2040qtpicoprobe.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+adafruit_trinkeyrp2040qtpicoprobe.menu.usbstack.picosdknoser=Pico SDK (No Serial)
+adafruit_trinkeyrp2040qtpicoprobe.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
+adafruit_trinkeyrp2040qtpicoprobe.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
+adafruit_trinkeyrp2040qtpicoprobe.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+adafruit_trinkeyrp2040qtpicoprobe.menu.usbstack.nousb=No USB
+adafruit_trinkeyrp2040qtpicoprobe.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
 # -----------------------------------
 # Adafruit MacroPad RP2040
@@ -1831,6 +1903,12 @@ adafruit_macropad2040.menu.usbstack.picosdk=Pico SDK
 adafruit_macropad2040.menu.usbstack.picosdk.build.usbstack_flags="-I{runtime.platform.path}/tools/libpico"
 adafruit_macropad2040.menu.usbstack.tinyusb=Adafruit TinyUSB
 adafruit_macropad2040.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+adafruit_macropad2040.menu.usbstack.picosdknoser=Pico SDK (No Serial)
+adafruit_macropad2040.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
+adafruit_macropad2040.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
+adafruit_macropad2040.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+adafruit_macropad2040.menu.usbstack.nousb=No USB
+adafruit_macropad2040.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
 # -----------------------------------
 # Adafruit MacroPad RP2040 (Picoprobe)
@@ -1977,6 +2055,12 @@ adafruit_macropad2040picoprobe.menu.usbstack.picosdk=Pico SDK
 adafruit_macropad2040picoprobe.menu.usbstack.picosdk.build.usbstack_flags="-I{runtime.platform.path}/tools/libpico"
 adafruit_macropad2040picoprobe.menu.usbstack.tinyusb=Adafruit TinyUSB
 adafruit_macropad2040picoprobe.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+adafruit_macropad2040picoprobe.menu.usbstack.picosdknoser=Pico SDK (No Serial)
+adafruit_macropad2040picoprobe.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
+adafruit_macropad2040picoprobe.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
+adafruit_macropad2040picoprobe.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+adafruit_macropad2040picoprobe.menu.usbstack.nousb=No USB
+adafruit_macropad2040picoprobe.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
 # -----------------------------------
 # Arduino Nano RP2040 Connect
@@ -2171,6 +2255,12 @@ arduino_nano_connect.menu.usbstack.picosdk=Pico SDK
 arduino_nano_connect.menu.usbstack.picosdk.build.usbstack_flags="-I{runtime.platform.path}/tools/libpico"
 arduino_nano_connect.menu.usbstack.tinyusb=Adafruit TinyUSB
 arduino_nano_connect.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+arduino_nano_connect.menu.usbstack.picosdknoser=Pico SDK (No Serial)
+arduino_nano_connect.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
+arduino_nano_connect.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
+arduino_nano_connect.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+arduino_nano_connect.menu.usbstack.nousb=No USB
+arduino_nano_connect.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
 # -----------------------------------
 # Arduino Nano RP2040 Connect (Picoprobe)
@@ -2365,6 +2455,12 @@ arduino_nano_connectpicoprobe.menu.usbstack.picosdk=Pico SDK
 arduino_nano_connectpicoprobe.menu.usbstack.picosdk.build.usbstack_flags="-I{runtime.platform.path}/tools/libpico"
 arduino_nano_connectpicoprobe.menu.usbstack.tinyusb=Adafruit TinyUSB
 arduino_nano_connectpicoprobe.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+arduino_nano_connectpicoprobe.menu.usbstack.picosdknoser=Pico SDK (No Serial)
+arduino_nano_connectpicoprobe.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
+arduino_nano_connectpicoprobe.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
+arduino_nano_connectpicoprobe.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+arduino_nano_connectpicoprobe.menu.usbstack.nousb=No USB
+arduino_nano_connectpicoprobe.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
 # -----------------------------------
 # SparkFun ProMicro RP2040
@@ -2559,6 +2655,12 @@ sparkfun_promicrorp2040.menu.usbstack.picosdk=Pico SDK
 sparkfun_promicrorp2040.menu.usbstack.picosdk.build.usbstack_flags="-I{runtime.platform.path}/tools/libpico"
 sparkfun_promicrorp2040.menu.usbstack.tinyusb=Adafruit TinyUSB
 sparkfun_promicrorp2040.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+sparkfun_promicrorp2040.menu.usbstack.picosdknoser=Pico SDK (No Serial)
+sparkfun_promicrorp2040.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
+sparkfun_promicrorp2040.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
+sparkfun_promicrorp2040.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+sparkfun_promicrorp2040.menu.usbstack.nousb=No USB
+sparkfun_promicrorp2040.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
 # -----------------------------------
 # SparkFun ProMicro RP2040 (Picoprobe)
@@ -2753,6 +2855,12 @@ sparkfun_promicrorp2040picoprobe.menu.usbstack.picosdk=Pico SDK
 sparkfun_promicrorp2040picoprobe.menu.usbstack.picosdk.build.usbstack_flags="-I{runtime.platform.path}/tools/libpico"
 sparkfun_promicrorp2040picoprobe.menu.usbstack.tinyusb=Adafruit TinyUSB
 sparkfun_promicrorp2040picoprobe.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+sparkfun_promicrorp2040picoprobe.menu.usbstack.picosdknoser=Pico SDK (No Serial)
+sparkfun_promicrorp2040picoprobe.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
+sparkfun_promicrorp2040picoprobe.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
+sparkfun_promicrorp2040picoprobe.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+sparkfun_promicrorp2040picoprobe.menu.usbstack.nousb=No USB
+sparkfun_promicrorp2040picoprobe.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
 # -----------------------------------
 # Generic RP2040
@@ -2875,6 +2983,12 @@ generic.menu.usbstack.picosdk=Pico SDK
 generic.menu.usbstack.picosdk.build.usbstack_flags="-I{runtime.platform.path}/tools/libpico"
 generic.menu.usbstack.tinyusb=Adafruit TinyUSB
 generic.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+generic.menu.usbstack.picosdknoser=Pico SDK (No Serial)
+generic.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
+generic.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
+generic.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+generic.menu.usbstack.nousb=No USB
+generic.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 generic.menu.boot2.boot2_generic_03h_2_padded_checksum=Generic SPI /2
 generic.menu.boot2.boot2_generic_03h_2_padded_checksum.build.boot2=boot2_generic_03h_2_padded_checksum
 generic.menu.boot2.boot2_generic_03h_4_padded_checksum=Generic SPI /4
@@ -3013,6 +3127,12 @@ genericpicoprobe.menu.usbstack.picosdk=Pico SDK
 genericpicoprobe.menu.usbstack.picosdk.build.usbstack_flags="-I{runtime.platform.path}/tools/libpico"
 genericpicoprobe.menu.usbstack.tinyusb=Adafruit TinyUSB
 genericpicoprobe.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+genericpicoprobe.menu.usbstack.picosdknoser=Pico SDK (No Serial)
+genericpicoprobe.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
+genericpicoprobe.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
+genericpicoprobe.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+genericpicoprobe.menu.usbstack.nousb=No USB
+genericpicoprobe.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 genericpicoprobe.menu.boot2.boot2_generic_03h_2_padded_checksum=Generic SPI /2
 genericpicoprobe.menu.boot2.boot2_generic_03h_2_padded_checksum.build.boot2=boot2_generic_03h_2_padded_checksum
 genericpicoprobe.menu.boot2.boot2_generic_03h_4_padded_checksum=Generic SPI /4

--- a/boards.txt
+++ b/boards.txt
@@ -117,8 +117,6 @@ rpipico.menu.usbstack.tinyusb=Adafruit TinyUSB
 rpipico.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 rpipico.menu.usbstack.picosdknoser=Pico SDK (No Serial)
 rpipico.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
-rpipico.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
-rpipico.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 rpipico.menu.usbstack.nousb=No USB
 rpipico.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
@@ -233,8 +231,6 @@ rpipicopicoprobe.menu.usbstack.tinyusb=Adafruit TinyUSB
 rpipicopicoprobe.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 rpipicopicoprobe.menu.usbstack.picosdknoser=Pico SDK (No Serial)
 rpipicopicoprobe.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
-rpipicopicoprobe.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
-rpipicopicoprobe.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 rpipicopicoprobe.menu.usbstack.nousb=No USB
 rpipicopicoprobe.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
@@ -385,8 +381,6 @@ adafruit_feather.menu.usbstack.tinyusb=Adafruit TinyUSB
 adafruit_feather.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 adafruit_feather.menu.usbstack.picosdknoser=Pico SDK (No Serial)
 adafruit_feather.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
-adafruit_feather.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
-adafruit_feather.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 adafruit_feather.menu.usbstack.nousb=No USB
 adafruit_feather.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
@@ -537,8 +531,6 @@ adafruit_featherpicoprobe.menu.usbstack.tinyusb=Adafruit TinyUSB
 adafruit_featherpicoprobe.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 adafruit_featherpicoprobe.menu.usbstack.picosdknoser=Pico SDK (No Serial)
 adafruit_featherpicoprobe.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
-adafruit_featherpicoprobe.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
-adafruit_featherpicoprobe.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 adafruit_featherpicoprobe.menu.usbstack.nousb=No USB
 adafruit_featherpicoprobe.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
@@ -689,8 +681,6 @@ adafruit_itsybitsy.menu.usbstack.tinyusb=Adafruit TinyUSB
 adafruit_itsybitsy.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 adafruit_itsybitsy.menu.usbstack.picosdknoser=Pico SDK (No Serial)
 adafruit_itsybitsy.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
-adafruit_itsybitsy.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
-adafruit_itsybitsy.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 adafruit_itsybitsy.menu.usbstack.nousb=No USB
 adafruit_itsybitsy.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
@@ -841,8 +831,6 @@ adafruit_itsybitsypicoprobe.menu.usbstack.tinyusb=Adafruit TinyUSB
 adafruit_itsybitsypicoprobe.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 adafruit_itsybitsypicoprobe.menu.usbstack.picosdknoser=Pico SDK (No Serial)
 adafruit_itsybitsypicoprobe.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
-adafruit_itsybitsypicoprobe.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
-adafruit_itsybitsypicoprobe.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 adafruit_itsybitsypicoprobe.menu.usbstack.nousb=No USB
 adafruit_itsybitsypicoprobe.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
@@ -993,8 +981,6 @@ adafruit_qtpy.menu.usbstack.tinyusb=Adafruit TinyUSB
 adafruit_qtpy.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 adafruit_qtpy.menu.usbstack.picosdknoser=Pico SDK (No Serial)
 adafruit_qtpy.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
-adafruit_qtpy.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
-adafruit_qtpy.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 adafruit_qtpy.menu.usbstack.nousb=No USB
 adafruit_qtpy.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
@@ -1145,8 +1131,6 @@ adafruit_qtpypicoprobe.menu.usbstack.tinyusb=Adafruit TinyUSB
 adafruit_qtpypicoprobe.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 adafruit_qtpypicoprobe.menu.usbstack.picosdknoser=Pico SDK (No Serial)
 adafruit_qtpypicoprobe.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
-adafruit_qtpypicoprobe.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
-adafruit_qtpypicoprobe.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 adafruit_qtpypicoprobe.menu.usbstack.nousb=No USB
 adafruit_qtpypicoprobe.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
@@ -1297,8 +1281,6 @@ adafruit_stemmafriend.menu.usbstack.tinyusb=Adafruit TinyUSB
 adafruit_stemmafriend.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 adafruit_stemmafriend.menu.usbstack.picosdknoser=Pico SDK (No Serial)
 adafruit_stemmafriend.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
-adafruit_stemmafriend.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
-adafruit_stemmafriend.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 adafruit_stemmafriend.menu.usbstack.nousb=No USB
 adafruit_stemmafriend.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
@@ -1449,8 +1431,6 @@ adafruit_stemmafriendpicoprobe.menu.usbstack.tinyusb=Adafruit TinyUSB
 adafruit_stemmafriendpicoprobe.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 adafruit_stemmafriendpicoprobe.menu.usbstack.picosdknoser=Pico SDK (No Serial)
 adafruit_stemmafriendpicoprobe.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
-adafruit_stemmafriendpicoprobe.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
-adafruit_stemmafriendpicoprobe.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 adafruit_stemmafriendpicoprobe.menu.usbstack.nousb=No USB
 adafruit_stemmafriendpicoprobe.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
@@ -1601,8 +1581,6 @@ adafruit_trinkeyrp2040qt.menu.usbstack.tinyusb=Adafruit TinyUSB
 adafruit_trinkeyrp2040qt.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 adafruit_trinkeyrp2040qt.menu.usbstack.picosdknoser=Pico SDK (No Serial)
 adafruit_trinkeyrp2040qt.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
-adafruit_trinkeyrp2040qt.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
-adafruit_trinkeyrp2040qt.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 adafruit_trinkeyrp2040qt.menu.usbstack.nousb=No USB
 adafruit_trinkeyrp2040qt.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
@@ -1753,8 +1731,6 @@ adafruit_trinkeyrp2040qtpicoprobe.menu.usbstack.tinyusb=Adafruit TinyUSB
 adafruit_trinkeyrp2040qtpicoprobe.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 adafruit_trinkeyrp2040qtpicoprobe.menu.usbstack.picosdknoser=Pico SDK (No Serial)
 adafruit_trinkeyrp2040qtpicoprobe.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
-adafruit_trinkeyrp2040qtpicoprobe.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
-adafruit_trinkeyrp2040qtpicoprobe.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 adafruit_trinkeyrp2040qtpicoprobe.menu.usbstack.nousb=No USB
 adafruit_trinkeyrp2040qtpicoprobe.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
@@ -1905,8 +1881,6 @@ adafruit_macropad2040.menu.usbstack.tinyusb=Adafruit TinyUSB
 adafruit_macropad2040.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 adafruit_macropad2040.menu.usbstack.picosdknoser=Pico SDK (No Serial)
 adafruit_macropad2040.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
-adafruit_macropad2040.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
-adafruit_macropad2040.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 adafruit_macropad2040.menu.usbstack.nousb=No USB
 adafruit_macropad2040.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
@@ -2057,8 +2031,6 @@ adafruit_macropad2040picoprobe.menu.usbstack.tinyusb=Adafruit TinyUSB
 adafruit_macropad2040picoprobe.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 adafruit_macropad2040picoprobe.menu.usbstack.picosdknoser=Pico SDK (No Serial)
 adafruit_macropad2040picoprobe.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
-adafruit_macropad2040picoprobe.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
-adafruit_macropad2040picoprobe.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 adafruit_macropad2040picoprobe.menu.usbstack.nousb=No USB
 adafruit_macropad2040picoprobe.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
@@ -2257,8 +2229,6 @@ arduino_nano_connect.menu.usbstack.tinyusb=Adafruit TinyUSB
 arduino_nano_connect.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 arduino_nano_connect.menu.usbstack.picosdknoser=Pico SDK (No Serial)
 arduino_nano_connect.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
-arduino_nano_connect.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
-arduino_nano_connect.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 arduino_nano_connect.menu.usbstack.nousb=No USB
 arduino_nano_connect.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
@@ -2457,8 +2427,6 @@ arduino_nano_connectpicoprobe.menu.usbstack.tinyusb=Adafruit TinyUSB
 arduino_nano_connectpicoprobe.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 arduino_nano_connectpicoprobe.menu.usbstack.picosdknoser=Pico SDK (No Serial)
 arduino_nano_connectpicoprobe.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
-arduino_nano_connectpicoprobe.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
-arduino_nano_connectpicoprobe.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 arduino_nano_connectpicoprobe.menu.usbstack.nousb=No USB
 arduino_nano_connectpicoprobe.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
@@ -2657,8 +2625,6 @@ sparkfun_promicrorp2040.menu.usbstack.tinyusb=Adafruit TinyUSB
 sparkfun_promicrorp2040.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 sparkfun_promicrorp2040.menu.usbstack.picosdknoser=Pico SDK (No Serial)
 sparkfun_promicrorp2040.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
-sparkfun_promicrorp2040.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
-sparkfun_promicrorp2040.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 sparkfun_promicrorp2040.menu.usbstack.nousb=No USB
 sparkfun_promicrorp2040.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
@@ -2857,8 +2823,6 @@ sparkfun_promicrorp2040picoprobe.menu.usbstack.tinyusb=Adafruit TinyUSB
 sparkfun_promicrorp2040picoprobe.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 sparkfun_promicrorp2040picoprobe.menu.usbstack.picosdknoser=Pico SDK (No Serial)
 sparkfun_promicrorp2040picoprobe.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
-sparkfun_promicrorp2040picoprobe.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
-sparkfun_promicrorp2040picoprobe.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 sparkfun_promicrorp2040picoprobe.menu.usbstack.nousb=No USB
 sparkfun_promicrorp2040picoprobe.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 
@@ -2985,8 +2949,6 @@ generic.menu.usbstack.tinyusb=Adafruit TinyUSB
 generic.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 generic.menu.usbstack.picosdknoser=Pico SDK (No Serial)
 generic.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
-generic.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
-generic.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 generic.menu.usbstack.nousb=No USB
 generic.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 generic.menu.boot2.boot2_generic_03h_2_padded_checksum=Generic SPI /2
@@ -3129,8 +3091,6 @@ genericpicoprobe.menu.usbstack.tinyusb=Adafruit TinyUSB
 genericpicoprobe.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 genericpicoprobe.menu.usbstack.picosdknoser=Pico SDK (No Serial)
 genericpicoprobe.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"
-genericpicoprobe.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)
-genericpicoprobe.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
 genericpicoprobe.menu.usbstack.nousb=No USB
 genericpicoprobe.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"
 genericpicoprobe.menu.boot2.boot2_generic_03h_2_padded_checksum=Generic SPI /2

--- a/cores/rp2040/main.cpp
+++ b/cores/rp2040/main.cpp
@@ -61,16 +61,18 @@ extern "C" int main() {
     mutex_init(&_pioMutex);
     initVariant();
 
-#ifdef USE_TINYUSB
-    TinyUSB_Device_Init(0);
+#ifndef NO_USB
+	#ifdef USE_TINYUSB
+		TinyUSB_Device_Init(0);
 
-#else
-    __USBStart();
+	#else
+		__USBStart();
 
-#ifndef DISABLE_USB_SERIAL
-    // Enable serial port for reset/upload always
-    Serial.begin(115200);
-#endif
+	#ifndef DISABLE_USB_SERIAL
+		// Enable serial port for reset/upload always
+		Serial.begin(115200);
+	#endif
+	#endif
 #endif
 
 #if defined DEBUG_RP2040_PORT

--- a/tools/makeboards.py
+++ b/tools/makeboards.py
@@ -49,6 +49,12 @@ def BuildUSBStack(name):
     print('%s.menu.usbstack.picosdk.build.usbstack_flags="-I{runtime.platform.path}/tools/libpico"' % (name))
     print("%s.menu.usbstack.tinyusb=Adafruit TinyUSB" % (name))
     print('%s.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"' % (name))
+    print("%s.menu.usbstack.picosdknoser=Pico SDK (No Serial)" % (name))
+    print('%s.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"' % (name))
+    print("%s.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)" % (name))
+    print('%s.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"' % (name))
+    print("%s.menu.usbstack.nousb=No USB" % (name))
+    print('%s.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"' % (name))
 
 def BuildHeader(name, vendor_name, product_name, pidtouse, vid, pid, boarddefine, variant, uploadtool, flashsize, boot2):
     prettyname = vendor_name + " " + product_name

--- a/tools/makeboards.py
+++ b/tools/makeboards.py
@@ -51,8 +51,6 @@ def BuildUSBStack(name):
     print('%s.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"' % (name))
     print("%s.menu.usbstack.picosdknoser=Pico SDK (No Serial)" % (name))
     print('%s.menu.usbstack.picosdknoser.build.usbstack_flags=-DDISABLE_USB_SERIAL "-I{runtime.platform.path}/tools/libpico"' % (name))
-    print("%s.menu.usbstack.tinyusbnoser=Adafruit TinyUSB (No Serial)" % (name))
-    print('%s.menu.usbstack.tinyusbnoser.build.usbstack_flags=-DDISABLE_USB_SERIAL -DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"' % (name))
     print("%s.menu.usbstack.nousb=No USB" % (name))
     print('%s.menu.usbstack.nousb.build.usbstack_flags=-DNO_USB "-I{runtime.platform.path}/tools/libpico"' % (name))
 


### PR DESCRIPTION
Adding additional options to the 'USB Stack' menu, which allow the user to disable USB Serial or USB altogether.