### PR TITLE
Minor PIO Docs Fixup

### DIFF
--- a/docs/platformio.rst
+++ b/docs/platformio.rst
@@ -243,7 +243,7 @@ Whereas the ``#master`` can also be replaced by a ``#branchname`` or a
 ``#commithash``. If left out, it will pull the default branch, which is ``master``.
 
 The ``file://`` and ``symlink://`` pseudo-protocols can also be used instead of ``https://`` to point to a
-local copy of the core (with e.g. some modifications) on disk (`see documentation <https://docs.platformio.org/en/latest/core/userguide/pkg/cmd_install.html?#local-folder>_`).
+local copy of the core (with e.g. some modifications) on disk (`see documentation <https://docs.platformio.org/en/latest/core/userguide/pkg/cmd_install.html?#local-folder>`_).
 
 Note that this can only be done for versions that have the PlatformIO
 builder script it in, so versions before 1.9.2 are not supported.
@@ -305,5 +305,3 @@ The files you want to upload should be placed in a folder called ``data`` inside
 The task "Build Filesystem Image" will take all files in the data directory and create a ``littlefs.bin`` file from it using the ``mklittlefs`` tool.
 
 The task "Upload Filesystem Image" will upload the filesystem image to the Pico via the specified ``upload_protocol``. 
-
-**Note:** Currently only the default ``picotool`` (regular direct USB upload) and the OpenOCD-based debug methods (meaning all but ``jlink``) can transport the filesystem to the Pico.

--- a/docs/platformio.rst
+++ b/docs/platformio.rst
@@ -73,8 +73,6 @@ in the `PlatformIO CLI <https://docs.platformio.org/en/latest/integration/ide/vs
 The toolchain, which was also renamed to ``toolchain-rp2040-earlephilhower`` is downloaded automatically from the registry. The same goes for the ``framework-arduinopico`` toolchain package, which points directly to the Arduino-Pico Github repository.
 However, users can still select a custom fork or branch of the core if desired so, as detailed in a chapter below.
 
-As the pull req
-
 Selecting the new core
 ----------------------
 


### PR DESCRIPTION
* Fixes that the link is properly displayed (see https://arduino-pico.readthedocs.io/en/latest/platformio.html#selecting-a-different-core-version)
* Remove warning regarding JLink Filesystem Upload (implemented in https://github.com/maxgerhardt/platform-raspberrypi/commit/d24609b89e26da75a5a7fe01df2b98818716611f)
* Remove unfinished, dangling sentence

(Docs should be rebuilt thereafter.)