### PR TITLE
Update PlatformIO board files, add PIO CI

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -181,9 +181,12 @@ jobs:
 
 # Build a few examples with PlatformIO to test if integration works
   build-platformio:
+    name: Build PlatformIO Examples
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
+    - with:
+        submodules: 'recursive'
     - name: Cache pip
       uses: actions/cache@v2
       with:
@@ -205,6 +208,6 @@ jobs:
         pio pkg install --global --platform https://github.com/maxgerhardt/platform-raspberrypi.git
         pio pkg install --global --tool symlink://.
     - name: Build Multicore Example
-      run: pio ci --board=rpipico --board=adafruit_feather libraries/rp2040/examples/Multicore/Multicore.ino
+      run: pio ci --board=rpipico --board=adafruit_feather -O "platform_packages=framework-arduinopico@symlink:///home/runner/work/arduino-pico/arduino-pico" libraries/rp2040/examples/Multicore/Multicore.ino
     - name: Build Fade Example
-      run: pio ci --board=rpipico --board=adafruit_feather libraries/rp2040/examples/Fade/Fade.ino
+      run: pio ci --board=rpipico --board=adafruit_feather -O "platform_packages=framework-arduinopico@symlink:///home/runner/work/arduino-pico/arduino-pico" libraries/rp2040/examples/Fade/Fade.ino

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -179,7 +179,7 @@ jobs:
         cd ..
         bash ./tests/build.sh
 
-# Build a few examples with PlatformIO to test if integration still works
+# Build a few examples with PlatformIO to test if integration works
   build-platformio:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,7 +5,6 @@ name: Arduino-Pico CI
 
 on:
   pull_request:
-  push:
 
 
 jobs:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -186,7 +186,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
       with:
-        submodules: true
+        submodules: 'recursive'
     - name: Cache pip
       uses: actions/cache@v2
       with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -184,9 +184,9 @@ jobs:
     name: Build PlatformIO Examples
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v2
       with:
-        submodules: 'recursive'
+        submodules: true
     - name: Cache pip
       uses: actions/cache@v2
       with:
@@ -208,6 +208,8 @@ jobs:
         pio pkg install --global --platform https://github.com/maxgerhardt/platform-raspberrypi.git
         pio pkg install --global --tool symlink://.
     - name: Build Multicore Example
-      run: pio ci -v --board=rpipico --board=adafruit_feather -O "platform_packages=framework-arduinopico@symlink:///home/runner/work/arduino-pico/arduino-pico" libraries/rp2040/examples/Multicore/Multicore.ino
+      run: pio ci --board=rpipico --board=adafruit_feather -O "platform_packages=framework-arduinopico@symlink:///home/runner/work/arduino-pico/arduino-pico" libraries/rp2040/examples/Multicore/Multicore.ino
     - name: Build Fade Example
-      run: pio ci -v --board=rpipico --board=adafruit_feather -O "platform_packages=framework-arduinopico@symlink:///home/runner/work/arduino-pico/arduino-pico" libraries/rp2040/examples/Fade/Fade.ino
+      run: pio ci --board=rpipico --board=adafruit_feather -O "platform_packages=framework-arduinopico@symlink:///home/runner/work/arduino-pico/arduino-pico" libraries/rp2040/examples/Fade/Fade.ino
+    - name: Build TinyUSB Example
+      run: pio ci --board=rpipico --board=adafruit_feather -O "platform_packages=framework-arduinopico@symlink:///home/runner/work/arduino-pico/arduino-pico" -O "build_flags=-DUSE_TINYUSB" libraries/rp2040/examples/Adafruit_TinyUSB_Arduino/examples/CDC/cdc_multi/cdc_multi.ino

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -15,7 +15,7 @@ jobs:
     name: Check spelling
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
     - name: Run codespell
@@ -29,7 +29,7 @@ jobs:
     name: Style, Boards, Package
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: false
     - name: Check package references
@@ -60,7 +60,7 @@ jobs:
       matrix:
         chunk: [0, 1, 2, 3]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
     - uses: actions/setup-python@v2
@@ -90,7 +90,7 @@ jobs:
     name: Build TinyUSB Examples
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
     - uses: actions/setup-python@v2
@@ -118,7 +118,7 @@ jobs:
     name: Windows
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
     - uses: actions/setup-python@v2
@@ -153,7 +153,7 @@ jobs:
     name: Mac
     runs-on: macOS-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
     - uses: actions/setup-python@v2
@@ -184,7 +184,7 @@ jobs:
     name: Build PlatformIO Examples
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: 'recursive'
     - name: Cache pip
@@ -212,4 +212,4 @@ jobs:
     - name: Build Fade Example
       run: pio ci --board=rpipico --board=adafruit_feather -O "platform_packages=framework-arduinopico@symlink:///home/runner/work/arduino-pico/arduino-pico" libraries/rp2040/examples/Fade/Fade.ino
     - name: Build TinyUSB Example
