### PR TITLE
PDM library: Update PIO and interrupt use

### DIFF
--- a/libraries/PDM/src/PDM.h
+++ b/libraries/PDM/src/PDM.h
@@ -58,6 +58,12 @@ private:
   int _gain;
   int _init;
 
+// Hardware peripherals used
+  uint _dmaChannel;
+  PIO _pio;
+  int _smIdx;
+  int _pgmOffset;
+
   PDMDoubleBuffer _doubleBuffer;
 
   void (*_onReceive)(void);

--- a/libraries/PDM/src/rp2040/pdm.pio
+++ b/libraries/PDM/src/rp2040/pdm.pio
@@ -26,6 +26,7 @@ static inline void pdm_pio_program_init(PIO pio, uint sm, uint offset, uint clkP
   sm_config_set_in_pins(&c, dataPin);
   sm_config_set_sideset_pins(&c, clkPin);
   sm_config_set_clkdiv(&c, clkDiv);
+  sm_config_set_fifo_join(&c, PIO_FIFO_JOIN_RX);
 
   pio_sm_set_consecutive_pindirs(pio, sm, dataPin, 1, false);
   pio_sm_set_consecutive_pindirs(pio, sm, clkPin, 1, true);

--- a/libraries/PDM/src/rp2040/pdm.pio.h
+++ b/libraries/PDM/src/rp2040/pdm.pio.h
@@ -43,6 +43,7 @@ static inline void pdm_pio_program_init(PIO pio, uint sm, uint offset, uint clkP
   sm_config_set_in_pins(&c, dataPin);
   sm_config_set_sideset_pins(&c, clkPin);
   sm_config_set_clkdiv(&c, clkDiv);
+  sm_config_set_fifo_join(&c, PIO_FIFO_JOIN_RX);
   pio_sm_set_consecutive_pindirs(pio, sm, dataPin, 1, false);
   pio_sm_set_consecutive_pindirs(pio, sm, clkPin, 1, true);
   pio_sm_set_pins_with_mask(pio, sm, 0, (1u << clkPin) );


### PR DESCRIPTION
The PIO and state machine were hard wired as PIO 0 and SM 0, so this caused problems if they were not free. The approach used by the Servo library has been adopted to search for a free PIO and SM.

The DMA_IRQ_0 was grabbed exclusively, but this conflicts with the use with SPI DMA. The interrupt is now shared, but has been allocated the highest possible priority.