### PR TITLE
Fix ::printf/etc. due to mutex size conflict

### DIFF
--- a/package/package_pico_index.template.json
+++ b/package/package_pico_index.template.json
@@ -114,22 +114,22 @@
                "toolsDependencies": [
                   {
                      "packager": "rp2040",
-                     "version": "1.4.0-b-cb31b54",
+                     "version": "1.4.0-c-0196c06",
                      "name": "pqt-gcc"
                   },
                   {
                      "packager": "rp2040",
-                     "version": "1.4.0-b-cb31b54",
+                     "version": "1.4.0-c-0196c06",
                      "name": "pqt-mklittlefs"
                   },
                   {
                      "packager": "rp2040",
-                     "version": "1.4.0-b-cb31b54",
+                     "version": "1.4.0-c-0196c06",
                      "name": "pqt-elf2uf2"
                   },
                   {
                      "packager": "rp2040",
-                     "version": "1.4.0-b-cb31b54",
+                     "version": "1.4.0-c-0196c06",
                      "name": "pqt-pioasm"
                   },
                   {
@@ -139,7 +139,7 @@
                   },
                   {
                      "packager": "rp2040",
-                     "version": "1.4.0-b-cb31b54",
+                     "version": "1.4.0-c-0196c06",
                      "name": "pqt-openocd"
                   }
                ],
