### PR TITLE
Add warning flags to build, catch missing return

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -32,11 +32,11 @@ compiler.path={runtime.tools.pqt-gcc.path}/bin/
 # Compile variables
 # -----------------
 
-compiler.warning_flags=-w
-compiler.warning_flags.none=-w
-compiler.warning_flags.default=
-compiler.warning_flags.more=-Wall
-compiler.warning_flags.all=-Wall -Wextra
+compiler.warning_flags=-Werror=return-type
+compiler.warning_flags.none=-Werror=return-type
+compiler.warning_flags.default=-Werror=return-type
+compiler.warning_flags.more=-Wall -Werror=return-type
+compiler.warning_flags.all=-Wall -Wextra -Werror=return-type
 
 compiler.defines={build.led} {build.usbstack_flags} -DCFG_TUSB_MCU=OPT_MCU_RP2040 -DUSB_VID={build.vid} -DUSB_PID={build.pid} '-DUSB_MANUFACTURER={build.usb_manufacturer}' '-DUSB_PRODUCT={build.usb_product}'
 compiler.includes="-iprefix{runtime.platform.path}/" "@{runtime.platform.path}/lib/platform_inc.txt"
@@ -45,13 +45,13 @@ compiler.wrap="@{runtime.platform.path}/lib/platform_wrap.txt"
 compiler.libpico="{runtime.platform.path}/lib/libpico.a"
 
 compiler.c.cmd=arm-none-eabi-gcc
-compiler.c.flags=-c {compiler.defines} {compiler.flags} {compiler.includes} -std=gnu17 -g
+compiler.c.flags=-c {compiler.warning_flags} {compiler.defines} {compiler.flags} {compiler.includes} -std=gnu17 -g
 compiler.c.elf.cmd=arm-none-eabi-g++
-compiler.c.elf.flags={compiler.defines} {compiler.flags} -u _printf_float -u _scanf_float
+compiler.c.elf.flags={compiler.warning_flags} {compiler.defines} {compiler.flags} -u _printf_float -u _scanf_float
 compiler.S.cmd=arm-none-eabi-gcc
-compiler.S.flags=-c -g -x assembler-with-cpp -MMD {compiler.includes} -g
+compiler.S.flags=-c {compiler.warning_flags} -g -x assembler-with-cpp -MMD {compiler.includes} -g
 compiler.cpp.cmd=arm-none-eabi-g++
-compiler.cpp.flags=-c {compiler.defines} {compiler.flags} {compiler.includes} -fno-rtti -std=gnu++17 -g
+compiler.cpp.flags=-c {compiler.warning_flags} {compiler.defines} {compiler.flags} {compiler.includes} -fno-rtti -std=gnu++17 -g
 
 compiler.ar.cmd=arm-none-eabi-ar
 compiler.ar.flags=rcs


### PR DESCRIPTION
Fixes #236

Compiler warning flags were completely ignored/missed in platform.txt.
Add them, as normal, and include -Werror=return-type because GCC will
produce crashing apps when a function return value is missing.