### PR TITLE
Make Wire buffer default to 256 for MBED compatibility

### DIFF
--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -31,7 +31,7 @@
 #define WIRE_HAS_END 1
 
 #ifndef WIRE_BUFFER_SIZE
-#define WIRE_BUFFER_SIZE 128
+#define WIRE_BUFFER_SIZE 256
 #endif
 
 class TwoWire : public HardwareI2C {


### PR DESCRIPTION
Fixes #411