### PR TITLE
 Correctly use earlephilhower.varant if variant not given, ensure USB…

### DIFF
--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -148,9 +148,12 @@ def configure_usb_flags(cpp_defines):
         ("USB_PID", usb_pid),
         ("USB_MANUFACTURER", '\\"%s\\"' % usb_manufacturer),
         ("USB_PRODUCT", '\\"%s\\"' % usb_product),
-        ("SERIALUSB_PID", usb_pid),
-        ("USBD_MAX_POWER_MA", 250)
+        ("SERIALUSB_PID", usb_pid)
     ])
+
+    if "USBD_MAX_POWER_MA" not in env.Flatten(env.get("CPPDEFINES", [])):
+        env.Append(CPPDEFINES=[("USBD_MAX_POWER_MA", 500)])
+        print("Warning: Undefined USBD_MAX_OWER_MA, assuming 500mA")
 
     # use vidtouse and pidtouse 
     # for USB PID/VID autodetection
@@ -195,9 +198,9 @@ if not board.get("build.ldscript", ""):
 
 libs = []
 
-variant = board.get("build.arduino.earlephilhower.variant", board.get("build.variant", None))
+variant = board.get("build.arduino.earlephilhower.variant", board.get("build.variant", ""))
 
-if variant is not None:
+if variant != "":
     env.Append(CPPPATH=[
         os.path.join(FRAMEWORK_DIR, "variants", variant)
     ])


### PR DESCRIPTION
… power macro is always there

Cherry-pick of https://github.com/maxgerhardt/arduino-pico/commit/beec911fce6151cee3f1306421d21af5528f35c7

Fixes a crash of the builder script, `board.get("build.variant", None)` will throw an exception if the `build.variant` was not found (and not return `None` as the fallback value which was the wanted behavior), but an empty string works, so check against that.

USB power defines moved directly into the board files, but still ensure that the macro always exists (with a default fallback value) to not fail the build.