### PR TITLE
Make TinyUSB linking work automatically with PIO

### DIFF
--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -159,6 +159,9 @@ def configure_usb_flags(cpp_defines):
     if "USE_TINYUSB" in cpp_defines:
         env.Append(CPPPATH=[os.path.join(
             FRAMEWORK_DIR, "libraries", "Adafruit_TinyUSB_Arduino", "src", "arduino")])
+        # automatically build with lib_archive = no to make weak linking work, needed for TinyUSB
+        env_section = "env:" + env["PIOENV"]
+        platform.config.set(env_section, "lib_archive", False)
     elif "PIO_FRAMEWORK_ARDUINO_NO_USB" in cpp_defines:
         env.Append(
             CPPPATH=[os.path.join(FRAMEWORK_DIR, "tools", "libpico")],


### PR DESCRIPTION
Closes #630.

As written in https://github.com/earlephilhower/arduino-pico/issues/630#issuecomment-1159775571, the TinyUSB library only works with PlatformIO during runtime if its object files are linked individually in the firmware instead of archiving them into a `.a` file and linking that.

So that users don't have to write
```ini
lib_archive = no
```
into their `platformio.ini` ([docs](https://docs.platformio.org/en/latest/projectconf/section_env_library.html#lib-archive)) and to make the docs valid (they say only `build_flags = -DUSE_TINYUSB` is needed), a small addition to the builder script is made which adds this option automatically.

So this is equivalent to https://github.com/adafruit/Adafruit_TinyUSB_Arduino/pull/116 on the framework builder script side.

It is still interesting that PlatformIO needs to link this as object files while the Arduino IDE does it apparently not -- this might be due to a slight difference in linking order that makes this work. This behavior has been there forever in PlatformIO, so I don't think a clean fix will come for this soon, hence the addition here.