### PR TITLE
Remove exception handling code, save RAM and FLASH

### DIFF
--- a/cores/rp2040/RP2040USB.cpp
+++ b/cores/rp2040/RP2040USB.cpp
@@ -168,7 +168,7 @@ const uint8_t *tud_descriptor_configuration_cb(uint8_t index) {
 
         uint8_t interface_count = (__USBInstallSerial ? 2 : 0) + (hasHID ? 1 : 0) + (__USBInstallMIDI ? 2 : 0);
 
-        static uint8_t cdc_desc[TUD_CDC_DESC_LEN] = {
+        uint8_t cdc_desc[TUD_CDC_DESC_LEN] = {
             // Interface number, string index, protocol, report descriptor len, EP In & Out address, size & polling interval
             TUD_CDC_DESCRIPTOR(USBD_ITF_CDC, USBD_STR_CDC, USBD_CDC_EP_CMD, USBD_CDC_CMD_MAX_SIZE, USBD_CDC_EP_OUT, USBD_CDC_EP_IN, USBD_CDC_IN_OUT_MAX_SIZE)
         };
@@ -176,20 +176,20 @@ const uint8_t *tud_descriptor_configuration_cb(uint8_t index) {
         int hid_report_len;
         GetDescHIDReport(&hid_report_len);
         uint8_t hid_itf = __USBInstallSerial ? 2 : 0;
-        static uint8_t hid_desc[TUD_HID_DESC_LEN] = {
+        uint8_t hid_desc[TUD_HID_DESC_LEN] = {
             // Interface number, string index, protocol, report descriptor len, EP In & Out address, size & polling interval
             TUD_HID_DESCRIPTOR(hid_itf, 0, HID_ITF_PROTOCOL_NONE, hid_report_len, EPNUM_HID, CFG_TUD_HID_EP_BUFSIZE, 10)
         };
 
         uint8_t midi_itf = hid_itf + (hasHID ? 1 : 0);
-        static uint8_t midi_desc[TUD_MIDI_DESC_LEN] = {
+        uint8_t midi_desc[TUD_MIDI_DESC_LEN] = {
             // Interface number, string index, EP Out & EP In address, EP size
             TUD_MIDI_DESCRIPTOR(midi_itf, 0, EPNUM_MIDI, 0x80 | EPNUM_MIDI, 64)
         };
 
         int usbd_desc_len = TUD_CONFIG_DESC_LEN + (__USBInstallSerial ? sizeof(cdc_desc) : 0) + (hasHID ? sizeof(hid_desc) : 0) + (__USBInstallMIDI ? sizeof(midi_desc) : 0);
 
-        static uint8_t tud_cfg_desc[TUD_CONFIG_DESC_LEN] = {
+        uint8_t tud_cfg_desc[TUD_CONFIG_DESC_LEN] = {
             // Config number, interface count, string index, total length, attribute, power in mA
             TUD_CONFIG_DESCRIPTOR(1, interface_count, USBD_STR_0, usbd_desc_len, TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, USBD_MAX_POWER_MA)
         };
@@ -277,6 +277,7 @@ void __USBStart() {
     }
 
     mutex_init(&__usb_mutex);
+
     tusb_init();
 
     irq_set_exclusive_handler(USB_TASK_IRQ, usb_irq);

--- a/cores/rp2040/RP2040USB.cpp
+++ b/cores/rp2040/RP2040USB.cpp
@@ -122,32 +122,41 @@ int __USBGetMouseReportID() {
 }
 
 static uint8_t *GetDescHIDReport(int *len) {
+    static uint8_t *report = nullptr;
+    int report_len = 0;
+
+    if (report) {
+        free(report);
+    }
+
     if (__USBInstallKeyboard && __USBInstallMouse) {
-        static uint8_t desc_hid_report[] = {
+        uint8_t desc_hid_report[] = {
             TUD_HID_REPORT_DESC_KEYBOARD(HID_REPORT_ID(1)),
             TUD_HID_REPORT_DESC_MOUSE(HID_REPORT_ID(2))
         };
-        if (len) {
-            *len = sizeof(desc_hid_report);
-        }
-        return desc_hid_report;
+        report_len = sizeof(desc_hid_report);
+        report = (uint8_t *)malloc(report_len);
+        memcpy(report, desc_hid_report, report_len);
     } else if (__USBInstallKeyboard && ! __USBInstallMouse) {
-        static uint8_t desc_hid_report[] = {
+        uint8_t desc_hid_report[] = {
             TUD_HID_REPORT_DESC_KEYBOARD(HID_REPORT_ID(1))
         };
-        if (len) {
-            *len = sizeof(desc_hid_report);
-        }
-        return desc_hid_report;
+        report_len = sizeof(desc_hid_report);
+        report = (uint8_t *)malloc(report_len);
+        memcpy(report, desc_hid_report, report_len);
     } else { // if (!__USBInstallKeyboard && __USBInstallMouse) {
-        static uint8_t desc_hid_report[] = {
+        uint8_t desc_hid_report[] = {
             TUD_HID_REPORT_DESC_MOUSE(HID_REPORT_ID(1))
         };
-        if (len) {
-            *len = sizeof(desc_hid_report);
-        }
-        return desc_hid_report;
+        report_len = sizeof(desc_hid_report);
+        report = (uint8_t *)malloc(report_len);
+        memcpy(report, desc_hid_report, report_len);
     }
+
+    if (len) {
+        *len = report_len;
+    }
+    return report;
 }
 
 // Invoked when received GET HID REPORT DESCRIPTOR
@@ -161,7 +170,7 @@ uint8_t const * tud_hid_descriptor_report_cb(uint8_t instance) {
 
 const uint8_t *tud_descriptor_configuration_cb(uint8_t index) {
     (void)index;
-    static uint8_t *usbd_desc_cfg = NULL;
+    static uint8_t *usbd_desc_cfg = nullptr;
 
     if (!usbd_desc_cfg) {
         bool hasHID = __USBInstallKeyboard || __USBInstallMouse;

--- a/cores/rp2040/main.cpp
+++ b/cores/rp2040/main.cpp
@@ -76,7 +76,7 @@ extern "C" int main() {
 #endif
 
 #if defined DEBUG_RP2040_PORT
-    DEBUG_RP2040_PORT.begin();
+    DEBUG_RP2040_PORT.begin(115200);
 #endif
 
 #ifndef NO_USB

--- a/platform.txt
+++ b/platform.txt
@@ -43,6 +43,7 @@ compiler.includes="-iprefix{runtime.platform.path}/" "@{runtime.platform.path}/l
 compiler.flags=-Os -march=armv6-m -mcpu=cortex-m0plus -mthumb -ffunction-sections -fdata-sections -fno-exceptions
 compiler.wrap="@{runtime.platform.path}/lib/platform_wrap.txt"
 compiler.libpico="{runtime.platform.path}/lib/libpico.a"
+compiler.libstdcpp="{runtime.platform.path}/lib/libstdc++.a"
 
 compiler.c.cmd=arm-none-eabi-gcc
 compiler.c.flags=-c {compiler.warning_flags} {compiler.defines} {compiler.flags} {compiler.includes} -std=gnu17 -g
@@ -113,7 +114,7 @@ recipe.hooks.linking.prelink.1.pattern="{runtime.tools.pqt-python3.path}/python3
 recipe.hooks.linking.prelink.2.pattern="{compiler.path}{compiler.S.cmd}" {compiler.c.elf.flags} {compiler.c.elf.extra_flags} -c "{runtime.platform.path}/boot2/{build.boot2}.S" "-I{runtime.platform.path}/pico-sdk/src/rp2040/hardware_regs/include/" "-I{runtime.platform.path}/pico-sdk/src/common/pico_binary_info/include" -o "{build.path}/boot2.o"
 
 ## Combine gc-sections, archives, and objects
-recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" "-L{build.path}" {compiler.c.elf.flags} {compiler.c.elf.extra_flags} {compiler.ldflags} "-Wl,--script={build.path}/memmap_default.ld" "-Wl,-Map,{build.path}/{build.project_name}.map" -o "{build.path}/{build.project_name}.elf" -Wl,--start-group {object_files} "{build.path}/{archive_file}" "{build.path}/boot2.o" {compiler.libpico} -lm -lc -lstdc++ -lc -Wl,--end-group
+recipe.c.combine.pattern="{compiler.path}{compiler.c.elf.cmd}" "-L{build.path}" {compiler.c.elf.flags} {compiler.c.elf.extra_flags} {compiler.ldflags} "-Wl,--script={build.path}/memmap_default.ld" "-Wl,-Map,{build.path}/{build.project_name}.map" -o "{build.path}/{build.project_name}.elf" -Wl,--start-group {object_files} "{build.path}/{archive_file}" "{build.path}/boot2.o" {compiler.libpico} -lm -lc {compiler.libstdcpp} -lc -Wl,--end-group
 
 ## Create output (UF2 file)
 recipe.objcopy.uf2.pattern="{runtime.tools.pqt-elf2uf2.path}/elf2uf2" "{build.path}/{build.project_name}.elf" "{build.path}/{build.project_name}.uf2"


### PR DESCRIPTION
Use a libstdc++ compiled with -fno-exceptions to avoid including the
code needed to unwind C++ exceptions.

Saves 4K RAM and 6K flash.