### PR TITLE
Only call Wire.onReceive if data is available

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -146,7 +146,7 @@ void TwoWire::onIRQ() {
         _i2c->hw->clr_start_det;
     }
     if (_i2c->hw->intr_stat & (1 << 9)) {
-        if (_onReceiveCallback) {
+        if (_onReceiveCallback && _buffLen) {
             _onReceiveCallback(_buffLen);
         }
         _buffLen = 0;


### PR DESCRIPTION
The Pico HW seems to generate an interrupt on the end of every I2C
write cycle, even if the slave address wasn't actually targeted.
This would cause the onReceive method to be called with a 0-len
parameter for every write on the I2C bus.

Now, only call onReceive if there is 1 or more bytes of data available.