### PR TITLE
Wrap xxx_r re-entrant memory allocator functions

### DIFF
--- a/cores/rp2040/malloc_lock.c
+++ b/cores/rp2040/malloc_lock.c
@@ -1,0 +1,59 @@
+/*
+    Newlib allocator wrapper for multicore fixes
+
+    File a .C and not .CPP because auto_init_recursive_mutex() does not
+    compile under C++ for some reason.
+
+    Copyright (c) 2022 Earle F. Philhower, III <earlephilhower@yahoo.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#include "pico.h"
+#include "pico/mutex.h"
+
+auto_init_recursive_mutex(__malloc_reent_mutex);
+
+extern void *__real__malloc_r(void *reent, size_t size);
+extern void *__real__calloc_r(void *reent, size_t count, size_t size);
+extern void *__real__realloc_r(void *reent, void *mem, size_t size);
+extern void __real__free_r(void *reent, void *mem);
+
+void *__wrap__malloc_r(void *reent, size_t size) {
+    recursive_mutex_enter_blocking(&__malloc_reent_mutex);
+    void *rc = __real__malloc_r(reent, size);
+    recursive_mutex_exit(&__malloc_reent_mutex);
+    return rc;
+}
+
+void *__wrap__calloc_r(void *reent, size_t count, size_t size) {
+    recursive_mutex_enter_blocking(&__malloc_reent_mutex);
+    void *rc = __real__calloc_r(reent, count, size);
+    recursive_mutex_exit(&__malloc_reent_mutex);
+    return rc;
+}
+
+void *__wrap__realloc_r(void *reent, void *mem, size_t size) {
+    recursive_mutex_enter_blocking(&__malloc_reent_mutex);
+    void *rc = __real__realloc_r(reent, mem, size);
+    recursive_mutex_exit(&__malloc_reent_mutex);
+    return rc;
+}
+
+void __wrap__free_r(void *reent, void *mem) {
+    recursive_mutex_enter_blocking(&__malloc_reent_mutex);
+    __real__free_r(reent, mem);
+    recursive_mutex_exit(&__malloc_reent_mutex);
+}

--- a/lib/platform_wrap.txt
+++ b/lib/platform_wrap.txt
@@ -71,7 +71,6 @@
 -Wl,--wrap=atanf
 -Wl,--wrap=atanh
 -Wl,--wrap=atanhf
--Wl,--wrap=calloc
 -Wl,--wrap=cbrt
 -Wl,--wrap=cbrtf
 -Wl,--wrap=ceil
@@ -105,7 +104,6 @@
 -Wl,--wrap=fmaf
 -Wl,--wrap=fmod
 -Wl,--wrap=fmodf
--Wl,--wrap=free
 -Wl,--wrap=hypot
 -Wl,--wrap=hypotf
 -Wl,--wrap=ldexp
@@ -118,7 +116,6 @@
 -Wl,--wrap=log2
 -Wl,--wrap=log2f
 -Wl,--wrap=logf
--Wl,--wrap=malloc
 -Wl,--wrap=memcpy
 -Wl,--wrap=memset
 -Wl,--wrap=__popcountdi2
@@ -127,7 +124,6 @@
 -Wl,--wrap=powf
 -Wl,--wrap=powint
 -Wl,--wrap=powintf
--Wl,--wrap=realloc
 -Wl,--wrap=remainder
 -Wl,--wrap=remainderf
 -Wl,--wrap=remquo
@@ -148,3 +144,7 @@
 -Wl,--wrap=tanhf
 -Wl,--wrap=trunc
 -Wl,--wrap=truncf
+-Wl,--wrap=_calloc_r
+-Wl,--wrap=_free_r
+-Wl,--wrap=_malloc_r
+-Wl,--wrap=_realloc_r


### PR DESCRIPTION
Fixes #614 in a temporary way.  A more complete patch should rebuild
Newlib and include overrides for all the calls in sys/lock.h