### PR TITLE
Add retries for serial port init. Change order of tests to favor /run…

### DIFF
--- a/tools/uf2conv.py
+++ b/tools/uf2conv.py
@@ -317,23 +317,17 @@ def main():
 
     if args.serial:
         if str(args.serial).startswith("/dev/tty") or str(args.serial).startswith("COM") or str(args.serial).startswith("/dev/cu"):
-            print("Entering serial port reset")
-            for tries in range(5):
+            try:
+                print("Resetting " + str(args.serial))
                 try:
-                    print("Resetting " + str(args.serial) + " try " + str(tries))
-                    try:
-                        ser = serial.Serial(args.serial, 1200)
-                        ser.dtr = False
-                        print("Reset succeeded. Sleeping 10s")
-                        time.sleep(10)
-                        break
-                    except:
-                        print("Caught exception during reset!")
-                    # Probably should be smart and check for device appearance or something
-                    print("Sleeping 30 seconds")
-                    time.sleep(30)
+                    ser = serial.Serial(args.serial, 1200)
+                    ser.dtr = False
                 except:
-                    pass
+                    print("Caught exception during reset!")
+                # Probably should be smart and check for device appearance or something
+                time.sleep(10)
+            except:
+                pass
     if args.list:
         list_drives()
     else:


### PR DESCRIPTION
This PR implements 3 changes:

1) Favor /run/media over /media. My OpenSUSE box has both paths but udiskctl uses /run/media. This is what actually kept it form working on OpenSUSE 15.3.
2) Add retries for serial port init. This seems to make things a little more robust.
3) The udiskctl was mounting the volume and then trying to find it. I was having trouble here and saw that it prints the mount point, so added a regex to find the path. If the regex doesn't match,it falls back to the old behavior of searching for the mount point.