### PR TITLE
Activate default -Os optimization

### DIFF
--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -51,6 +51,7 @@ env.Append(
     ASFLAGS=env.get("CCFLAGS", [])[:],
 
     CCFLAGS=[
+        "-Os", # Optimize for size by default
         "-Werror=return-type",
         "-march=armv6-m",
         "-mcpu=cortex-m0plus",


### PR DESCRIPTION
Very simple addition: Build with `-Os` by default Other builder scripts [do the same](https://github.com/stm32duino/Arduino_Core_STM32/blob/main/tools/platformio/platformio-build.py#L229-L230).

This is as always overridable with e.g.
```ini
build_unflags = -Os
build_flags = -O2
```

Needed for multicore and / or race-free malloc/free to work, see https://github.com/maxgerhardt/platform-raspberrypi/issues/7#issuecomment-1152519265