### PR TITLE
Fix PlatformIO build

### DIFF
--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -142,7 +142,8 @@ def configure_usb_flags(cpp_defines):
         ("USB_PID", usb_pid),
         ("USB_MANUFACTURER", '\\"%s\\"' % usb_manufacturer),
         ("USB_PRODUCT", '\\"%s\\"' % usb_product),
-        ("SERIALUSB_PID", usb_pid)
+        ("SERIALUSB_PID", usb_pid),
+        ("USBD_MAX_POWER_MA", 250)
     ])
 
     # use vidtouse and pidtouse 


### PR DESCRIPTION
Defines USBD_MAX_POWER_MA as a static 250mA, which is correct for all the boards supported in platform-raspberrypi (aka, RaspberryPi Pico and Nano RP2040 Connect) in accordance to [the generator code](https://github.com/earlephilhower/arduino-pico/blob/c80c08d32c07ff7704529f37f76bdb97030bfd8f/tools/makeboards.py#L157-L177).

Fixes previous build failure if attempting to use the latest core.

```
In file included from C:\Users\Max\.platformio\packages\framework-arduinopico/pico-sdk/lib/tinyusb/src/tusb.h:65,
                 from C:\Users\Max\.platformio\packages\framework-arduinopico\cores\rp2040\RP2040USB.cpp:28:
C:\Users\Max\.platformio\packages\framework-arduinopico\cores\rp2040\RP2040USB.cpp: In function 'const uint8_t* tud_descriptor_configuration_cb(uint8_t)':
C:\Users\Max\.platformio\packages\framework-arduinopico\cores\rp2040\RP2040USB.cpp:209:118: error: 'USBD_MAX_POWER_MA' was not declared in this scope
  209 |             TUD_CONFIG_DESCRIPTOR(1, interface_count, USBD_STR_0, usbd_desc_len, TUSB_DESC_CONFIG_ATT_REMOTE_WAKEUP, USBD_MAX_POWER_MA)
      |                                                                                                                      ^~~~~~~~~~~~~~~~~
```