### PR TITLE
Fix libraries and RAM size in PlatformIO build

### DIFF
--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -87,7 +87,7 @@ env.Append(
     LIBSOURCE_DIRS=[os.path.join(FRAMEWORK_DIR, "libraries")],
 
     # do **NOT** Add lib to LIBPATH, otherwise 
-    # erronous libstdc++.a will be found that crashes! 
+    # erroneous libstdc++.a will be found that crashes! 
     #LIBPATH=[
     #    os.path.join(FRAMEWORK_DIR, "lib")
     #],

--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -19,7 +19,9 @@ env = DefaultEnvironment()
 platform = env.PioPlatform()
 board = env.BoardConfig()
 upload_protocol = env.subst("$UPLOAD_PROTOCOL") or "picotool"
-ram_size = board.get("upload.maximum_ram_size")
+#ram_size = board.get("upload.maximum_ram_size") # PlatformIO gives 264K here
+# override to correct 256K for RAM section in linkerscript
+ram_size = 256 * 1024 # not the 264K, which is 256K SRAM + 2*4K SCRATCH(X/Y). 
 
 FRAMEWORK_DIR = platform.get_package_dir("framework-arduinopico")
 assert os.path.isdir(FRAMEWORK_DIR)
@@ -84,12 +86,16 @@ env.Append(
 
     LIBSOURCE_DIRS=[os.path.join(FRAMEWORK_DIR, "libraries")],
 
-    LIBPATH=[
-        os.path.join(FRAMEWORK_DIR, "lib")
-    ],
+    # do **NOT** Add lib to LIBPATH, otherwise 
+    # erronous libstdc++.a will be found that crashes! 
+    #LIBPATH=[
+    #    os.path.join(FRAMEWORK_DIR, "lib")
+    #],
 
-    # link lib/libpico.a
-    LIBS=["pico", "m", "c", "stdc++", "c"]
+    # link lib/libpico.a by full path, ignore libstdc++
+    LIBS=[
+        File(os.path.join(FRAMEWORK_DIR, "lib", "libpico.a")), 
+        "m", "c", "stdc++", "c"]
 )
 
 


### PR DESCRIPTION
This fixes two things:
* the `ram_size` variable which is fixed at 256K. Previously PlatformIO's board definitions would have 264K there (+4K scratch x/y), which would generate a linker script with the content
```
MEMORY
{
    FLASH(rx) : ORIGIN = 0x10000000, LENGTH = 1044480
    RAM(rwx) : ORIGIN =  0x20000000, LENGTH = 264k
    SCRATCH_X(rwx) : ORIGIN = 0x20040000, LENGTH = 4k
    SCRATCH_Y(rwx) : ORIGIN = 0x20041000, LENGTH = 4k
}
```
i.e., the `RAM` section length would be off by 8K. 
* links **only** against `lib/libpico.a`, not `lib/libstdc++.a` by reworking the linkerflags (no `-L` flag to add to the search directory and `-lpico -lstdc++`, only link `libpico.a` by full path and source `libstdc++.a` from compiler). The `libstdc++.a` has weird errors which make the the system crash & burn when attempting to use even the smallest bits of the C++ standard library, such as creating a `std::string` or a `std::map`. I am not sure why this file exists here, the Arduino IDE build also does not link against it.

Related to https://github.com/maxgerhardt/pio-pico-core-earlephilhower-test/issues/3 and #436.