### PR TITLE
Disable pull-up/pull-down when setting pin as input

### DIFF
--- a/cores/rp2040/wiring_digital.cpp
+++ b/cores/rp2040/wiring_digital.cpp
@@ -28,6 +28,7 @@ extern "C" void pinMode(pin_size_t ulPin, PinMode ulMode) {
     case INPUT:
         gpio_init(ulPin);
         gpio_set_dir(ulPin, false);
+        gpio_disable_pulls(ulPin);
         break;
     case INPUT_PULLUP:
         gpio_init(ulPin);


### PR DESCRIPTION
In `pinMode()` I think it would be better to call `gpio_disable_pulls()` on the ulPin when ulMode == INPUT.
As a case for the modification, consider the following code:

```
#include "pico/stdlib.h"
#define RP_PIN 24

void setup() {
  Serial.begin(9600);
  pinMode(RP_PIN, INPUT);
  while(!Serial) ;
}

void loop() {
  Serial.println(digitalRead(RP_PIN));
  delay(1000);
}
```

On a generic RP2040 board, where GPIO24 is used as generic input, the above would not work in cases where the input is weakly driven up.
Adding `gpio_disable_pulls(RP_PIN);` after `pinMode(RP_PIN, INPUT);` solves the issue.