### PR TITLE
Correct PlatformIO build for Pico W, add to CI

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -212,3 +212,5 @@ jobs:
       run: pio ci --board=rpipico --board=adafruit_feather -O "platform_packages=framework-arduinopico@symlink:///home/runner/work/arduino-pico/arduino-pico" libraries/rp2040/examples/Fade/Fade.ino
     - name: Build TinyUSB Example
       run: pio ci --board=rpipico --board=adafruit_feather -O "platform_packages=framework-arduinopico@symlink:///home/runner/work/arduino-pico/arduino-pico" -O "build_flags=-DUSE_TINYUSB" libraries/Adafruit_TinyUSB_Arduino/examples/CDC/cdc_multi/cdc_multi.ino
+    - name: Build WiFi Example
+      run: pio ci --board=rpipicow -O "platform_packages=framework-arduinopico@symlink:///home/runner/work/arduino-pico/arduino-pico" libraries/WiFi/examples/ScanNetworks/ScanNetworks.ino

--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -228,6 +228,15 @@ def configure_usb_flags(cpp_defines):
     board.update("build.hwids", hw_ids)
     board.update("upload.maximum_ram_size", ram_size)
 
+def configure_network_flags():
+    env.Append(CPPDEFINES=[
+        ("PICO_CYW43_ARCH_THREADSAFE_BACKGROUND", 1),
+        ("CYW43_LWIP", 0),
+        ("LWIP_IPV6", 1),
+        ("LWIP_IPV4", 1),
+        ("LWIP_IGMP", 1),
+        ("LWIP_CHECKSUM_CTRL_PER_NETIF", 1)
+    ])
 #
 # Process configuration flags
 #
@@ -246,6 +255,7 @@ if not "USE_TINYUSB" in cpp_defines:
         )
 # configure USB stuff
 configure_usb_flags(cpp_defines)
+configure_network_flags()
 
 # ensure LWIP headers are in path after any TINYUSB distributed versions, also PicoSDK USB path headers
 env.Append(CPPPATH=[os.path.join(FRAMEWORK_DIR, "include")])


### PR DESCRIPTION
Successfull compilation was prevented by missing to add the 

```
compiler.netdefines=-DPICO_CYW43_ARCH_THREADSAFE_BACKGROUND=1 -DCYW43_LWIP=0 -DLWIP_IPV6=1 -DLWIP_IPV4=1 -DLWIP_IGMP=1 -DLWIP_CHECKSUM_CTRL_PER_NETIF=1
```
flags only present in the `platform.txt` to the `platformio-build.py` (PIO does not automatically read the `platform.txt`).

Also adds the WiFi scan example to the CI with the newly added `rpipicow` board definition.