### PR TITLE
udisks v2.9.0 dropped the trailing period for "udisksctl mount".

### DIFF
--- a/tools/uf2conv.py
+++ b/tools/uf2conv.py
@@ -380,7 +380,7 @@ def main():
                         proc_out = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                         if proc_out.returncode == 0:
                             stdoutput = proc_out.stdout.decode("UTF-8")
-                            match = re.search(r'Mounted\s+.*\s+at\s+([^\.]*)', stdoutput)
+                            match = re.search(r'Mounted\s+.*\s+at\s+([^\.\r\n]*)', stdoutput)
                             if match is None:
                                 print("Warn: {} did not print mount point. Attempting to locate mounted drive in file system. StdOut={}".format(cmd[0], stdoutput))
                                 drives = get_drives()


### PR DESCRIPTION
udisks >= 2.9.0 dropped the period at the end.  Adjust regex to look a period or newline.

Fixes: #515
Upstream reference: https://github.com/storaged-project/udisks/commit/6842123525966ad5fd5dfa5eccef43c3ea985c21