-      run: pio ci --board=rpipico --board=adafruit_feather -O "platform_packages=framework-arduinopico@symlink:///home/runner/work/arduino-pico/arduino-pico" -O "build_flags=-DUSE_TINYUSB" -O "lib_deps=symlink:///home/runner/work/arduino-pico/arduino-pico/libraries/Adafruit_TinyUSB_Arduino" libraries/rp2040/examples/Adafruit_TinyUSB_Arduino/examples/CDC/cdc_multi/cdc_multi.ino
+      run: pio ci --board=rpipico --board=adafruit_feather -O "platform_packages=framework-arduinopico@symlink:///home/runner/work/arduino-pico/arduino-pico" -O "build_flags=-DUSE_TINYUSB" libraries/Adafruit_TinyUSB_Arduino/examples/CDC/cdc_multi/cdc_multi.ino

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -212,4 +212,4 @@ jobs:
     - name: Build Fade Example
       run: pio ci --board=rpipico --board=adafruit_feather -O "platform_packages=framework-arduinopico@symlink:///home/runner/work/arduino-pico/arduino-pico" libraries/rp2040/examples/Fade/Fade.ino
     - name: Build TinyUSB Example
-      run: pio ci --board=rpipico --board=adafruit_feather -O "platform_packages=framework-arduinopico@symlink:///home/runner/work/arduino-pico/arduino-pico" -O "build_flags=-DUSE_TINYUSB" libraries/rp2040/examples/Adafruit_TinyUSB_Arduino/examples/CDC/cdc_multi/cdc_multi.ino
+      run: pio ci --board=rpipico --board=adafruit_feather -O "platform_packages=framework-arduinopico@symlink:///home/runner/work/arduino-pico/arduino-pico" -O "build_flags=-DUSE_TINYUSB" -O "lib_deps=symlink:///home/runner/work/arduino-pico/arduino-pico/libraries/Adafruit_TinyUSB_Arduino" libraries/rp2040/examples/Adafruit_TinyUSB_Arduino/examples/CDC/cdc_multi/cdc_multi.ino

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -185,7 +185,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - with:
+      with:
         submodules: 'recursive'
     - name: Cache pip
       uses: actions/cache@v2

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -208,6 +208,6 @@ jobs:
         pio pkg install --global --platform https://github.com/maxgerhardt/platform-raspberrypi.git
         pio pkg install --global --tool symlink://.
     - name: Build Multicore Example
-      run: pio ci --board=rpipico --board=adafruit_feather -O "platform_packages=framework-arduinopico@symlink:///home/runner/work/arduino-pico/arduino-pico" libraries/rp2040/examples/Multicore/Multicore.ino
+      run: pio ci -v --board=rpipico --board=adafruit_feather -O "platform_packages=framework-arduinopico@symlink:///home/runner/work/arduino-pico/arduino-pico" libraries/rp2040/examples/Multicore/Multicore.ino
     - name: Build Fade Example
-      run: pio ci --board=rpipico --board=adafruit_feather -O "platform_packages=framework-arduinopico@symlink:///home/runner/work/arduino-pico/arduino-pico" libraries/rp2040/examples/Fade/Fade.ino
+      run: pio ci -v --board=rpipico --board=adafruit_feather -O "platform_packages=framework-arduinopico@symlink:///home/runner/work/arduino-pico/arduino-pico" libraries/rp2040/examples/Fade/Fade.ino

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,6 +5,7 @@ name: Arduino-Pico CI
 
 on:
   pull_request:
+  push:
 
 
 jobs:
@@ -178,3 +179,32 @@ jobs:
         cd ..
         bash ./tests/build.sh
 
+# Build a few examples with PlatformIO to test if integration still works
+  build-platformio:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Cache pip
+      uses: actions/cache@v2
+      with:
+        path: ~/.cache/pip
+        key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements.txt') }}
+        restore-keys: |
+          ${{ runner.os }}-pip-
+    - name: Cache PlatformIO
+      uses: actions/cache@v2
+      with:
+        path: ~/.platformio
+        key: ${{ runner.os }}-${{ hashFiles('**/lockfiles') }}
+    - name: Set up Python
+      uses: actions/setup-python@v2
+    - name: Install PlatformIO
+      run: |
+        python -m pip install --upgrade pip
+        pip install --upgrade platformio
+        pio pkg install --global --platform https://github.com/maxgerhardt/platform-raspberrypi.git
+        pio pkg install --global --tool symlink://.
+    - name: Build Multicore Example
+      run: pio ci --board=rpipico --board=adafruit_feather libraries/rp2040/examples/Multicore/Multicore.ino
+    - name: Build Fade Example
+      run: pio ci --board=rpipico --board=adafruit_feather libraries/rp2040/examples/Fade/Fade.ino

--- a/tools/json/adafruit_feather.json
+++ b/tools/json/adafruit_feather.json
@@ -1,5 +1,12 @@
 {
   "build": {
+    "arduino": {
+      "earlephilhower": {
+        "boot2_source": "boot2_w25x10cl_4_padded_checksum.S",
+        "usb_vid": "0x239a",
+        "usb_pid": "0x80f1"
+      }
+    },
     "core": "earlephilhower",
     "cpu": "cortex-m0plus",
     "extra_flags": "-D ARDUINO_ADAFRUIT_FEATHER_RP2040 -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=250",
@@ -11,14 +18,7 @@
       ]
     ],
     "mcu": "rp2040",
