### PR TITLE
Add a poor-man's software FIFO for serial UART reads

### DIFF
--- a/cores/rp2040/SerialUART.h
+++ b/cores/rp2040/SerialUART.h
@@ -23,6 +23,7 @@
 #include <Arduino.h>
 #include "api/HardwareSerial.h"
 #include <stdarg.h>
+#include <queue>
 #include "CoreMutex.h"
 
 extern "C" typedef struct uart_inst uart_inst_t;
@@ -61,8 +62,10 @@ private:
     uart_inst_t *_uart;
     pin_size_t _tx, _rx;
     int _baud;
-    int _peek;
     mutex_t _mutex;
+
+    void _pumpFIFO();
+    std::queue<uint8_t> _swFIFO;
 };
 
 extern SerialUART Serial1; // HW UART 0


### PR DESCRIPTION
Because the hardware FIFO is quite small and doesn't report the actual number
of bytes available, implement a software FIFO that will pull all available
bytes out of the HW FIFO on any Serial call.  It's not as efficient or as
bulletproof as an IRQ based method, but it is simpler to implement and can
help with issues like #378 