### PR TITLE
Hide get.py download percent when not interactive

### DIFF
--- a/tests/common.sh
+++ b/tests/common.sh
@@ -212,7 +212,7 @@ function install_ide()
     cat rp2040/platform.local.txt
     echo -e "\n----\n"
     cd rp2040/tools
-    python3 get.py -q
+    python3 get.py
     if [ "$WINDOWS" = "1" ]; then
         # Because the symlinks don't work well under Win32, we need to add the path to this copy, not the original...
         relbin=$(realpath $PWD/../system/arm-none-eabi/bin)

--- a/tools/get.py
+++ b/tools/get.py
@@ -15,8 +15,6 @@ import tarfile
 import zipfile
 import re
 
-verbose = True
-
 if sys.version_info[0] == 3:
     from urllib.request import urlretrieve
 else:
@@ -40,8 +38,7 @@ def mkdir_p(path):
             raise
 
 def report_progress(count, blockSize, totalSize):
-    global verbose
-    if verbose:
+    if sys.stdout.isatty():
         percent = int(count*blockSize*100/totalSize)
         percent = min(100, percent)
         sys.stdout.write("\r%d%%" % percent)
@@ -121,14 +118,6 @@ def identify_platform():
     return arduino_platform_names[sys_name][bits]
 
 def main():
-    global verbose
-    # Support optional "-q" quiet mode simply
-    if len(sys.argv) == 2:
-        if sys.argv[1] == "-q":
-            verbose = False
-    # Remove a symlink generated in 2.6.3 which causes later issues since the tarball can't properly overwrite it
-    if (os.path.exists('python3/python3')):
-        os.unlink('python3/python3')
     print('Platform: {0}'.format(identify_platform()))
     tools_to_download = load_tools_list('../package/package_pico_index.template.json', identify_platform())
     mkdir_p(dist_dir)


### PR DESCRIPTION
When get.py is run in a script the percent-update printouts shown while
downloading the toolchain end up as 100s to 1000s of lines in log files.

When stdout is not a terminal, avoid printing these percentages and
shrink logfiles significantly. Errors/etc. are still reported as normal.