### PR TITLE
Add support for analogReadResolution, default 10b

### DIFF
--- a/cores/rp2040/Arduino.h
+++ b/cores/rp2040/Arduino.h
@@ -70,6 +70,7 @@ void noInterrupts();
 #define portModeRegister(port)      ((volatile uint32_t*) sio_hw->gpio_oe)
 
 // ADC RP2040-specific calls
+void analogReadResolution(int bits);
 float analogReadTemp();  // Returns core temp in Centigrade
 
 // PWM RP2040-specific calls

--- a/cores/rp2040/wiring_analog.cpp
+++ b/cores/rp2040/wiring_analog.cpp
@@ -117,6 +117,7 @@ extern "C" void analogWrite(pin_size_t pin, int val) {
 }
 
 auto_init_mutex(_adcMutex);
+static int _readBits = 10;
 
 extern "C" int analogRead(pin_size_t pin) {
     CoreMutex m(&_adcMutex);
@@ -133,7 +134,7 @@ extern "C" int analogRead(pin_size_t pin) {
     }
     adc_gpio_init(pin);
     adc_select_input(pin - minPin);
-    return adc_read();
+    return (_readBits < 12) ? adc_read() >> (12 - _readBits) : adc_read() << (_readBits - 12);
 }
 
 extern "C" float analogReadTemp() {
@@ -152,4 +153,11 @@ extern "C" float analogReadTemp() {
     adc_set_temp_sensor_enabled(false);
     float t = 27.0f - ((v * 3.3f / 4096.0f) - 0.706f) / 0.001721f; // From the datasheet
     return t;
+}
+
+extern "C" void analogReadResolution(int bits) {
+    CoreMutex m(&_adcMutex);
+    if (m && ((bits > 0) && (bits < 32))) {
+        _readBits = bits;
+    }
 }


### PR DESCRIPTION
Most other boards and the MBED RP2040 support analogReadResolution which
just shifts read data around as needed, with a default of only 10b of
resolution.  The Pico ADC technically supports 12b, but only has about
8b of real data after noise, so you're not really losing anything in the
general case.

Fixes #460