### PR TITLE
Use interrupts to capture Serial1/2 data, not polling

### DIFF
--- a/cores/rp2040/SerialUART.cpp
+++ b/cores/rp2040/SerialUART.cpp
@@ -81,19 +81,37 @@ void SerialUART::begin(unsigned long baud, uint16_t config) {
     int bits, stop;
     uart_parity_t parity;
     switch (config & SERIAL_PARITY_MASK) {
-    case SERIAL_PARITY_EVEN: parity = UART_PARITY_EVEN; break;
-    case SERIAL_PARITY_ODD: parity = UART_PARITY_ODD; break;
-    default: parity = UART_PARITY_NONE; break;
+    case SERIAL_PARITY_EVEN:
+        parity = UART_PARITY_EVEN;
+        break;
+    case SERIAL_PARITY_ODD:
+        parity = UART_PARITY_ODD;
+        break;
+    default:
+        parity = UART_PARITY_NONE;
+        break;
     }
     switch (config & SERIAL_STOP_BIT_MASK) {
-    case SERIAL_STOP_BIT_1: stop = 1; break;
-    default: stop = 2; break;
+    case SERIAL_STOP_BIT_1:
+        stop = 1;
+        break;
+    default:
+        stop = 2;
+        break;
     }
     switch (config & SERIAL_DATA_MASK) {
-    case SERIAL_DATA_5: bits = 5; break;
-    case SERIAL_DATA_6: bits = 6; break;
-    case SERIAL_DATA_7: bits = 7; break;
-    default: bits = 8; break;
+    case SERIAL_DATA_5:
+        bits = 5;
+        break;
+    case SERIAL_DATA_6:
+        bits = 6;
+        break;
+    case SERIAL_DATA_7:
+        bits = 7;
+        break;
+    default:
+        bits = 8;
+        break;
     }
     uart_set_format(_uart, bits, stop, parity);
     gpio_set_function(_tx, GPIO_FUNC_UART);
@@ -115,6 +133,11 @@ void SerialUART::begin(unsigned long baud, uint16_t config) {
 void SerialUART::end() {
     if (!_running) {
         return;
+    }
+    if (_uart == uart0) {
+        irq_set_enabled(UART0_IRQ, false);
+    } else {
+        irq_set_enabled(UART1_IRQ, false);
     }
     uart_deinit(_uart);
     _running = false;

--- a/cores/rp2040/SerialUART.cpp
+++ b/cores/rp2040/SerialUART.cpp
@@ -225,7 +225,7 @@ void arduino::serialEvent2Run(void) {
 // IRQ handler, called when FIFO > 1/4 full or when it had held unread data for >32 bit times
 void __not_in_flash_func(SerialUART::_handleIRQ)() {
     uart_get_hw(_uart)->icr |= UART_UARTICR_RTIC_BITS | UART_UARTICR_RXIC_BITS;
-    while ( (uart_is_readable(_uart)) && ((_writer + 1) % sizeof(_queue) != _reader) ) {
+    while ((uart_is_readable(_uart)) && ((_writer + 1) % sizeof(_queue) != _reader)) {
         _queue[_writer] = uart_getc(_uart);
         _writer = (_writer + 1) % sizeof(_queue);
     }

--- a/cores/rp2040/SerialUART.cpp
+++ b/cores/rp2040/SerialUART.cpp
@@ -227,6 +227,7 @@ void __not_in_flash_func(SerialUART::_handleIRQ)() {
     uart_get_hw(_uart)->icr |= UART_UARTICR_RTIC_BITS | UART_UARTICR_RXIC_BITS;
     while ((uart_is_readable(_uart)) && ((_writer + 1) % sizeof(_queue) != _reader)) {
         _queue[_writer] = uart_getc(_uart);
+        asm volatile("" ::: "memory"); // Ensure the queue is written before the written count advances
         _writer = (_writer + 1) % sizeof(_queue);
     }
 }

--- a/cores/rp2040/SerialUART.h
+++ b/cores/rp2040/SerialUART.h
@@ -57,6 +57,9 @@ public:
     using Print::write;
     operator bool() override;
 
+    // Not to be called by users, only from the IRQ handler.  In public so that the C-language IQR callback can access it
+    void _handleIRQ();
+
 private:
     bool _running = false;
     uart_inst_t *_uart;
@@ -64,8 +67,10 @@ private:
     int _baud;
     mutex_t _mutex;
 
-    void _pumpFIFO();
-    std::queue<uint8_t> _swFIFO;
+    // Lockless, IRQ-handled circular queue
+    uint32_t _writer;
+    uint32_t _reader;
+    uint8_t  _queue[32];
 };
 
 extern SerialUART Serial1; // HW UART 0


### PR DESCRIPTION
PR #379 was an ugly hack which works only if you poll the Serial port more
frequently than ~8 byte times.

This PR replaces the polling with an IRQ based lockless writer/reader queue
so that even if you only read every 32 byte times, the Serial1/2 port should
not lose data.  It also should use less CPU and allow for somewhat higher
throughput.