### PR TITLE
Add SoftwareSerial wrapper around SerialPIO

### DIFF
--- a/cores/rp2040/SoftwareSerial.h
+++ b/cores/rp2040/SoftwareSerial.h
@@ -1,0 +1,35 @@
+/*
+    SoftwareSerial wrapper for SerialPIO
+
+    Copyright (c) 2022 Earle F. Philhower, III <earlephilhower@yahoo.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#pragma once
+
+#include "SerialPIO.h"
+
+class SoftwareSerial : public SerialPIO {
+public:
+    // Note the rx/tx pins are swapped in PIO vs SWSerial
+    SoftwareSerial(pin_size_t rx, pin_size_t tx, bool invert = true) : SerialPIO(tx, rx) {
+        if (invert) {
+            panic("SoftwareSerial inverted operation not supported\n");
+        }
+    }
+    void listen() { /* noop */ }
+    bool isListening() { return true; }
+};

--- a/cores/rp2040/SoftwareSerial.h
+++ b/cores/rp2040/SoftwareSerial.h
@@ -31,5 +31,7 @@ public:
         }
     }
     void listen() { /* noop */ }
-    bool isListening() { return true; }
+    bool isListening() {
+        return true;
+    }
 };

--- a/docs/piouart.rst
+++ b/docs/piouart.rst
@@ -21,3 +21,13 @@ For example, to make a transmit-only port on GP16
 
 For detailed information about the Serial ports, see the
 Arduino `Serial Reference <https://www.arduino.cc/reference/en/language/functions/communication/serial/>`_ .
+
+
+SoftwareSerial Emulation
+========================
+A ``SoftwareSerial`` wrapper is included to provide plug-and-play compatibility
+with the Arduino `Software Serial <https://docs.arduino.cc/learn/built-in-libraries/software-serial>`_
+library.  Use the normal ``#include <SoftwareSerial.h>`` to include it.   The following
+differences from the Arduino standard are present:
+* Inverted mode is not supported
+* All ports are always listening.  The ``listen`` call is a no-op, and ``isListening()`` always returns ``true`` .


### PR DESCRIPTION
I receive mails weekly asking how to use `SoftwareSerial` on this core.
Avoid the issue by including a simple wrapper class around `SerialPIO`
which gives the proper class name and constructor parameters.

Note that inverted mode is not supported.