### PR TITLE
Change SDA and SCL to Wire1

### DIFF
--- a/variants/adafruit_itsybitsy/pins_arduino.h
+++ b/variants/adafruit_itsybitsy/pins_arduino.h
@@ -26,13 +26,13 @@
 #define PIN_SPI1_SCK   (31u)
 #define PIN_SPI1_SS    (31u)
 
-// Wire
-#define PIN_WIRE0_SDA  (2u)
-#define PIN_WIRE0_SCL  (3u)
-
 // Not pinned out
-#define PIN_WIRE1_SDA  (31u)
-#define PIN_WIRE1_SCL  (31u)
+#define PIN_WIRE0_SDA  (31u)
+#define PIN_WIRE0_SCL  (31u)
+
+// Wire
+#define PIN_WIRE1_SDA  (2u)
+#define PIN_WIRE1_SCL  (3u)
 
 #define SERIAL_HOWMANY (2u)
 #define SPI_HOWMANY    (1u)


### PR DESCRIPTION
Pins 2 and 3 are on I2C1 which is Wire1. The Wire instance (I2C0) does not work with this pin assignment.