### PR TITLE
Remove timeout for SerialUART/SerialPIO::read/peek

### DIFF
--- a/cores/rp2040/SerialPIO.cpp
+++ b/cores/rp2040/SerialPIO.cpp
@@ -258,16 +258,10 @@ int SerialPIO::peek() {
         return -1;
     }
     // If there's something in the FIFO now, just peek at it
-    uint32_t start = millis();
-    uint32_t now = millis();
-    while ((now - start) < _timeout) {
-        if (_writer != _reader) {
-            return _queue[_reader];
-        }
-        delay(1);
-        now = millis();
+    if (_writer != _reader) {
+        return _queue[_reader];
     }
-    return -1; // Nothing available before timeout
+    return -1;
 }
 
 int SerialPIO::read() {
@@ -275,18 +269,12 @@ int SerialPIO::read() {
     if (!_running || !m || (_rx == NOPIN)) {
         return -1;
     }
-    uint32_t start = millis();
-    uint32_t now = millis();
-    while ((now - start) < _timeout) {
-        if (_writer != _reader) {
-            auto ret = _queue[_reader];
-            _reader = (_reader + 1) % _fifosize;
-            return ret;
-        }
-        delay(1);
-        now = millis();
+    if (_writer != _reader) {
+        auto ret = _queue[_reader];
+        _reader = (_reader + 1) % _fifosize;
+        return ret;
     }
-    return -1; // Timeout
+    return -1;
 }
 
 int SerialPIO::available() {

--- a/cores/rp2040/SerialUART.cpp
+++ b/cores/rp2040/SerialUART.cpp
@@ -158,16 +158,10 @@ int SerialUART::peek() {
     if (!_running || !m) {
         return -1;
     }
-    uint32_t start = millis();
-    uint32_t now = millis();
-    while ((now - start) < _timeout) {
-        if (_writer != _reader) {
-            return _queue[_reader];
-        }
-        delay(1);
-        now = millis();
+    if (_writer != _reader) {
+        return _queue[_reader];
     }
-    return -1; // Nothing available before timeout
+    return -1;
 }
 
 int SerialUART::read() {
@@ -175,18 +169,12 @@ int SerialUART::read() {
     if (!_running || !m) {
         return -1;
     }
-    uint32_t start = millis();
-    uint32_t now = millis();
-    while ((now - start) < _timeout) {
-        if (_writer != _reader) {
-            auto ret = _queue[_reader];
-            _reader = (_reader + 1) % _fifoSize;
-            return ret;
-        }
-        delay(1);
-        now = millis();
+    if (_writer != _reader) {
+        auto ret = _queue[_reader];
+        _reader = (_reader + 1) % _fifoSize;
+        return ret;
     }
-    return -1; // Timeout
+    return -1;
 }
 
 int SerialUART::available() {


### PR DESCRIPTION
Fixes #464 and other incompatibilities

Remove the timeout check from ::read and ::peek on the SerialUART/PIO
classes  (SerialUSB already ignores it).  See documentation
https://www.arduino.cc/reference/en/language/functions/communication/serial/settimeout/
and thanks to @jandrassy's explanation
https://github.com/earlephilhower/arduino-pico/issues/464#issuecomment-1031657044