### PR TITLE
Fix IDE include paths / Intellisense

### DIFF
--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -37,7 +37,7 @@ for l in file_lines:
     path = l.strip().replace("-iwithprefixbefore/", "").replace("/", os.sep)
     # emulate -iprefix <framework path>.
     path = os.path.join(FRAMEWORK_DIR, path)
-    # prevent non-existant paths from being added
+    # prevent non-existent paths from being added
     # looking at you here, pico-extras/src/common/pico_audio and co.
     if os.path.isdir(path):
         includes.append(path)


### PR DESCRIPTION
The Arduino IDE / `platform.txt` builds this core by using a `-iprefix <framework path>` directive followed by the file in https://github.com/earlephilhower/arduino-pico/blob/master/lib/platform_inc.txt.

This however causes problems in PlatformIO because for the Intellisense of IDEs, since only what is in `env["CPPPATH"]` is exported as to be searched include path for headers is exported by PlatformIO. It's not smart enough to scan the compiler invocations for `iprefix` etc lines and reconstruct the paths from that for the IDE.

This restructures the build script to read the contents of the `platform_inc.txt` file, reconstruct the full path and then add them to `env["CPPPATH"]`. This fixes IntelliSense issues on Mac and Linux. Most interestingly, this did not affect Windows intellisense.

See https://github.com/platformio/platform-raspberrypi/pull/36#issuecomment-1151630439.

The compilation should be **equivalent** (`-I<paths>` vs `iprefix` + `-iwithprefixbefore`) and still works for me. I also read the same [in the documentation](https://gcc.gnu.org/onlinedocs/gcc/Directory-Options.html).

Note: Mac users also complain that this core doesn't play nice with Arduino IDE 2 intellisense, very likely because of this very reason, it can't figure out the exact include paths. This could be looked into as a separate issue.

Before:

![grafik](https://user-images.githubusercontent.com/26485477/172954151-f76138e1-af82-4d12-a581-566dc8e9fe7b.png)


After:

![grafik](https://user-images.githubusercontent.com/26485477/172954060-4e059f8d-ef15-4de2-8b50-0e75b5977409.png)
