### PR TITLE
Update SimpleTone.ino

### DIFF
--- a/libraries/I2S/examples/SimpleTone/SimpleTone.ino
+++ b/libraries/I2S/examples/SimpleTone/SimpleTone.ino
@@ -8,7 +8,7 @@
   modified for ESP8266 by Earle F. Philhower, III <earlephilhower@yahoo.com>
 
 
-Only 16 bitsPerSample are allowed by the PIO code.  Only write, no read.
+  Only 16 bitsPerSample are allowed by the PIO code.  Only write, no read.
 
     bool setBCLK(pin_size_t pin);	// Must be 28 or less.  Default is 26
 	// This assigns two adjacent pins - the pin after this one (one greater) is the WS (word select) signal,

--- a/libraries/I2S/examples/SimpleTone/SimpleTone.ino
+++ b/libraries/I2S/examples/SimpleTone/SimpleTone.ino
@@ -11,7 +11,7 @@
 Only 16 bitsPerSample are allowed by the PIO code.  Only write, no read.
 
     bool setBCLK(pin_size_t pin);	// Must be 28 or less.  Default is 26
-	// This assigns two adjacent pins - the pin after this one (one greater) is the WS (word select) signal, 
+	// This assigns two adjacent pins - the pin after this one (one greater) is the WS (word select) signal,
 	// which toggles before the sample for each channel is sent
 
     bool setDOUT(pin_size_t pin);	// Must be 29 or less.  Default is 28
@@ -43,12 +43,12 @@ int count = 0;
 void setup() {
   pinMode(LED_BUILTIN, OUTPUT);
   digitalWrite(LED_BUILTIN, 1);
-  
+
   Serial.begin(9600);
   Serial.println("I2S simple tone");
 
   I2S.setBCLK(pBCLK);  // Must be 28 or less.  Default is 26
-  // This assigns two adjacent pins - the pin after this one (one greater) is the WS (word select) signal, 
+  // This assigns two adjacent pins - the pin after this one (one greater) is the WS (word select) signal,
   // which toggles before the sample for each channel is sent
 
   I2S.setDOUT(pDOUT); // Must be 29 or less.  Default is 28
@@ -57,7 +57,7 @@ void setup() {
   if (!I2S.begin(sampleRate)) {
     Serial.println("Failed to initialize I2S!");
     while (1); // do nothing
-   }
+  }
 
 }
 

--- a/libraries/I2S/examples/SimpleTone/SimpleTone.ino
+++ b/libraries/I2S/examples/SimpleTone/SimpleTone.ino
@@ -6,28 +6,59 @@
   created 17 November 2016
   by Sandeep Mistry
   modified for ESP8266 by Earle F. Philhower, III <earlephilhower@yahoo.com>
+
+
+Only 16 bitsPerSample are allowed by the PIO code.  Only write, no read.
+
+    bool setBCLK(pin_size_t pin);	// Must be 28 or less.  Default is 26
+	// This assigns two adjacent pins - the pin after this one (one greater) is the WS (word select) signal, 
+	// which toggles before the sample for each channel is sent
+
+    bool setDOUT(pin_size_t pin);	// Must be 29 or less.  Default is 28
+
+
 */
 
 #include <I2S.h>
 
+// GPIO pin numbers
+
+//define pBCLK 26
+#define pBCLK 20
+#define pWS (pBCLK+1)
+//define pDOUT 28
+#define pDOUT 22
+
 const int frequency = 440; // frequency of square wave in Hz
 const int amplitude = 500; // amplitude of square wave
-const int sampleRate = 8000; // sample rate in Hz
+//const int sampleRate = 8000; // sample rate in Hz
+const int sampleRate = 16000; // minimum for UDA1334A
 
 const int halfWavelength = (sampleRate / frequency); // half wavelength of square wave
 
 short sample = amplitude; // current sample value
 int count = 0;
 
+
 void setup() {
-  Serial.begin(115200);
+  pinMode(LED_BUILTIN, OUTPUT);
+  digitalWrite(LED_BUILTIN, 1);
+  
+  Serial.begin(9600);
   Serial.println("I2S simple tone");
+
+  I2S.setBCLK(pBCLK);  // Must be 28 or less.  Default is 26
+  // This assigns two adjacent pins - the pin after this one (one greater) is the WS (word select) signal, 
+  // which toggles before the sample for each channel is sent
+
+  I2S.setDOUT(pDOUT); // Must be 29 or less.  Default is 28
 
   // start I2S at the sample rate with 16-bits per sample
   if (!I2S.begin(sampleRate)) {
     Serial.println("Failed to initialize I2S!");
     while (1); // do nothing
-  }
+   }
+
 }
 
 void loop() {
@@ -43,4 +74,3 @@ void loop() {
   // increment the counter for the next sample
   count++;
 }
-


### PR DESCRIPTION
Adds code to define which pins are used, moving them from the defaults, which are the same as the only three analogue input pins, and adding comments to explain how to change them.

The original didn't give any clues about which pins were used, which isn't ideal for a beginner - it was necessary to look at the code for the library, to work that out.

The new code redundantly defines a pWS pin number (as pBCLK+1), which isn't used in the example, but is meant as a reminder to the person using it, of how to wire up WS.