### PR TITLE
Disable ignored-qualifier warning in SDK

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -35,8 +35,8 @@ compiler.path={runtime.tools.pqt-gcc.path}/bin/
 compiler.warning_flags=-Werror=return-type
 compiler.warning_flags.none=-Werror=return-type
 compiler.warning_flags.default=-Werror=return-type
-compiler.warning_flags.more=-Wall -Werror=return-type
-compiler.warning_flags.all=-Wall -Wextra -Werror=return-type
+compiler.warning_flags.more=-Wall -Werror=return-type -Wno-ignored-qualifiers
+compiler.warning_flags.all=-Wall -Wextra -Werror=return-type -Wno-ignored-qualifiers
 
 compiler.defines={build.led} {build.usbstack_flags} -DCFG_TUSB_MCU=OPT_MCU_RP2040 -DUSB_VID={build.vid} -DUSB_PID={build.pid} '-DUSB_MANUFACTURER={build.usb_manufacturer}' '-DUSB_PRODUCT={build.usb_product}'
 compiler.includes="-iprefix{runtime.platform.path}/" "@{runtime.platform.path}/lib/platform_inc.txt"


### PR DESCRIPTION
The Pico SDK has some magic with const pointers that generates lots of
"ignored qualifer" warnings on the more pedantic modes.  To clean the
normal builds up, disable this warning for now.  At some point a PR to
the PICO-SDK may be indicated.

````
In file included from /home/earle/Arduino/hardware/pico/rp2040//pico-sdk/src/rp2_common/hardware_timer/include/hardware/timer.h:11,
                 from /home/earle/Arduino/hardware/pico/rp2040//pico-sdk/src/common/pico_time/include/pico/time.h:11,
                 from /home/earle/Arduino/hardware/pico/rp2040//pico-sdk/src/common/pico_sync/include/pico/lock_core.h:11,
                 from /home/earle/Arduino/hardware/pico/rp2040//pico-sdk/src/common/pico_sync/include/pico/mutex.h:10,
                 from /home/earle/Arduino/hardware/pico/rp2040/cores/rp2040/CoreMutex.h:26,
                 from /home/earle/Arduino/hardware/pico/rp2040/cores/rp2040/SerialUART.h:26,
                 from /home/earle/Arduino/hardware/pico/rp2040/cores/rp2040/Arduino.h:97,
                 from /tmp/arduino_build_863393/sketch/sketch_jul04a.ino.cpp:1:
/home/earle/Arduino/hardware/pico/rp2040//pico-sdk/src/rp2_common/hardware_timer/include/hardware/timer.h: In function 'uint32_t time_us_32()':
/home/earle/Arduino/hardware/pico/rp2040//pico-sdk/src/rp2040/hardware_structs/include/hardware/structs/timer.h:33:19: warning: type qualifiers ignored on cast result type [-Wignored-qualifiers]
   33 | #define timer_hw ((timer_hw_t *const)TIMER_BASE)
/home/earle/Arduino/hardware/pico/rp2040//pico-sdk/src/rp2_common/hardware_timer/include/hardware/timer.h:66:12: note: in expansion of macro 'timer_hw'
   66 |     return timer_hw->timerawl;
      |            ^~~~~~~~
/home/earle/Arduino/hardware/pico/rp2040//pico-sdk/src/rp2_common/hardware_timer/include/hardware/timer.h: In function 'bool time_reached(absolute_time_t)':
/home/earle/Arduino/hardware/pico/rp2040//pico-sdk/src/rp2040/hardware_structs/include/hardware/structs/timer.h:33:19: warning: type qualifiers ignored on cast result type [-Wignored-qualifiers]
   33 | #define timer_hw ((timer_hw_t *const)TIMER_BASE)
/home/earle/Arduino/hardware/pico/rp2040//pico-sdk/src/rp2_common/hardware_timer/include/hardware/timer.h:117:19: note: in expansion of macro 'timer_hw'
  117 |     uint32_t hi = timer_hw->timerawh;
      |                   ^~~~~~~~
/home/earle/Arduino/hardware/pico/rp2040//pico-sdk/src/rp2040/hardware_structs/include/hardware/structs/timer.h:33:19: warning: type qualifiers ignored on cast result type [-Wignored-qualifiers]
   33 | #define timer_hw ((timer_hw_t *const)TIMER_BASE)
/home/earle/Arduino/hardware/pico/rp2040//pico-sdk/src/rp2_common/hardware_timer/include/hardware/timer.h:118:33: note: in expansion of macro 'timer_hw'
  118 |     return (hi >= hi_target && (timer_hw->timerawl >= (uint32_t) target || hi != hi_target));
      |                                 ^~~~~~~~
````