### PR TITLE
Set available() to 0 when Wire.requestFrom fails

### DIFF
--- a/libraries/Wire/Wire.cpp
+++ b/libraries/Wire/Wire.cpp
@@ -192,6 +192,7 @@ void TwoWire::beginTransmission(uint8_t addr) {
     }
     _addr = addr;
     _buffLen = 0;
+    _buffOff = 0;
     _txBegun = true;
 }
 
@@ -201,6 +202,9 @@ size_t TwoWire::requestFrom(uint8_t address, size_t quantity, bool stopBit) {
     }
 
     _buffLen = i2c_read_blocking_until(_i2c, address, _buff, quantity, !stopBit, make_timeout_time_ms(50));
+    if (_buffLen == PICO_ERROR_GENERIC) {
+        _buffLen = 0;
+    }
     _buffOff = 0;
     return _buffLen;
 }


### PR DESCRIPTION
Wire::requestFrom() returns the number of bytes read from the slave.  In
the case of error, the slave can end up returning a very large integer
for PICO_GENERIC_ERROR which would then be used as the # of bytes read
causing crashes and errors.

Running TalkingToMyself without connecting the I2C ports would show
this behavior.

Now, when PICO_GENERIC_ERROR is returned, set the read-back buffer len
to 0 explicitly.