### PR TITLE
Fix Wire I2C restart handling

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -149,7 +149,7 @@ void TwoWire::onIRQ() {
         _buffLen = 0;
         _buffOff = 0;
         _slaveStartDet = false;
-        _i2c->hw->clr_reset_det;
+        _i2c->hw->clr_restart_det;
     }
     if (_i2c->hw->intr_stat & (1 << 10)) {
         _buffLen = 0;


### PR DESCRIPTION
Fixes #585

On an I2C bus restart, call the onReceive callback and clear the buffer.

Thanks to @DWiskow for the debug and patch!