### PR TITLE
Allow setting the SerialPIO FIFO depth in the constructor

### DIFF
--- a/cores/rp2040/SerialPIO.cpp
+++ b/cores/rp2040/SerialPIO.cpp
@@ -114,20 +114,27 @@ void __not_in_flash_func(SerialPIO::_handleIRQ)() {
             }
         }
 
-        if ((_writer + 1) % sizeof(_queue) != _reader) {
+        if ((_writer + 1) % _fifosize != _reader) {
             _queue[_writer] = val & ((1 << _bits) -  1);
             asm volatile("" ::: "memory"); // Ensure the queue is written before the written count advances
-            _writer = (_writer + 1) % sizeof(_queue);
+            _writer = (_writer + 1) % _fifosize;
         } else {
             // TODO: Overflow
         }
     }
 }
 
-SerialPIO::SerialPIO(pin_size_t tx, pin_size_t rx) {
+SerialPIO::SerialPIO(pin_size_t tx, pin_size_t rx, size_t fifosize) {
     _tx = tx;
     _rx = rx;
+    _fifosize = fifosize;
+    _queue = new uint8_t[_fifosize];
     mutex_init(&_mutex);
+}
+
+SerialPIO::~SerialPIO() {
+    end();
+    delete[] _queue;
 }
 
 void SerialPIO::begin(unsigned long baud, uint16_t config) {
@@ -273,7 +280,7 @@ int SerialPIO::read() {
     while ((now - start) < _timeout) {
         if (_writer != _reader) {
             auto ret = _queue[_reader];
-            _reader = (_reader + 1) % sizeof(_queue);
+            _reader = (_reader + 1) % _fifosize;
             return ret;
         }
         delay(1);
@@ -287,7 +294,7 @@ int SerialPIO::available() {
     if (!_running || !m || (_rx == NOPIN)) {
         return 0;
     }
-    return (_writer - _reader) % sizeof(_queue);
+    return (_writer - _reader) % _fifosize;
 }
 
 int SerialPIO::availableForWrite() {

--- a/cores/rp2040/SerialPIO.h
+++ b/cores/rp2040/SerialPIO.h
@@ -32,7 +32,8 @@ extern "C" typedef struct uart_inst uart_inst_t;
 class SerialPIO : public HardwareSerial {
 public:
     static const pin_size_t NOPIN = 0xff; // Use in constructor to disable RX or TX unit
-    SerialPIO(pin_size_t tx, pin_size_t rx);
+    SerialPIO(pin_size_t tx, pin_size_t rx, size_t fifosize = 32);
+    ~SerialPIO();
 
     void begin(unsigned long baud = 115200) override {
         begin(baud, SERIAL_8N1);
@@ -72,7 +73,8 @@ private:
     int _rxBits;
 
     // Lockless, IRQ-handled circular queue
+    size_t   _fifosize;
     uint32_t _writer;
     uint32_t _reader;
-    uint8_t  _queue[32];
+    uint8_t  *_queue;
 };

--- a/docs/piouart.rst
+++ b/docs/piouart.rst
@@ -6,9 +6,10 @@ one or two PIO state machines is included in the Arduino-Pico core.  This
 allows for up to 8 additional serial ports to be run from the RP2040 without
 requiring additional CPU resources.
 
-Instantiate a ``SerialPIO(txpin, rxpin)`` object in your sketch and then
+Instantiate a ``SerialPIO(txpin, rxpin, fifosize)`` object in your sketch and then
 use it the same as any other serial port.  Even, odd, and no parity modes
-are supported, as well as data sizes from 5- to 8-bits.
+are supported, as well as data sizes from 5- to 8-bits.  Fifosize, if not
+specified, defaults to 32 bytes.
 
 To instantiate only a serial transmit or receive unit, pass in
 ``SerialPIO::NOPIN`` as the ``txpin`` or ``rxpin``.


### PR DESCRIPTION
Defaults to 32 bytes, like the HW Serial ports, but can be set to
any desired value when instantiated.