### PR TITLE
Add setFIFOSize to UART Serial ports

### DIFF
--- a/cores/rp2040/SerialPIO.cpp
+++ b/cores/rp2040/SerialPIO.cpp
@@ -127,7 +127,7 @@ void __not_in_flash_func(SerialPIO::_handleIRQ)() {
 SerialPIO::SerialPIO(pin_size_t tx, pin_size_t rx, size_t fifosize) {
     _tx = tx;
     _rx = rx;
-    _fifosize = fifosize;
+    _fifosize = fifosize + 1; // Always one unused entry
     _queue = new uint8_t[_fifosize];
     mutex_init(&_mutex);
 }

--- a/cores/rp2040/SerialUART.h
+++ b/cores/rp2040/SerialUART.h
@@ -40,6 +40,7 @@ public:
         ret &= setTX(tx);
         return ret;
     }
+    bool setFIFOSize(size_t size);
 
     void begin(unsigned long baud = 115200) override {
         begin(baud, SERIAL_8N1);
@@ -70,7 +71,8 @@ private:
     // Lockless, IRQ-handled circular queue
     uint32_t _writer;
     uint32_t _reader;
-    uint8_t  _queue[32];
+    size_t   _fifoSize = 32;
+    uint8_t  *_queue;
 };
 
 extern SerialUART Serial1; // HW UART 0

--- a/docs/serial.rst
+++ b/docs/serial.rst
@@ -24,5 +24,12 @@ Configure their pins using the ``setXXX`` calls prior to calling ``begin()``
         Serial1.setTX(pin);
         Serial1.begin(baud);
 
+The size of the receive FIFO may also be adjusted from the default 32 bytes by
+using the ``setFIFOSize`` call prior to calling ``begin()``
+
+.. code:: cpp
+        Serial1.setFIFOSize(128);
+        Serial1.begin(baud);
+
 For detailed information about the Serial ports, see the
 Arduino `Serial Reference <https://www.arduino.cc/reference/en/language/functions/communication/serial/>`_ .

--- a/keywords.txt
+++ b/keywords.txt
@@ -34,3 +34,4 @@ resumeOtherCore	KEYWORD2
 PIOProgram	KEYWORD2
 prepare	KEYWORD2
 SerialPIO	KEYWORD2
+setFIFOSize	KEYWORD2


### PR DESCRIPTION
Allow setting the size of the receive buffer by the application using a
call to Serial1/2.setFIFOSize(xxx) before the begin() call.