### PR TITLE
Add interpolater include path

### DIFF
--- a/lib/platform_inc.txt
+++ b/lib/platform_inc.txt
@@ -28,6 +28,7 @@
 -iwithprefixbefore/pico-sdk/src/rp2_common/hardware_flash/include
 -iwithprefixbefore/pico-sdk/src/rp2_common/hardware_gpio/include
 -iwithprefixbefore/pico-sdk/src/rp2_common/hardware_i2c/include
+-iwithprefixbefore/pico-sdk/src/rp2_common/hardware_interp/include
 -iwithprefixbefore/pico-sdk/src/rp2_common/hardware_irq/include
 -iwithprefixbefore/pico-sdk/src/rp2_common/hardware_rtc/include
 -iwithprefixbefore/pico-sdk/src/rp2_common/hardware_pio/include


### PR DESCRIPTION
Fixes #427.  The libpico.a build already includes the HW interpolator
sources, but the include was missing from the Arduino path.