### PR TITLE
Additional FreeRTOS adjustments

### DIFF
--- a/libraries/FreeRTOS/src/FreeRTOSConfig.h
+++ b/libraries/FreeRTOS/src/FreeRTOSConfig.h
@@ -113,7 +113,7 @@ command interpreter running. */
 #define configCOMMAND_INT_MAX_OUTPUT_SIZE 2048
 
 
-#define configUSE_DYNAMIC_EXCEPTION_HANDLERS 1
+#define configUSE_DYNAMIC_EXCEPTION_HANDLERS 0
 #define configSUPPORT_PICO_SYNC_INTEROP 1
 #define configSUPPORT_PICO_TIME_INTEROP 1
 

--- a/libraries/FreeRTOS/src/port.c
+++ b/libraries/FreeRTOS/src/port.c
@@ -1,1 +1,4 @@
+// Port.c seems to leave interrupts disabled occasionally when built w/anything other than -O0
+
+#pragma GCC optimize ("O0")
 #include "../lib/FreeRTOS-Kernel/portable/ThirdParty/GCC/RP2040/port.c"

--- a/libraries/FreeRTOS/src/variantHooks.cpp
+++ b/libraries/FreeRTOS/src/variantHooks.cpp
@@ -163,7 +163,7 @@ void vApplicationIdleHook( void ) __attribute__((weak));
 
 void vApplicationIdleHook( void )
 {
-    //__wfe(); // Low power idle if nothing to do...
+    __wfe(); // Low power idle if nothing to do...
 }
 
 #endif /* configUSE_IDLE_HOOK == 1 */


### PR DESCRIPTION
Use low power WFE when idle.

Set PORT.C to built `-O0` always because it seems to occasinally end
up with interrupts disabled in task code, causing the SYSTICK never to
fire and killing task switching.

No need for dynamic exceptions.  We don't move the execbase.