### PR TITLE
Fix memory corruption introducted in FreeRTOS port

### DIFF
--- a/libraries/FreeRTOS/src/port.c
+++ b/libraries/FreeRTOS/src/port.c
@@ -1,4 +1,1 @@
-// Port.c seems to leave interrupts disabled occasionally when built w/anything other than -O0
-
-#pragma GCC optimize ("O0")
 #include "../lib/FreeRTOS-Kernel/portable/ThirdParty/GCC/RP2040/port.c"


### PR DESCRIPTION
To remove compiler warning the valid core macro was modified to only check
that the core passed in was < # of total cores.  Unfortunately there are
parts of the FreeRTOS code where the passed in core # is -1.  The upstream
catches this and returns FALSE, but my hacked version returned TRUE.  This
caused interesting memory corruption errors and crashes when the
current task block[-1] was updated.

Undo the change and fix the 1 spot where a warning happens instead.

Undo the forced compiler -O0 for port.c, it was only masking the fault.