### PR TITLE
Fix wire defines on feather

### DIFF
--- a/variants/adafruit_feather/pins_arduino.h
+++ b/variants/adafruit_feather/pins_arduino.h
@@ -27,12 +27,10 @@
 #define PIN_SPI1_SS    (31u)
 
 // Wire
-#define PIN_WIRE0_SDA  (2u)
-#define PIN_WIRE0_SCL  (3u)
-
-// Not pinned out
-#define PIN_WIRE1_SDA  (31u)
-#define PIN_WIRE1_SCL  (31u)
+#define PIN_WIRE0_SDA  (24u)
+#define PIN_WIRE0_SCL  (25u)
+#define PIN_WIRE1_SDA  (2u)
+#define PIN_WIRE1_SCL  (3u)
 
 #define SERIAL_HOWMANY (2u)
 #define SPI_HOWMANY    (1u)


### PR DESCRIPTION
In troubleshooting issues using the STEMMA QT connector on my feather, I think I've discovered an issue with the board's variants file, specifically the WIRE lines below. The file seems to associate the i2c0 peripheral with the 2 and 3 pins, and doesn't seem to be attempting to assign any functional pins to i2c1.
https://github.com/earlephilhower/arduino-pico/blob/8451bc21ec4cca39f189a0493b2714749b272816/variants/adafruit_feather/pins_arduino.h#L29-L35

However looking at the Wires library, it doesn't seem like pins 2 and 3 are valid for i2c0 at all, but they are valid for the i2c1 peripheral.
https://github.com/earlephilhower/arduino-pico/blob/8451bc21ec4cca39f189a0493b2714749b272816/libraries/Wire/src/Wire.cpp#L50-L52
https://github.com/earlephilhower/arduino-pico/blob/8451bc21ec4cca39f189a0493b2714749b272816/libraries/Wire/src/Wire.cpp#L67-L69

This led me to try this in my script, which seems to work correctly with both the built in STEMMA QT connector, and the pins labeled SCL and SDA on the board itself. When trying these same pins with the "zero" Wire object instead of Wire1, it seemed like the program would panic, but I don't have a full debugger to 100% confirm that. This suggests to me that Wire.cpp is correct, and the pins page should be made to agree to it.
```C++
Wire1.setSDA(PIN_WIRE0_SDA);
Wire1.setSCL(PIN_WIRE0_SCL);
  ```
  
From Adafruit's pinout page from the board https://cdn-learn.adafruit.com/assets/assets/000/100/740/original/adafruit_products_RP2040Pinout300DPI.png?1615928836, it seems like there are only 4 pairs of adjacent i2c0 supported pins. Specifically 24+25, RX+TX, 12+13, and 6+9. RX+TX seem labeled for other uses, 13 is tied to the built in LED making it not a great choice here, and it seems like it'd be very easy for people to read 6 and 9 from the wrong direction and incorrectly plug their SDA line into the SCL pin and vice-versa. Therefore 24+25 seems like the a sensible default choice for the PIN_WIRE0 defines on this board. I've tested with those values on Wire "zero" and they work as expected.
 
These changes look correct to me. They allow the STEMMA QT connector to work out of the box so long as the code is using Wire1, and it provides default pins for any code that uses "zero" Wire, instead of requiring extra lines of code from the user specifying which i2c0 valid pins they want to use. All that being said, I'm not especially experienced in electronics and microcontrollers so please let me know if I've made a mistake or overlooked anything.