### PR TITLE
Make multiple begin calls noops SDFS/LittleFS

### DIFF
--- a/libraries/LittleFS/src/LittleFS.h
+++ b/libraries/LittleFS/src/LittleFS.h
@@ -176,6 +176,9 @@ public:
     }
 
     bool begin() override {
+        if (_mounted) {
+            return true;
+        }
         if (_size <= 0) {
             DEBUGV("LittleFS size is <= zero");
             return false;

--- a/libraries/SDFS/src/SDFS.h
+++ b/libraries/SDFS/src/SDFS.h
@@ -148,7 +148,7 @@ public:
 
     bool begin() override {
         if (_mounted) {
-            end();
+            return true;
         }
         _mounted = _fs.begin(_cfg._csPin, _cfg._spiSettings);
         if (!_mounted && _cfg._autoFormat) {


### PR DESCRIPTION
When LittleFS.begin() or SDFS.begin() is called after the filesystem is
already mounted, don't unmount/remount.  When an unmount happens, all old
Files become invalid (but the core doesn't know this), so you would end
up with random crashes in FS code.

Now, check for _mounted, and if so just return immediately from begin().