### PR TITLE
Fix PlatformIO linking for variant-specific overrides

### DIFF
--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -295,10 +295,11 @@ if variant != "":
         os.path.join(FRAMEWORK_DIR, "variants", variant)
     ])
 
-    libs.append(
-        env.BuildLibrary(
-            os.path.join("$BUILD_DIR", "FrameworkArduinoVariant"),
-            os.path.join(FRAMEWORK_DIR, "variants", variant)))
+    # link variant's source files as object files into the binary.
+    # otherwise weak function overriding won't work in the linking stage.
+    env.BuildSources(
+        os.path.join("$BUILD_DIR", "FrameworkArduinoVariant"),
+        os.path.join(FRAMEWORK_DIR, "variants", variant))
 
 libs.append(
     env.BuildLibrary(


### PR DESCRIPTION
Fixes the issue discussed in https://github.com/earlephilhower/arduino-pico/issues/66#issuecomment-1191300424.  The issue description and fix are basically the same as in https://github.com/espressif/arduino-esp32/pull/6809. 

Test case
```ini
[env:rpipicow]
platform = https://github.com/maxgerhardt/platform-raspberrypi.git
framework = arduino
board = rpipicow
board_build.core = earlephilhower
board_build.filesystem_size = 0.5m
```

Before fix: initVariant is an empty function, returns immediately (the `_weak` default)
```
> C:\Users\Max\.platformio\packages\toolchain-rp2040-earlephilhower\bin\arm-none-eabi-objdump.exe -d .\.pio\build\rpipicow\firmware.elf  | grep -A5 initVariant
100008a4 <initVariant>:
100008a4:       4770            bx      lr
```

After fix: initVariant for the RPiPico W calls into the WiFi init function
```
> C:\Users\Max\.platformio\packages\toolchain-rp2040-earlephilhower\bin\arm-none-eabi-objdump.exe -d .\.pio\build\rpipicow\firmware.elf  | grep -A5 initVariant
1000032c <initVariant>:
1000032c:       b510            push    {r4, lr}
1000032e:       f000 fc85       bl      10000c3c <cyw43_arch_init>
10000332:       bd10            pop     {r4, pc}
```