### PR TITLE
Tweak README git setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,12 +51,8 @@ To install via GIT (for latest and greatest versions):
 mkdir -p ~/Arduino/hardware/pico
 git clone https://github.com/earlephilhower/arduino-pico.git ~/Arduino/hardware/pico/rp2040
 cd ~/Arduino/hardware/pico/rp2040
-git submodule update --init
-cd pico-sdk
-git submodule update --init
-cd ../pico-extras
-git submodule update --init
-cd ../tools
+git submodule update --init --recursive
+cd tools
 python3 ./get.py
 `````
 


### PR DESCRIPTION
git submodule update has a --recursive flag, which can potentially save users a few steps, but it looks like it may check out a bunch of extra HAL drivers inside tinyusb. 

I'm not sure if the slightly increased disk usage and clone time outweighs the easier onboarding. Please feel free to reject this PR if you deem it undesirable.