### PR TITLE
Fix SerialPIO receive interrupt on PIO1

### DIFF
--- a/cores/rp2040/SerialPIO.cpp
+++ b/cores/rp2040/SerialPIO.cpp
@@ -238,8 +238,9 @@ void SerialPIO::begin(unsigned long baud, uint16_t config) {
         case 2: pio_set_irq0_source_enabled(_rxPIO, pis_sm2_rx_fifo_not_empty, true); break;
         case 3: pio_set_irq0_source_enabled(_rxPIO, pis_sm3_rx_fifo_not_empty, true); break;
         }
-        irq_set_exclusive_handler(PIO0_IRQ_0, _fifoIRQ);
-        irq_set_enabled(PIO0_IRQ_0, true);
+        auto irqno = pio_get_index(_rxPIO) == 0 ? PIO0_IRQ_0 : PIO1_IRQ_0;
+        irq_set_exclusive_handler(irqno, _fifoIRQ);
+        irq_set_enabled(irqno, true);
 
         pio_sm_set_enabled(_rxPIO, _rxSM, true);
     }


### PR DESCRIPTION
Fixes #489

Only the PIO0 IRQ handler was ever installed due to a hardcoding bug.
Attach the IRQ handler to the PIO being started instead.