### PR TITLE
Correct typo in PlatformIO docs

### DIFF
--- a/docs/platformio.rst
+++ b/docs/platformio.rst
@@ -206,7 +206,7 @@ and 0.5MByte filesystem.
     platform = https://github.com/maxgerhardt/platform-raspberrypi.git
     board = pico
     framework = arduino
-    build_board.core = earlephilhower
+    board_build.core = earlephilhower
     board_build.filesystem_size = 0.5m
     ; note that download link for toolchain is specific for OS. see https://github.com/earlephilhower/pico-quick-toolchain/releases.
     platform_packages = 


### PR DESCRIPTION
The correct option name is `board_build.<xyz>`, just as in the line below.

Just as in [the docs](https://docs.platformio.org/en/latest/boards/raspberrypi/pico.html).