@@ -150,57 +150,57 @@
          ],
          "tools": [
             {
-               "version": "1.4.0-b-cb31b54",
+               "version": "1.4.0-c-0196c06",
                "name": "pqt-openocd",
                "systems": [
                   {
                      "host": "aarch64-linux-gnu",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/aarch64-linux-gnu.openocd-e3428fadb.220619.tar.gz",
-                     "archiveFileName": "aarch64-linux-gnu.openocd-e3428fadb.220619.tar.gz",
-                     "checksum": "SHA-256:8cdddf73090b6d7f5ef7fdb1b60e9f755166ce494d774b91004e6655a80abfa1",
-                     "size": "5607149"
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/aarch64-linux-gnu.openocd-e3428fadb.220714.tar.gz",
+                     "archiveFileName": "aarch64-linux-gnu.openocd-e3428fadb.220714.tar.gz",
+                     "checksum": "SHA-256:8da4fd922fd7392e87c0057b193e67962606cd13450af935c9846992f2bce916",
+                     "size": "5607131"
                   },
                   {
                      "host": "arm-linux-gnueabihf",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/arm-linux-gnueabihf.openocd-e3428fadb.220619.tar.gz",
-                     "archiveFileName": "arm-linux-gnueabihf.openocd-e3428fadb.220619.tar.gz",
-                     "checksum": "SHA-256:07d4e170396f57d5180569168d9bc24b258207900fbc8c87b38056ac1b2fed1e",
-                     "size": "5344134"
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/arm-linux-gnueabihf.openocd-e3428fadb.220714.tar.gz",
+                     "archiveFileName": "arm-linux-gnueabihf.openocd-e3428fadb.220714.tar.gz",
+                     "checksum": "SHA-256:ce7650961c8200fe2cc2d4a88efc952fe1bb7b4175f2cf650a9a7d992ae08298",
+                     "size": "5344149"
                   },
                   {
                      "host": "i686-pc-linux-gnu",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/i686-linux-gnu.openocd-e3428fadb.220619.tar.gz",
-                     "archiveFileName": "i686-linux-gnu.openocd-e3428fadb.220619.tar.gz",
-                     "checksum": "SHA-256:9e3f18ccfb47ee4051bb93c8b9b177e3135eedbbfb3fd9207524b649efe09aed",
-                     "size": "5168404"
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/i686-linux-gnu.openocd-e3428fadb.220714.tar.gz",
+                     "archiveFileName": "i686-linux-gnu.openocd-e3428fadb.220714.tar.gz",
+                     "checksum": "SHA-256:9391ae74c6474f685f45ccefb82e18f382f1a59f3e13e2b22fe00967264d2482",
+                     "size": "5168334"
                   },
                   {
                      "host": "i686-mingw32",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/i686-w64-mingw32.openocd-e3428fadb.220619.zip",
-                     "archiveFileName": "i686-w64-mingw32.openocd-e3428fadb.220619.zip",
-                     "checksum": "SHA-256:c38bf855c099d933c09d92d57fd1473853eee205957fe22b618e3514d638fe4f",
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/i686-w64-mingw32.openocd-e3428fadb.220714.zip",
+                     "archiveFileName": "i686-w64-mingw32.openocd-e3428fadb.220714.zip",
+                     "checksum": "SHA-256:f4b7803527a0a587fe95e52bcf056fcbe58d64b78705edd38810655d3abee1fe",
                      "size": "2156831"
                   },
                   {
                      "host": "x86_64-apple-darwin",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/x86_64-apple-darwin14.openocd-e3428fadb.220619.tar.gz",
-                     "archiveFileName": "x86_64-apple-darwin14.openocd-e3428fadb.220619.tar.gz",
-                     "checksum": "SHA-256:c36483c5cecfdeba8466b6e112552736c99a2409e6f8e80287b80a3f8d8fdb16",
-                     "size": "2002506"
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/x86_64-apple-darwin14.openocd-e3428fadb.220714.tar.gz",
+                     "archiveFileName": "x86_64-apple-darwin14.openocd-e3428fadb.220714.tar.gz",
+                     "checksum": "SHA-256:4e6a8da43758941478e6740e023ea5be051f09bf92e49d65c2b54a1ca4a2660c",
+                     "size": "2002508"
                   },
                   {
                      "host": "x86_64-pc-linux-gnu",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/x86_64-linux-gnu.openocd-e3428fadb.220619.tar.gz",
-                     "archiveFileName": "x86_64-linux-gnu.openocd-e3428fadb.220619.tar.gz",
-                     "checksum": "SHA-256:57083723758814567f6b54e4f81713ce1ce070c6878362a97636da73362f00c9",
-                     "size": "5540547"
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/x86_64-linux-gnu.openocd-e3428fadb.220714.tar.gz",
+                     "archiveFileName": "x86_64-linux-gnu.openocd-e3428fadb.220714.tar.gz",
+                     "checksum": "SHA-256:2518c6451c0e4c148c8c6cb9330e216075177003b064c509b168f42a44a6eb5a",
+                     "size": "5540574"
                   },
                   {
                      "host": "x86_64-mingw32",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/x86_64-w64-mingw32.openocd-e3428fadb.220619.zip",
-                     "archiveFileName": "x86_64-w64-mingw32.openocd-e3428fadb.220619.zip",
-                     "checksum": "SHA-256:b05d1dbf32d277e214664ae44dd86be96bae61f615c0bac6c1c1c281d6b52b71",
-                     "size": "2156832"
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/x86_64-w64-mingw32.openocd-e3428fadb.220714.zip",
+                     "archiveFileName": "x86_64-w64-mingw32.openocd-e3428fadb.220714.zip",
+                     "checksum": "SHA-256:c2da993d74152ec8ca80b350ede77ee94942518081a48dafd7a3b49631778e75",
+                     "size": "2156831"
                   }
                ]
             },
@@ -267,222 +267,222 @@
                ]
             },
             {
-               "version": "1.4.0-b-cb31b54",
+               "version": "1.4.0-c-0196c06",
                "name": "pqt-gcc",
                "systems": [
                   {
                      "host": "aarch64-linux-gnu",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/aarch64-linux-gnu.arm-none-eabi-cb31b54.220619.tar.gz",
-                     "archiveFileName": "aarch64-linux-gnu.arm-none-eabi-cb31b54.220619.tar.gz",
-                     "checksum": "SHA-256:27dd4a1fe0b6010588928acc9b61937d149ebcd7a4aa47ce944506d71827c460",
-                     "size": "77881122"
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/aarch64-linux-gnu.arm-none-eabi-0196c06.220714.tar.gz",
+                     "archiveFileName": "aarch64-linux-gnu.arm-none-eabi-0196c06.220714.tar.gz",
+                     "checksum": "SHA-256:0bc906c2eb4b3999285ea8a71ec0c95a20a21f2ff46b1bdd264f2fd3c30fe580",
+                     "size": "77889379"
                   },
                   {
                      "host": "arm-linux-gnueabihf",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/arm-linux-gnueabihf.arm-none-eabi-cb31b54.220619.tar.gz",
-                     "archiveFileName": "arm-linux-gnueabihf.arm-none-eabi-cb31b54.220619.tar.gz",
-                     "checksum": "SHA-256:3e3547998b6c2382d7c6e91b43f0a7a3190e2955160bb471de4cc204b599a757",
-                     "size": "73345531"
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/arm-linux-gnueabihf.arm-none-eabi-0196c06.220714.tar.gz",
+                     "archiveFileName": "arm-linux-gnueabihf.arm-none-eabi-0196c06.220714.tar.gz",
+                     "checksum": "SHA-256:2bf9f691d1fa97cea3b835a364fc24d06102181725001a00fe3e77526f90e2bd",
+                     "size": "73342377"
                   },
                   {
                      "host": "i686-pc-linux-gnu",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/i686-linux-gnu.arm-none-eabi-cb31b54.220619.tar.gz",
-                     "archiveFileName": "i686-linux-gnu.arm-none-eabi-cb31b54.220619.tar.gz",
-                     "checksum": "SHA-256:fca37e1e49a6e25dd507a24e2e9a6947fd0eec7d0a8a30f4bdcac524c9bd18a1",
-                     "size": "79497966"
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/i686-linux-gnu.arm-none-eabi-0196c06.220714.tar.gz",
+                     "archiveFileName": "i686-linux-gnu.arm-none-eabi-0196c06.220714.tar.gz",
+                     "checksum": "SHA-256:e0fe347f2602247ffbc16bb7b74653fdb78c4f75b90037f2e82fc5498b5d1cb9",
+                     "size": "79511866"
                   },
                   {
                      "host": "i686-mingw32",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/i686-w64-mingw32.arm-none-eabi-cb31b54.220619.zip",
-                     "archiveFileName": "i686-w64-mingw32.arm-none-eabi-cb31b54.220619.zip",
-                     "checksum": "SHA-256:61f31ae875a67e8334e031c188fbe30d98c5f1bceb33305acf49d985d9ca71ce",
-                     "size": "82625221"
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/i686-w64-mingw32.arm-none-eabi-0196c06.220714.zip",
+                     "archiveFileName": "i686-w64-mingw32.arm-none-eabi-0196c06.220714.zip",
+                     "checksum": "SHA-256:d1ee0f00c97dc50dc06487d6fb6b5dd94bbb3cf1579c975bcd23d7a7922e53b7",
+                     "size": "82626868"
                   },
                   {
                      "host": "x86_64-apple-darwin",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/x86_64-apple-darwin14.arm-none-eabi-cb31b54.220619.tar.gz",
-                     "archiveFileName": "x86_64-apple-darwin14.arm-none-eabi-cb31b54.220619.tar.gz",
-                     "checksum": "SHA-256:d32c7797be2c31d20dc4b5182a0dd77be67324c3c6a52737bfb4e63e1d622f80",
-                     "size": "82123114"
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/x86_64-apple-darwin14.arm-none-eabi-0196c06.220714.tar.gz",
+                     "archiveFileName": "x86_64-apple-darwin14.arm-none-eabi-0196c06.220714.tar.gz",
+                     "checksum": "SHA-256:1b030451a5a6ddf42ac796c46b2f077f90f6d56586f4537a3486ce47670996cd",
+                     "size": "82119254"
                   },
                   {
                      "host": "x86_64-pc-linux-gnu",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/x86_64-linux-gnu.arm-none-eabi-cb31b54.220619.tar.gz",
-                     "archiveFileName": "x86_64-linux-gnu.arm-none-eabi-cb31b54.220619.tar.gz",
-                     "checksum": "SHA-256:470cbe690b2553d3b780ece36cda9fc26c7b53db47362ced3a937d701e696e9e",
-                     "size": "80361816"
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/x86_64-linux-gnu.arm-none-eabi-0196c06.220714.tar.gz",
+                     "archiveFileName": "x86_64-linux-gnu.arm-none-eabi-0196c06.220714.tar.gz",
+                     "checksum": "SHA-256:73d032ba42d33f6e9c1d5de79b73bf5e9740b8e6b7fee37de3db03814c553694",
+                     "size": "80363125"
                   },
                   {
                      "host": "x86_64-mingw32",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/x86_64-w64-mingw32.arm-none-eabi-cb31b54.220619.zip",
-                     "archiveFileName": "x86_64-w64-mingw32.arm-none-eabi-cb31b54.220619.zip",
-                     "checksum": "SHA-256:7b50d3f34cd602a28d8cf1580c65dd22e683088ce5b954be5bfb67ba50094134",
-                     "size": "86068608"
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/x86_64-w64-mingw32.arm-none-eabi-0196c06.220714.zip",
+                     "archiveFileName": "x86_64-w64-mingw32.arm-none-eabi-0196c06.220714.zip",
+                     "checksum": "SHA-256:3f67e15adbe49ebaee72734e9d469bd6b34fd1be30ccdb6e55a1e05a0be4e1db",
+                     "size": "86064664"
                   }
                ]
             },
             {
-               "version": "1.4.0-b-cb31b54",
+               "version": "1.4.0-c-0196c06",
                "name": "pqt-elf2uf2",
                "systems": [
                   {
                      "host": "aarch64-linux-gnu",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/aarch64-linux-gnu.elf2uf2-2062372.220619.tar.gz",
-                     "archiveFileName": "aarch64-linux-gnu.elf2uf2-2062372.220619.tar.gz",
-                     "checksum": "SHA-256:74dd8cf38160bd9f972ea22e02bd6fa6b11bc510aa7738b603c7fbd016fe4b50",
-                     "size": "79874"
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/aarch64-linux-gnu.elf2uf2-2e6142b.220714.tar.gz",
+                     "archiveFileName": "aarch64-linux-gnu.elf2uf2-2e6142b.220714.tar.gz",
+                     "checksum": "SHA-256:14d7c1be08151bcddcc19fdb5741bf52b435f08f52daff2d498a07c5ebfb5bfb",
+                     "size": "82682"
                   },
                   {
                      "host": "arm-linux-gnueabihf",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/arm-linux-gnueabihf.elf2uf2-2062372.220619.tar.gz",
-                     "archiveFileName": "arm-linux-gnueabihf.elf2uf2-2062372.220619.tar.gz",
-                     "checksum": "SHA-256:efa24ac288a5eacad7b535ce4d9ac66a25686d993f80daf86248858310b3fc63",
-                     "size": "54265"
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/arm-linux-gnueabihf.elf2uf2-2e6142b.220714.tar.gz",
+                     "archiveFileName": "arm-linux-gnueabihf.elf2uf2-2e6142b.220714.tar.gz",
+                     "checksum": "SHA-256:31b790b5a19bbb5950212098aa42be43702fb4db50aa541c9f40b2320e2280be",
+                     "size": "55991"
                   },
                   {
                      "host": "i686-pc-linux-gnu",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/i686-linux-gnu.elf2uf2-2062372.220619.tar.gz",
-                     "archiveFileName": "i686-linux-gnu.elf2uf2-2062372.220619.tar.gz",
-                     "checksum": "SHA-256:c0816a703fe5821a1d1bf60dcb584d98185b83e926d532fd37c69e8801e211ff",
-                     "size": "87908"
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/i686-linux-gnu.elf2uf2-2e6142b.220714.tar.gz",
+                     "archiveFileName": "i686-linux-gnu.elf2uf2-2e6142b.220714.tar.gz",
+                     "checksum": "SHA-256:a3dd93861857fd81f8c9ed01509a0af012f446f23f405bc696f6a4d2f344262c",
+                     "size": "91386"
                   },
                   {
                      "host": "i686-mingw32",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/i686-w64-mingw32.elf2uf2-2062372.220619.zip",
-                     "archiveFileName": "i686-w64-mingw32.elf2uf2-2062372.220619.zip",
-                     "checksum": "SHA-256:7a2f86735220fef0946856f418a136ff4ed3ad4cf0cacc17d8016f6cbd1ca735",
-                     "size": "70416"
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/i686-w64-mingw32.elf2uf2-2e6142b.220714.zip",
+                     "archiveFileName": "i686-w64-mingw32.elf2uf2-2e6142b.220714.zip",
+                     "checksum": "SHA-256:25d6a934643074590c3006468ec051f62d02298abbff27d7e3643ee147e818e0",
+                     "size": "71949"
                   },
                   {
                      "host": "x86_64-apple-darwin",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/x86_64-apple-darwin14.elf2uf2-2062372.220619.tar.gz",
-                     "archiveFileName": "x86_64-apple-darwin14.elf2uf2-2062372.220619.tar.gz",
-                     "checksum": "SHA-256:2ae3ffd477eaabb891e68e1b4525e3d4d4b2fee3c6f70e6ae68c45746c03fb54",
-                     "size": "81995"
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/x86_64-apple-darwin14.elf2uf2-2e6142b.220714.tar.gz",
+                     "archiveFileName": "x86_64-apple-darwin14.elf2uf2-2e6142b.220714.tar.gz",
+                     "checksum": "SHA-256:f2743d086d1992599d656aaa9a38a736d443bdc96619fd5bcabdc7fcb05225c8",
+                     "size": "86600"
                   },
                   {
                      "host": "x86_64-pc-linux-gnu",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/x86_64-linux-gnu.elf2uf2-2062372.220619.tar.gz",
-                     "archiveFileName": "x86_64-linux-gnu.elf2uf2-2062372.220619.tar.gz",
-                     "checksum": "SHA-256:2be1052db1e676418c59a4331ef688f686b4a31053330c90348219ab1ecd6bcf",
-                     "size": "79610"
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/x86_64-linux-gnu.elf2uf2-2e6142b.220714.tar.gz",
+                     "archiveFileName": "x86_64-linux-gnu.elf2uf2-2e6142b.220714.tar.gz",
+                     "checksum": "SHA-256:5b0e79bfd9d7e5f4d5e5cb0e6e2b685e10fdf3071139c00bf6274a5ca9b9717e",
+                     "size": "82339"
                   },
                   {
                      "host": "x86_64-mingw32",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/x86_64-w64-mingw32.elf2uf2-2062372.220619.zip",
-                     "archiveFileName": "x86_64-w64-mingw32.elf2uf2-2062372.220619.zip",
-                     "checksum": "SHA-256:2a39f7f20e42c5b981286dfdf50bc3d7201cbe63d191caf38a0ffa306422ed08",
-                     "size": "78291"
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/x86_64-w64-mingw32.elf2uf2-2e6142b.220714.zip",
+                     "archiveFileName": "x86_64-w64-mingw32.elf2uf2-2e6142b.220714.zip",
+                     "checksum": "SHA-256:f09e022cbb1fe73315ccf16a2af6bc687b64d0c44066f801fb9dee8326e941b1",
+                     "size": "80399"
                   }
                ]
             },
             {
-               "version": "1.4.0-b-cb31b54",
+               "version": "1.4.0-c-0196c06",
                "name": "pqt-pioasm",
                "systems": [
                   {
                      "host": "aarch64-linux-gnu",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/aarch64-linux-gnu.pioasm-2062372.220619.tar.gz",
-                     "archiveFileName": "aarch64-linux-gnu.pioasm-2062372.220619.tar.gz",
-                     "checksum": "SHA-256:71887999ad64e64f75658a1883029b337cb9738d87e04944b1dbc0321d3c7a67",
-                     "size": "453580"
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/aarch64-linux-gnu.pioasm-2e6142b.220714.tar.gz",
+                     "archiveFileName": "aarch64-linux-gnu.pioasm-2e6142b.220714.tar.gz",
+                     "checksum": "SHA-256:d4ac4b39841984178babd75f5c09cad87e06bd2fb18cf04e40f561d72e604a5d",
+                     "size": "453440"
                   },
                   {
                      "host": "arm-linux-gnueabihf",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/arm-linux-gnueabihf.pioasm-2062372.220619.tar.gz",
-                     "archiveFileName": "arm-linux-gnueabihf.pioasm-2062372.220619.tar.gz",
-                     "checksum": "SHA-256:5b2e863e5764b0c4d53f536b5ea217e2a27f02f04b74da799e19b1fa6c8b39a8",
-                     "size": "360581"
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/arm-linux-gnueabihf.pioasm-2e6142b.220714.tar.gz",
+                     "archiveFileName": "arm-linux-gnueabihf.pioasm-2e6142b.220714.tar.gz",
+                     "checksum": "SHA-256:568ebdd7b1a47c6dbf45793f9bf019855a1b14182fbeb7ed7e342979c6632eef",
+                     "size": "360675"
                   },
                   {
                      "host": "i686-pc-linux-gnu",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/i686-linux-gnu.pioasm-2062372.220619.tar.gz",
-                     "archiveFileName": "i686-linux-gnu.pioasm-2062372.220619.tar.gz",
-                     "checksum": "SHA-256:fd5ec8b1940e51db6ec2e2beea73d7be7f1e9cf09f6e66d739e3ed1be177a7a6",
-                     "size": "511417"
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/i686-linux-gnu.pioasm-2e6142b.220714.tar.gz",
+                     "archiveFileName": "i686-linux-gnu.pioasm-2e6142b.220714.tar.gz",
+                     "checksum": "SHA-256:2abac2bef690f7ffadfcf74af4832bfcc0e212606efbed21b385bda0517554ef",
+                     "size": "511442"
                   },
                   {
                      "host": "i686-mingw32",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/i686-w64-mingw32.pioasm-2062372.220619.zip",
-                     "archiveFileName": "i686-w64-mingw32.pioasm-2062372.220619.zip",
-                     "checksum": "SHA-256:6a4a5f4f3c0b7a3bc08b2b3bd8111d33a5619633de9b04e03bf0bca6f17d1337",
-                     "size": "385759"
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/i686-w64-mingw32.pioasm-2e6142b.220714.zip",
+                     "archiveFileName": "i686-w64-mingw32.pioasm-2e6142b.220714.zip",
+                     "checksum": "SHA-256:0b1336b999a31d164248248d37fa550aa14a06dae8ef5b215818c5f0597ca80b",
+                     "size": "385882"
                   },
                   {
                      "host": "x86_64-apple-darwin",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/x86_64-apple-darwin14.pioasm-2062372.220619.tar.gz",
-                     "archiveFileName": "x86_64-apple-darwin14.pioasm-2062372.220619.tar.gz",
-                     "checksum": "SHA-256:9d9d7a3addaaca00712fdf5516a21fdae94926210f12f7ae16dc8ebf7beacfe8",
-                     "size": "480510"
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/x86_64-apple-darwin14.pioasm-2e6142b.220714.tar.gz",
+                     "archiveFileName": "x86_64-apple-darwin14.pioasm-2e6142b.220714.tar.gz",
+                     "checksum": "SHA-256:7057ba222a54ff9bd43a6a4232a6355100f29e0cc20d3facb5d600180f418e68",
+                     "size": "480538"
                   },
                   {
                      "host": "x86_64-pc-linux-gnu",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/x86_64-linux-gnu.pioasm-2062372.220619.tar.gz",
-                     "archiveFileName": "x86_64-linux-gnu.pioasm-2062372.220619.tar.gz",
-                     "checksum": "SHA-256:be77c350eb7777de01c93312919c370e4ef3e5e281f122f46a2348a21693c480",
-                     "size": "458738"
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/x86_64-linux-gnu.pioasm-2e6142b.220714.tar.gz",
+                     "archiveFileName": "x86_64-linux-gnu.pioasm-2e6142b.220714.tar.gz",
+                     "checksum": "SHA-256:30b367e8d2cd4ccdf151e728b4137bad1d993c42f0d640307e27d5fc55fce2c0",
+                     "size": "458691"
                   },
                   {
                      "host": "x86_64-mingw32",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/x86_64-w64-mingw32.pioasm-2062372.220619.zip",
-                     "archiveFileName": "x86_64-w64-mingw32.pioasm-2062372.220619.zip",
-                     "checksum": "SHA-256:451ad335a5cebcee3b6acda73d887a488f98c4a8839b8e98d557425f8d7f47ea",
-                     "size": "408660"
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/x86_64-w64-mingw32.pioasm-2e6142b.220714.zip",
+                     "archiveFileName": "x86_64-w64-mingw32.pioasm-2e6142b.220714.zip",
+                     "checksum": "SHA-256:b7b340862e673f9e57287f02219b2d56094a497fe9d8c451acf28aaef721e038",
+                     "size": "409101"
                   }
                ]
             },
             {
-               "version": "1.4.0-b-cb31b54",
+               "version": "1.4.0-c-0196c06",
                "name": "pqt-mklittlefs",
                "systems": [
                   {
                      "host": "aarch64-linux-gnu",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/aarch64-linux-gnu.mklittlefs-affa497.220619.tar.gz",
-                     "archiveFileName": "aarch64-linux-gnu.mklittlefs-affa497.220619.tar.gz",
-                     "checksum": "SHA-256:1752294e6cc6ce3edd8b417e773c8703a1dc4e616f158ed6c928b62bec7289b5",
-                     "size": "47286"
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/aarch64-linux-gnu.mklittlefs-affa497.220714.tar.gz",
+                     "archiveFileName": "aarch64-linux-gnu.mklittlefs-affa497.220714.tar.gz",
+                     "checksum": "SHA-256:ad0af70d568e10a9a2a74c6e0a3cf8659a47b80fbf594b01731579bc21a5c212",
+                     "size": "47287"
                   },
                   {
                      "host": "arm-linux-gnueabihf",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/arm-linux-gnueabihf.mklittlefs-affa497.220619.tar.gz",
-                     "archiveFileName": "arm-linux-gnueabihf.mklittlefs-affa497.220619.tar.gz",
-                     "checksum": "SHA-256:07e182ca15cf60d0f266030ff796ffc566c78e5e1fd148948a6ec3cbab444103",
-                     "size": "40823"
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/arm-linux-gnueabihf.mklittlefs-affa497.220714.tar.gz",
+                     "archiveFileName": "arm-linux-gnueabihf.mklittlefs-affa497.220714.tar.gz",
+                     "checksum": "SHA-256:f8f1a1dd7b02220f11cf0f6a6c88692f7e056eb245fbc41017c33d333751980e",
+                     "size": "40826"
                   },
                   {
                      "host": "i686-pc-linux-gnu",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/i686-linux-gnu.mklittlefs-affa497.220619.tar.gz",
-                     "archiveFileName": "i686-linux-gnu.mklittlefs-affa497.220619.tar.gz",
-                     "checksum": "SHA-256:774657fbfaca1793acd8461e90399de1be0e99715b9135af0b935adc40211c72",
-                     "size": "50926"
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/i686-linux-gnu.mklittlefs-affa497.220714.tar.gz",
+                     "archiveFileName": "i686-linux-gnu.mklittlefs-affa497.220714.tar.gz",
+                     "checksum": "SHA-256:4d10a2bc6a8fa41a7e5642aa30128f797f84b099e1bb2282c6c2d62a06e81e21",
+                     "size": "50925"
                   },
                   {
                      "host": "i686-mingw32",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/i686-w64-mingw32.mklittlefs-affa497.220619.zip",
-                     "archiveFileName": "i686-w64-mingw32.mklittlefs-affa497.220619.zip",
-                     "checksum": "SHA-256:473ba014d011737d97e703059cf2819d9ee2328f2af2f93f52c43eba53e34f55",
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/i686-w64-mingw32.mklittlefs-affa497.220714.zip",
+                     "archiveFileName": "i686-w64-mingw32.mklittlefs-affa497.220714.zip",
+                     "checksum": "SHA-256:71117412351ea2486848848d76f4d1e3c7a507a4d7546f6b0646bbc10c96d557",
                      "size": "334062"
                   },
                   {
                      "host": "x86_64-apple-darwin",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/x86_64-apple-darwin14.mklittlefs-affa497.220619.tar.gz",
-                     "archiveFileName": "x86_64-apple-darwin14.mklittlefs-affa497.220619.tar.gz",
-                     "checksum": "SHA-256:ffc1fef60f4c359978f6476a8cc33995638d826e4820ca96fc17f3cf47250bec",
-                     "size": "365767"
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/x86_64-apple-darwin14.mklittlefs-affa497.220714.tar.gz",
+                     "archiveFileName": "x86_64-apple-darwin14.mklittlefs-affa497.220714.tar.gz",
+                     "checksum": "SHA-256:b3d0c30f942982337cd4c0e4f70855f8eabcf1d378eac78465c7fee39ab5915f",
+                     "size": "365780"
                   },
                   {
                      "host": "x86_64-pc-linux-gnu",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/x86_64-linux-gnu.mklittlefs-affa497.220619.tar.gz",
-                     "archiveFileName": "x86_64-linux-gnu.mklittlefs-affa497.220619.tar.gz",
-                     "checksum": "SHA-256:0a05281f13ae48a1ce4894107525e7027258746c1cac3a568b51b8082f99e93f",
-                     "size": "49786"
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/x86_64-linux-gnu.mklittlefs-affa497.220714.tar.gz",
+                     "archiveFileName": "x86_64-linux-gnu.mklittlefs-affa497.220714.tar.gz",
+                     "checksum": "SHA-256:9241e8e642748048bd32c7ccf4a8200e8bc104d6e328fe7437e8727866f29d94",
+                     "size": "49787"
                   },
                   {
                      "host": "x86_64-mingw32",
-                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-b/x86_64-w64-mingw32.mklittlefs-affa497.220619.zip",
-                     "archiveFileName": "x86_64-w64-mingw32.mklittlefs-affa497.220619.zip",
-                     "checksum": "SHA-256:039981ec41f38a9c89de3466d9fd8c9e7c0723ab53798223ceb4d122fdcac914",
-                     "size": "347613"
+                     "url": "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/1.4.0-c/x86_64-w64-mingw32.mklittlefs-affa497.220714.zip",
+                     "archiveFileName": "x86_64-w64-mingw32.mklittlefs-affa497.220714.zip",
+                     "checksum": "SHA-256:2f39dd727e9cb61dbc631d00f543a99b6224fb24ffde0dff0cb2b70c9561ae69",
+                     "size": "347612"
                   }
                ]
             }


### PR DESCRIPTION
When real multicore/lockign support was added to newlib, there was an opaque
field in FILE that was used as a mutex, but was only 4 bytes in size.  The
recursive mutexes on the RP2040 are 8 bytes.  This mismatch caused corruption
of the FILE structure and crashes of the system when ::printf/::puts/etc. were
run.

Adjust the lock field size in FILE to 8 bytes and rebuild the toolchain to
fix.