### PR TITLE
Fix some pin definitions for Adafruit QT Py RP2040

### DIFF
--- a/variants/adafruit_qtpy/pins_arduino.h
+++ b/variants/adafruit_qtpy/pins_arduino.h
@@ -39,3 +39,10 @@
 #define WIRE_HOWMANY   (2u)
 
 #include "../generic/common.h"
+
+// Pin overrides specific to the QT Py RP2040
+// Note, these must go below the common.h include to work correctly
+#define A0 (29u)
+#define A1 (28u)
+#define A2 (27u)
+#define A3 (26u)

--- a/variants/adafruit_qtpy/pins_arduino.h
+++ b/variants/adafruit_qtpy/pins_arduino.h
@@ -38,11 +38,10 @@
 #define SPI_HOWMANY    (1u)
 #define WIRE_HOWMANY   (2u)
 
-#include "../generic/common.h"
-
 // Pin overrides specific to the QT Py RP2040
-// Note, these must go below the common.h include to work correctly
-#define A0 (29u)
-#define A1 (28u)
-#define A2 (27u)
-#define A3 (26u)
+#define __PIN_A0 (29u)
+#define __PIN_A1 (28u)
+#define __PIN_A2 (27u)
+#define __PIN_A3 (26u)
+
+#include "../generic/common.h"

--- a/variants/generic/common.h
+++ b/variants/generic/common.h
@@ -39,10 +39,29 @@ static const uint8_t D27 = (27u);
 static const uint8_t D28 = (28u);
 static const uint8_t D29 = (29u);
 
-static const uint8_t A0 = (26u);
-static const uint8_t A1 = (27u);
-static const uint8_t A2 = (28u);
-static const uint8_t A3 = (29u);
+#ifdef __PIN_A0
+	static const uint8_t A0 = __PIN_A0;
+#else
+	static const uint8_t A0 = (26u);
+#endif
+
+#ifdef __PIN_A1
+	static const uint8_t A1 = __PIN_A1;
+#else
+	static const uint8_t A1 = (27u);
+#endif
+
+#ifdef __PIN_A2
+	static const uint8_t A2 = __PIN_A2;
+#else
+	static const uint8_t A2 = (28u);
+#endif
+
+#ifdef __PIN_A3
+	static const uint8_t A3 = __PIN_A3;
+#else
+	static const uint8_t A3 = (29u);
+#endif
 
 static const uint8_t SS = PIN_SPI0_SS;
 static const uint8_t MOSI = PIN_SPI0_MOSI;


### PR DESCRIPTION
This PR corrects the pin definitions for pins A0, A1, A2, and A3 on the Adafruit QT Py RP2040.

On this board, the four pins above are reversed compared to what's defined in the common pin configuration. The current way this PR is fixing this is to just use preprocessor `#define` in the board-specific `variants/adafruit_qtpy/pins_arduino.h` to override the `static const` declarations from `variants/generic/common.h` of those four pins. This method appears to work fine and compiles without warnings while keeping the general board variant style alive.

Another option for correcting this problem would be to copy all the pin definitions from `variants/generic/common.h` into the board's specific file with the required changes and just not include that `common.h` in it, but that way doesn't fit the style of how other boards are defined, so is this method in the PR okay with you, or would you prefer it be done more like this other method?