### PR TITLE
Don't use no-c++-exceptions version of libstdc++

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -43,7 +43,7 @@ compiler.includes="-iprefix{runtime.platform.path}/" "@{runtime.platform.path}/l
 compiler.flags=-Os -march=armv6-m -mcpu=cortex-m0plus -mthumb -ffunction-sections -fdata-sections -fno-exceptions
 compiler.wrap="@{runtime.platform.path}/lib/platform_wrap.txt"
 compiler.libpico="{runtime.platform.path}/lib/libpico.a"
-compiler.libstdcpp="{runtime.platform.path}/lib/libstdc++.a"
+compiler.libstdcpp="-lstdc++"
 
 compiler.c.cmd=arm-none-eabi-gcc
 compiler.c.flags=-c {compiler.warning_flags} {compiler.defines} {compiler.flags} {compiler.includes} -std=gnu17 -g


### PR DESCRIPTION
Per #276, #277, #274 there seems to be an issue with interrupts and some
other low-level ARM operations when using the distributed libstdc++.

Use the default libstdc++ built with the toolchain, instead.

Fixes #277
Fixes #276
Fixes #274