### PR TITLE
Fix upload file path escaping for OpenOCD

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -147,10 +147,10 @@ tools.picoprobe.cmd={runtime.platform.path}/system/openocd
 tools.picoprobe.upload.protocol=picoprobe
 tools.picoprobe.upload.params.verbose=
 tools.picoprobe.upload.params.quiet=
-tools.picoprobe.upload.pattern="{cmd}/bin/openocd" -f "interface/picoprobe.cfg" -f "target/rp2040.cfg" -s "{cmd}/share/openocd/scripts" -c "program {build.path}/{build.project_name}.elf verify reset exit"
+tools.picoprobe.upload.pattern="{cmd}/bin/openocd" -f "interface/picoprobe.cfg" -f "target/rp2040.cfg" -s "{cmd}/share/openocd/scripts" -c "program {{build.path}/{build.project_name}.elf} verify reset exit"
 
 tools.picodebug.cmd={runtime.platform.path}/system/openocd
 tools.picodebug.upload.protocol=pico-debug
 tools.picodebug.upload.params.verbose=
 tools.picodebug.upload.params.quiet=
-tools.picodebug.upload.pattern="{cmd}/bin/openocd" -f "board/pico-debug.cfg" -s "{cmd}/share/openocd/scripts" -c "program {build.path}/{build.project_name}.elf verify reset exit"
+tools.picodebug.upload.pattern="{cmd}/bin/openocd" -f "board/pico-debug.cfg" -s "{cmd}/share/openocd/scripts" -c "program {{build.path}/{build.project_name}.elf} verify reset exit"


### PR DESCRIPTION
As discussed in https://github.com/earlephilhower/pico-quick-toolchain/issues/4#issuecomment-882636739, without using `{}` in the OpenOCD program command, OpenOCD fails to find the to be uploaded ELF file. 

The PR fixes that escaping.

Additionally with replacing the shipped OpenOCD version with the one discussed in the issue to make OpenOCD able to connect to the board at all, the uploading now works. 

Working upload log:

```
C:\Users\Max\Desktop\Programming Stuff\arduino-1.8.13\hardware\pico\rp2040/system/openocd/bin/openocd -f interface/picoprobe.cfg -f target/rp2040.cfg -s C:\Users\Max\Desktop\Programming Stuff\arduino-1.8.13\hardware\pico\rp2040/system/openocd/share/openocd/scripts -c program {C:\Users\Max\AppData\Local\Temp\arduino_build_395124/Fade.ino.elf} verify reset exit 
Open On-Chip Debugger 0.10.0+dev-g18b4c35 (2021-07-16-01:02)
Licensed under GNU GPL v2
For bug reports, read
	http://openocd.org/doc/doxygen/bugs.html
Info : only one transport option; autoselect 'swd'
Warn : Transport "swd" was already selected
adapter speed: 5000 kHz

Info : Hardware thread awareness created
Info : Hardware thread awareness created
Info : RP2040 Flash Bank Command
Info : clock speed 5000 kHz
Info : SWD DPIDR 0x0bc12477
Info : SWD DLPIDR 0x00000001
Info : SWD DPIDR 0x0bc12477
Info : SWD DLPIDR 0x10000001
Info : rp2040.core0: hardware has 4 breakpoints, 2 watchpoints
Info : rp2040.core1: hardware has 4 breakpoints, 2 watchpoints
Info : starting gdb server for rp2040.core0 on 3333
Info : Listening on port 3333 for gdb connections
target halted due to debug-request, current mode: Thread 
xPSR: 0xf1000000 pc: 0x000000ee msp: 0x20041f00
target halted due to debug-request, current mode: Thread 
xPSR: 0xf1000000 pc: 0x000000ee msp: 0x20041f00
** Programming Started **
Info : RP2040 B0 Flash Probe: 2097152 bytes @10000000, in 512 sectors

target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x00000178 msp: 0x20041f00
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x00000178 msp: 0x20041f00
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x00000178 msp: 0x20041f00
Info : Writing 65536 bytes starting at 0x0
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x00000178 msp: 0x20041f00
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x00000178 msp: 0x20041f00
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x00000178 msp: 0x20041f00
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x00000178 msp: 0x20041f00
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x00000178 msp: 0x20041f00
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x00000178 msp: 0x20041f00
** Programming Finished **
** Verify Started **
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x00000178 msp: 0x20041f00
target halted due to debug-request, current mode: Thread 
xPSR: 0x01000000 pc: 0x00000178 msp: 0x20041f00
** Verified OK **
** Resetting Target **
shutdown command invoked
Info : SWD DPIDR 0x0bc12477
Info : SWD DLPIDR 0x00000001
```

For previous non-working, see linked issue and last picture.

Edit: Changed title to more generic 'Fix upload file path escaping', the old method is very likely broken under Linux + Mac too if the path contains a space. I'll test in a VM.