-    "variant": "adafruit_feather",
-    "arduino": {
-      "earlephilhower": {
-        "boot2_source": "boot2_w25x10cl_4_padded_checksum.S",
-        "usb_vid": "0x239a",
-        "usb_pid": "0x80f1"
-      }
-    }
+    "variant": "adafruit_feather"
   },
   "debug": {
     "jlink_device": "RP2040_M0_0",

--- a/tools/json/adafruit_itsybitsy.json
+++ b/tools/json/adafruit_itsybitsy.json
@@ -1,5 +1,12 @@
 {
   "build": {
+    "arduino": {
+      "earlephilhower": {
+        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
+        "usb_vid": "0x239a",
+        "usb_pid": "0x80fd"
+      }
+    },
     "core": "earlephilhower",
     "cpu": "cortex-m0plus",
     "extra_flags": "-D ARDUINO_ADAFRUIT_ITSYBITSY_RP2040 -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=250",
@@ -11,14 +18,7 @@
       ]
     ],
     "mcu": "rp2040",
-    "variant": "adafruit_itsybitsy",
-    "arduino": {
-      "earlephilhower": {
-        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
-        "usb_vid": "0x239a",
-        "usb_pid": "0x80fd"
-      }
-    }
+    "variant": "adafruit_itsybitsy"
   },
   "debug": {
     "jlink_device": "RP2040_M0_0",

--- a/tools/json/adafruit_kb2040.json
+++ b/tools/json/adafruit_kb2040.json
@@ -1,5 +1,12 @@
 {
   "build": {
+    "arduino": {
+      "earlephilhower": {
+        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
+        "usb_vid": "0x239a",
+        "usb_pid": "0x8105"
+      }
+    },
     "core": "earlephilhower",
     "cpu": "cortex-m0plus",
     "extra_flags": "-D ARDUINO_ADAFRUIT_KB2040_RP2040 -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=250",
@@ -11,14 +18,7 @@
       ]
     ],
     "mcu": "rp2040",
-    "variant": "adafruit_kb2040",
-    "arduino": {
-      "earlephilhower": {
-        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
-        "usb_vid": "0x239a",
-        "usb_pid": "0x8105"
-      }
-    }
+    "variant": "adafruit_kb2040"
   },
   "debug": {
     "jlink_device": "RP2040_M0_0",

--- a/tools/json/adafruit_macropad2040.json
+++ b/tools/json/adafruit_macropad2040.json
@@ -1,5 +1,12 @@
 {
   "build": {
+    "arduino": {
+      "earlephilhower": {
+        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
+        "usb_vid": "0x239a",
+        "usb_pid": "0x8107"
+      }
+    },
     "core": "earlephilhower",
     "cpu": "cortex-m0plus",
     "extra_flags": "-D ARDUINO_ADAFRUIT_MACROPAD_RP2040 -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=250",
@@ -11,14 +18,7 @@
       ]
     ],
     "mcu": "rp2040",
-    "variant": "adafruit_macropad2040",
-    "arduino": {
-      "earlephilhower": {
-        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
-        "usb_vid": "0x239a",
-        "usb_pid": "0x8107"
-      }
-    }
+    "variant": "adafruit_macropad2040"
   },
   "debug": {
     "jlink_device": "RP2040_M0_0",

--- a/tools/json/adafruit_qtpy.json
+++ b/tools/json/adafruit_qtpy.json
@@ -1,5 +1,12 @@
 {
   "build": {
+    "arduino": {
+      "earlephilhower": {
+        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
+        "usb_vid": "0x239a",
+        "usb_pid": "0x80f7"
+      }
+    },
     "core": "earlephilhower",
     "cpu": "cortex-m0plus",
     "extra_flags": "-D ARDUINO_ADAFRUIT_QTPY_RP2040 -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=250",
@@ -11,14 +18,7 @@
       ]
     ],
     "mcu": "rp2040",
-    "variant": "adafruit_qtpy",
-    "arduino": {
-      "earlephilhower": {
-        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
-        "usb_vid": "0x239a",
-        "usb_pid": "0x80f7"
-      }
-    }
+    "variant": "adafruit_qtpy"
   },
   "debug": {
     "jlink_device": "RP2040_M0_0",

--- a/tools/json/adafruit_stemmafriend.json
+++ b/tools/json/adafruit_stemmafriend.json
@@ -1,5 +1,12 @@
 {
   "build": {
+    "arduino": {
+      "earlephilhower": {
+        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
+        "usb_vid": "0x239a",
+        "usb_pid": "0x80e3"
+      }
+    },
     "core": "earlephilhower",
     "cpu": "cortex-m0plus",
     "extra_flags": "-D ARDUINO_ADAFRUIT_STEMMAFRIEND_RP2040 -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=250",
@@ -11,14 +18,7 @@
       ]
     ],
     "mcu": "rp2040",
-    "variant": "adafruit_stemmafriend",
-    "arduino": {
-      "earlephilhower": {
-        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
-        "usb_vid": "0x239a",
-        "usb_pid": "0x80e3"
-      }
-    }
+    "variant": "adafruit_stemmafriend"
   },
   "debug": {
     "jlink_device": "RP2040_M0_0",

--- a/tools/json/adafruit_trinkeyrp2040qt.json
+++ b/tools/json/adafruit_trinkeyrp2040qt.json
@@ -1,5 +1,12 @@
 {
   "build": {
+    "arduino": {
+      "earlephilhower": {
+        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
+        "usb_vid": "0x239a",
+        "usb_pid": "0x8109"
+      }
+    },
     "core": "earlephilhower",
     "cpu": "cortex-m0plus",
     "extra_flags": "-D ARDUINO_ADAFRUIT_TRINKEYQT_RP2040 -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=250",
@@ -11,14 +18,7 @@
       ]
     ],
     "mcu": "rp2040",
-    "variant": "adafruit_trinkeyrp2040qt",
-    "arduino": {
-      "earlephilhower": {
-        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
-        "usb_vid": "0x239a",
-        "usb_pid": "0x8109"
-      }
-    }
+    "variant": "adafruit_trinkeyrp2040qt"
   },
   "debug": {
     "jlink_device": "RP2040_M0_0",

--- a/tools/json/arduino_nano_connect.json
+++ b/tools/json/arduino_nano_connect.json
@@ -1,5 +1,12 @@
 {
   "build": {
+    "arduino": {
+      "earlephilhower": {
+        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
+        "usb_vid": "0x2341",
+        "usb_pid": "0x0058"
+      }
+    },
     "core": "earlephilhower",
     "cpu": "cortex-m0plus",
     "extra_flags": "-D ARDUINO_NANO_RP2040_CONNECT -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=250",
@@ -11,14 +18,7 @@
       ]
     ],
     "mcu": "rp2040",
-    "variant": "arduino_nano_connect",
-    "arduino": {
-      "earlephilhower": {
-        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
-        "usb_vid": "0x2341",
-        "usb_pid": "0x0058"
-      }
-    }
+    "variant": "arduino_nano_connect"
   },
   "debug": {
     "jlink_device": "RP2040_M0_0",

--- a/tools/json/challenger_2040_lora.json
+++ b/tools/json/challenger_2040_lora.json
@@ -1,5 +1,12 @@
 {
   "build": {
+    "arduino": {
+      "earlephilhower": {
+        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
+        "usb_vid": "0x2e8a",
+        "usb_pid": "0x1023"
+      }
+    },
     "core": "earlephilhower",
     "cpu": "cortex-m0plus",
     "extra_flags": "-D ARDUINO_CHALLENGER_2040_LORA_RP2040 -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=250",
@@ -11,14 +18,7 @@
       ]
     ],
     "mcu": "rp2040",
-    "variant": "challenger_2040_lora",
-    "arduino": {
-      "earlephilhower": {
-        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
-        "usb_vid": "0x2e8a",
-        "usb_pid": "0x1023"
-      }
-    }
+    "variant": "challenger_2040_lora"
   },
   "debug": {
     "jlink_device": "RP2040_M0_0",

--- a/tools/json/challenger_2040_lte.json
+++ b/tools/json/challenger_2040_lte.json
@@ -1,5 +1,12 @@
 {
   "build": {
+    "arduino": {
+      "earlephilhower": {
+        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
+        "usb_vid": "0x2e8a",
+        "usb_pid": "0x100b"
+      }
+    },
     "core": "earlephilhower",
     "cpu": "cortex-m0plus",
     "extra_flags": "-D ARDUINO_CHALLENGER_2040_LTE_RP2040 -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=500",
@@ -11,14 +18,7 @@
       ]
     ],
     "mcu": "rp2040",
-    "variant": "challenger_2040_lte",
-    "arduino": {
-      "earlephilhower": {
-        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
-        "usb_vid": "0x2e8a",
-        "usb_pid": "0x100b"
-      }
-    }
+    "variant": "challenger_2040_lte"
   },
   "debug": {
     "jlink_device": "RP2040_M0_0",

--- a/tools/json/challenger_2040_wifi.json
+++ b/tools/json/challenger_2040_wifi.json
@@ -1,5 +1,12 @@
 {
   "build": {
+    "arduino": {
+      "earlephilhower": {
+        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
+        "usb_vid": "0x2e8a",
+        "usb_pid": "0x1006"
+      }
+    },
     "core": "earlephilhower",
     "cpu": "cortex-m0plus",
     "extra_flags": "-D ARDUINO_CHALLENGER_2040_WIFI_RP2040 -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=250",
@@ -11,14 +18,7 @@
       ]
     ],
     "mcu": "rp2040",
-    "variant": "challenger_2040_wifi",
-    "arduino": {
-      "earlephilhower": {
-        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
-        "usb_vid": "0x2e8a",
-        "usb_pid": "0x1006"
-      }
-    }
+    "variant": "challenger_2040_wifi"
   },
   "debug": {
     "jlink_device": "RP2040_M0_0",

--- a/tools/json/challenger_2040_wifi_ble.json
+++ b/tools/json/challenger_2040_wifi_ble.json
@@ -1,5 +1,12 @@
 {
   "build": {
+    "arduino": {
+      "earlephilhower": {
+        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
+        "usb_vid": "0x2e8a",
+        "usb_pid": "0x102C"
+      }
+    },
     "core": "earlephilhower",
     "cpu": "cortex-m0plus",
     "extra_flags": "-D ARDUINO_CHALLENGER_2040_WIFI_BLE_RP2040 -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=500",
@@ -11,14 +18,7 @@
       ]
     ],
     "mcu": "rp2040",
-    "variant": "challenger_2040_wifi_ble",
-    "arduino": {
-      "earlephilhower": {
-        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
-        "usb_vid": "0x2e8a",
-        "usb_pid": "0x102C"
-      }
-    }
+    "variant": "challenger_2040_wifi_ble"
   },
   "debug": {
     "jlink_device": "RP2040_M0_0",

--- a/tools/json/challenger_nb_2040_wifi.json
+++ b/tools/json/challenger_nb_2040_wifi.json
@@ -1,5 +1,12 @@
 {
   "build": {
+    "arduino": {
+      "earlephilhower": {
+        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
+        "usb_vid": "0x2e8a",
+        "usb_pid": "0x100b"
+      }
+    },
     "core": "earlephilhower",
     "cpu": "cortex-m0plus",
     "extra_flags": "-D ARDUINO_CHALLENGER_NB_2040_WIFI_RP2040 -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=500",
@@ -11,14 +18,7 @@
       ]
     ],
     "mcu": "rp2040",
-    "variant": "challenger_nb_2040_wifi",
-    "arduino": {
-      "earlephilhower": {
-        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
-        "usb_vid": "0x2e8a",
-        "usb_pid": "0x100b"
-      }
-    }
+    "variant": "challenger_nb_2040_wifi"
   },
   "debug": {
     "jlink_device": "RP2040_M0_0",

--- a/tools/json/cytron_maker_nano_rp2040.json
+++ b/tools/json/cytron_maker_nano_rp2040.json
@@ -1,5 +1,12 @@
 {
   "build": {
+    "arduino": {
+      "earlephilhower": {
+        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
+        "usb_vid": "0x2e8a",
+        "usb_pid": "0x100f"
+      }
+    },
     "core": "earlephilhower",
     "cpu": "cortex-m0plus",
     "extra_flags": "-D ARDUINO_CYTRON_MAKER_NANO_RP2040 -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=250",
@@ -11,14 +18,7 @@
       ]
     ],
     "mcu": "rp2040",
-    "variant": "cytron_maker_nano_rp2040",
-    "arduino": {
-      "earlephilhower": {
-        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
-        "usb_vid": "0x2e8a",
-        "usb_pid": "0x100f"
-      }
-    }
+    "variant": "cytron_maker_nano_rp2040"
   },
   "debug": {
     "jlink_device": "RP2040_M0_0",

--- a/tools/json/cytron_maker_pi_rp2040.json
+++ b/tools/json/cytron_maker_pi_rp2040.json
@@ -1,5 +1,12 @@
 {
   "build": {
+    "arduino": {
+      "earlephilhower": {
+        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
+        "usb_vid": "0x2e8a",
+        "usb_pid": "0x1000"
+      }
+    },
     "core": "earlephilhower",
     "cpu": "cortex-m0plus",
     "extra_flags": "-D ARDUINO_CYTRON_MAKER_PI_RP2040 -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=250",
@@ -11,14 +18,7 @@
       ]
     ],
     "mcu": "rp2040",
-    "variant": "cytron_maker_pi_rp2040",
-    "arduino": {
-      "earlephilhower": {
-        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
-        "usb_vid": "0x2e8a",
-        "usb_pid": "0x1000"
-      }
-    }
+    "variant": "cytron_maker_pi_rp2040"
   },
   "debug": {
     "jlink_device": "RP2040_M0_0",

--- a/tools/json/dfrobot_beetle_rp2040.json
+++ b/tools/json/dfrobot_beetle_rp2040.json
@@ -1,5 +1,12 @@
 {
   "build": {
+    "arduino": {
+      "earlephilhower": {
+        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
+        "usb_vid": "0x3343",
+        "usb_pid": "0x4253"
+      }
+    },
     "core": "earlephilhower",
     "cpu": "cortex-m0plus",
     "extra_flags": "-D ARDUINO_DFROBOT_BEETLE_RP2040 -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=250",
@@ -11,14 +18,7 @@
       ]
     ],
     "mcu": "rp2040",
-    "variant": "dfrobot_beetle_rp2040",
-    "arduino": {
-      "earlephilhower": {
-        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
-        "usb_vid": "0x3343",
-        "usb_pid": "0x4253"
-      }
-    }
+    "variant": "dfrobot_beetle_rp2040"
   },
   "debug": {
     "jlink_device": "RP2040_M0_0",

--- a/tools/json/flyboard2040_core.json
+++ b/tools/json/flyboard2040_core.json
@@ -1,5 +1,12 @@
 {
   "build": {
+    "arduino": {
+      "earlephilhower": {
+        "boot2_source": "boot2_generic_03h_4_padded_checksum.S",
+        "usb_vid": "0x2e8a",
+        "usb_pid": "0x008a"
+      }
+    },
     "core": "earlephilhower",
     "cpu": "cortex-m0plus",
     "extra_flags": "-D ARDUINO_FLYBOARD2040_CORE -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=500",
@@ -11,14 +18,7 @@
       ]
     ],
     "mcu": "rp2040",
-    "variant": "flyboard2040_core",
-    "arduino": {
-      "earlephilhower": {
-        "boot2_source": "boot2_generic_03h_4_padded_checksum.S",
-        "usb_vid": "0x2e8a",
-        "usb_pid": "0x008a"
-      }
-    }
+    "variant": "flyboard2040_core"
   },
   "debug": {
     "jlink_device": "RP2040_M0_0",

--- a/tools/json/generic.json
+++ b/tools/json/generic.json
@@ -1,5 +1,12 @@
 {
   "build": {
+    "arduino": {
+      "earlephilhower": {
+        "boot2_source": "boot2_generic_03h_4_padded_checksum.S",
+        "usb_vid": "0x2e8a",
+        "usb_pid": "0xf00a"
+      }
+    },
     "core": "earlephilhower",
     "cpu": "cortex-m0plus",
     "extra_flags": "-D ARDUINO_GENERIC_RP2040 -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=250",
@@ -11,14 +18,7 @@
       ]
     ],
     "mcu": "rp2040",
-    "variant": "generic",
-    "arduino": {
-      "earlephilhower": {
-        "boot2_source": "boot2_generic_03h_4_padded_checksum.S",
-        "usb_vid": "0x2e8a",
-        "usb_pid": "0xf00a"
-      }
-    }
+    "variant": "generic"
   },
   "debug": {
     "jlink_device": "RP2040_M0_0",

--- a/tools/json/ilabs_rpico32.json
+++ b/tools/json/ilabs_rpico32.json
@@ -1,5 +1,12 @@
 {
   "build": {
+    "arduino": {
+      "earlephilhower": {
+        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
+        "usb_vid": "0x2e8a",
+        "usb_pid": "0x1010"
+      }
+    },
     "core": "earlephilhower",
     "cpu": "cortex-m0plus",
     "extra_flags": "-D ARDUINO_ILABS_2040_RPICO32_RP2040 -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=250",
@@ -11,14 +18,7 @@
       ]
     ],
     "mcu": "rp2040",
-    "variant": "ilabs_rpico32",
-    "arduino": {
-      "earlephilhower": {
-        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
-        "usb_vid": "0x2e8a",
-        "usb_pid": "0x1010"
-      }
-    }
+    "variant": "ilabs_rpico32"
   },
   "debug": {
     "jlink_device": "RP2040_M0_0",

--- a/tools/json/melopero_shake_rp2040.json
+++ b/tools/json/melopero_shake_rp2040.json
@@ -1,5 +1,12 @@
 {
   "build": {
+    "arduino": {
+      "earlephilhower": {
+        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
+        "usb_vid": "0x2e8a",
+        "usb_pid": "0x1005"
+      }
+    },
     "core": "earlephilhower",
     "cpu": "cortex-m0plus",
     "extra_flags": "-D ARDUINO_MELOPERO_SHAKE_RP2040 -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=250",
@@ -11,14 +18,7 @@
       ]
     ],
     "mcu": "rp2040",
-    "variant": "melopero_shake_rp2040",
-    "arduino": {
-      "earlephilhower": {
-        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
-        "usb_vid": "0x2e8a",
-        "usb_pid": "0x1005"
-      }
-    }
+    "variant": "melopero_shake_rp2040"
   },
   "debug": {
     "jlink_device": "RP2040_M0_0",

--- a/tools/json/rpipico.json
+++ b/tools/json/rpipico.json
@@ -1,5 +1,12 @@
 {
   "build": {
+    "arduino": {
+      "earlephilhower": {
+        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
+        "usb_vid": "0x2e8a",
+        "usb_pid": "0x000a"
+      }
+    },
     "core": "earlephilhower",
     "cpu": "cortex-m0plus",
     "extra_flags": "-D ARDUINO_RASPBERRY_PI_PICO -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=250",
@@ -11,14 +18,7 @@
       ]
     ],
     "mcu": "rp2040",
-    "variant": "rpipico",
-    "arduino": {
-      "earlephilhower": {
-        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
-        "usb_vid": "0x2e8a",
-        "usb_pid": "0x000a"
-      }
-    }
+    "variant": "rpipico"
   },
   "debug": {
     "jlink_device": "RP2040_M0_0",

--- a/tools/json/seeed_xiao_rp2040.json
+++ b/tools/json/seeed_xiao_rp2040.json
@@ -1,5 +1,12 @@
 {
   "build": {
+    "arduino": {
+      "earlephilhower": {
+        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
+        "usb_vid": "0x2e8a",
+        "usb_pid": "0x000a"
+      }
+    },
     "core": "earlephilhower",
     "cpu": "cortex-m0plus",
     "extra_flags": "-D ARDUINO_SEEED_XAIO_RP2040 -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=250",
@@ -11,14 +18,7 @@
       ]
     ],
     "mcu": "rp2040",
-    "variant": "seeed_xiao_rp2040",
-    "arduino": {
-      "earlephilhower": {
-        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
-        "usb_vid": "0x2e8a",
-        "usb_pid": "0x000a"
-      }
-    }
+    "variant": "seeed_xiao_rp2040"
   },
   "debug": {
     "jlink_device": "RP2040_M0_0",

--- a/tools/json/solderparty_rp2040_stamp.json
+++ b/tools/json/solderparty_rp2040_stamp.json
@@ -1,5 +1,12 @@
 {
   "build": {
+    "arduino": {
+      "earlephilhower": {
+        "boot2_source": "boot2_generic_03h_4_padded_checksum.S",
+        "usb_vid": "0x1209",
+        "usb_pid": "0xa182"
+      }
+    },
     "core": "earlephilhower",
     "cpu": "cortex-m0plus",
     "extra_flags": "-D ARDUINO_SOLDERPARTY_RP2040_STAMP -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=500",
@@ -11,14 +18,7 @@
       ]
     ],
     "mcu": "rp2040",
-    "variant": "solderparty_rp2040_stamp",
-    "arduino": {
-      "earlephilhower": {
-        "boot2_source": "boot2_generic_03h_4_padded_checksum.S",
-        "usb_vid": "0x1209",
-        "usb_pid": "0xa182"
-      }
-    }
+    "variant": "solderparty_rp2040_stamp"
   },
   "debug": {
     "jlink_device": "RP2040_M0_0",

--- a/tools/json/sparkfun_promicrorp2040.json
+++ b/tools/json/sparkfun_promicrorp2040.json
@@ -1,5 +1,12 @@
 {
   "build": {
+    "arduino": {
+      "earlephilhower": {
+        "boot2_source": "boot2_generic_03h_4_padded_checksum.S",
+        "usb_vid": "0x1b4f",
+        "usb_pid": "0x0026"
+      }
+    },
     "core": "earlephilhower",
     "cpu": "cortex-m0plus",
     "extra_flags": "-D ARDUINO_SPARKFUN_PROMICRO_RP2040 -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=250",
@@ -11,14 +18,7 @@
       ]
     ],
     "mcu": "rp2040",
-    "variant": "sparkfun_promicrorp2040",
-    "arduino": {
-      "earlephilhower": {
-        "boot2_source": "boot2_generic_03h_4_padded_checksum.S",
-        "usb_vid": "0x1b4f",
-        "usb_pid": "0x0026"
-      }
-    }
+    "variant": "sparkfun_promicrorp2040"
   },
   "debug": {
     "jlink_device": "RP2040_M0_0",

--- a/tools/json/sparkfun_thingplusrp2040.json
+++ b/tools/json/sparkfun_thingplusrp2040.json
@@ -1,5 +1,12 @@
 {
   "build": {
+    "arduino": {
+      "earlephilhower": {
+        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
+        "usb_vid": "0x1b4f",
+        "usb_pid": "0x0026"
+      }
+    },
     "core": "earlephilhower",
     "cpu": "cortex-m0plus",
     "extra_flags": "-D ARDUINO_SPARKFUN_THINGPLUS_RP2040 -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=250",
@@ -11,14 +18,7 @@
       ]
     ],
     "mcu": "rp2040",
-    "variant": "sparkfun_thingplusrp2040",
-    "arduino": {
-      "earlephilhower": {
-        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
-        "usb_vid": "0x1b4f",
-        "usb_pid": "0x0026"
-      }
-    }
+    "variant": "sparkfun_thingplusrp2040"
   },
   "debug": {
     "jlink_device": "RP2040_M0_0",

--- a/tools/json/upesy_rp2040_devkit.json
+++ b/tools/json/upesy_rp2040_devkit.json
@@ -1,5 +1,12 @@
 {
   "build": {
+    "arduino": {
+      "earlephilhower": {
+        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
+        "usb_vid": "0x2e8a",
+        "usb_pid": "0x1007"
+      }
+    },
     "core": "earlephilhower",
     "cpu": "cortex-m0plus",
     "extra_flags": "-D ARDUINO_UPESY_RP2040_DEVKIT -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=250",
@@ -11,14 +18,7 @@
       ]
     ],
     "mcu": "rp2040",
-    "variant": "upesy_rp2040_devkit",
-    "arduino": {
-      "earlephilhower": {
-        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
-        "usb_vid": "0x2e8a",
-        "usb_pid": "0x1007"
-      }
-    }
+    "variant": "upesy_rp2040_devkit"
   },
   "debug": {
     "jlink_device": "RP2040_M0_0",

--- a/tools/json/wiznet_5100s_evb_pico.json
+++ b/tools/json/wiznet_5100s_evb_pico.json
@@ -1,5 +1,12 @@
 {
   "build": {
+    "arduino": {
+      "earlephilhower": {
+        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
+        "usb_vid": "0x2e8a",
+        "usb_pid": "0x1027"
+      }
+    },
     "core": "earlephilhower",
     "cpu": "cortex-m0plus",
     "extra_flags": "-D ARDUINO_WIZNET_5100S_EVB_PICO -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=250",
@@ -11,14 +18,7 @@
       ]
     ],
     "mcu": "rp2040",
-    "variant": "wiznet_5100s_evb_pico",
-    "arduino": {
-      "earlephilhower": {
-        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
-        "usb_vid": "0x2e8a",
-        "usb_pid": "0x1027"
-      }
-    }
+    "variant": "wiznet_5100s_evb_pico"
   },
   "debug": {
     "jlink_device": "RP2040_M0_0",

--- a/tools/json/wiznet_5500_evb_pico.json
+++ b/tools/json/wiznet_5500_evb_pico.json
@@ -1,5 +1,12 @@
 {
   "build": {
+    "arduino": {
+      "earlephilhower": {
+        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
+        "usb_vid": "0x2e8a",
+        "usb_pid": "0x1029"
+      }
+    },
     "core": "earlephilhower",
     "cpu": "cortex-m0plus",
     "extra_flags": "-D ARDUINO_WIZNET_5500_EVB_PICO -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=250",
@@ -11,14 +18,7 @@
       ]
     ],
     "mcu": "rp2040",
-    "variant": "wiznet_5500_evb_pico",
-    "arduino": {
-      "earlephilhower": {
-        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
-        "usb_vid": "0x2e8a",
-        "usb_pid": "0x1029"
-      }
-    }
+    "variant": "wiznet_5500_evb_pico"
   },
   "debug": {
     "jlink_device": "RP2040_M0_0",

--- a/tools/json/wiznet_wizfi360_evb_pico.json
+++ b/tools/json/wiznet_wizfi360_evb_pico.json
@@ -1,5 +1,12 @@
 {
   "build": {
+    "arduino": {
+      "earlephilhower": {
+        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
+        "usb_vid": "0x2e8a",
+        "usb_pid": "0x1028"
+      }
+    },
     "core": "earlephilhower",
     "cpu": "cortex-m0plus",
     "extra_flags": "-D ARDUINO_WIZNET_WIZFI360_EVB_PICO -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=250",
@@ -11,14 +18,7 @@
       ]
     ],
     "mcu": "rp2040",
-    "variant": "wiznet_wizfi360_evb_pico",
-    "arduino": {
-      "earlephilhower": {
-        "boot2_source": "boot2_w25q080_2_padded_checksum.S",
-        "usb_vid": "0x2e8a",
-        "usb_pid": "0x1028"
-      }
-    }
+    "variant": "wiznet_wizfi360_evb_pico"
   },
   "debug": {
     "jlink_device": "RP2040_M0_0",

--- a/tools/makeboards.py
+++ b/tools/makeboards.py
@@ -177,6 +177,13 @@ def MakeBoard(name, vendor_name, product_name, vid, pid, pwr, boarddefine, flash
 def MakeBoardJSON(name, vendor_name, product_name, vid, pid, pwr, boarddefine, flashsizemb, boot2):
     json = """{
   "build": {
+    "arduino": {
+      "earlephilhower": {
+        "boot2_source": "BOOT2.S",
+        "usb_vid": "VID",
+        "usb_pid": "PID"
+      }
+    },
     "core": "earlephilhower",
     "cpu": "cortex-m0plus",
     "extra_flags": "-D ARDUINO_BOARDDEFINE -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=USBPWR",
@@ -188,14 +195,7 @@ def MakeBoardJSON(name, vendor_name, product_name, vid, pid, pwr, boarddefine, f
       ]
     ],
     "mcu": "rp2040",
-    "variant": "VARIANTNAME",
-    "arduino": {
-      "earlephilhower": {
-        "boot2_source": "BOOT2.S",
-        "usb_vid": "VID",
-        "usb_pid": "PID"
-      }
-    }
+    "variant": "VARIANTNAME"
   },
   "debug": {
     "jlink_device": "RP2040_M0_0",


### PR DESCRIPTION
* Pushes `arduino` object higher in JSON file as the first entry in `boot` to keep alphabetical ordering, done in feedpack to PR (https://github.com/platformio/platform-raspberrypi/pull/36#discussion_r899927068)
* Adds PlatformIO to CI
  * builds the Multcore.ino, Fade.ino and CDC_Multi.ino (Adafruit TinyUSB) examples for Pico and Adafruit Feather boards
* upgrades the checkout version to latest stable v3