### PR TITLE
Add basic ESP32 WiFiClientSecure support

### DIFF
--- a/docs/bearssl-client-secure-class.rst
+++ b/docs/bearssl-client-secure-class.rst
@@ -1,7 +1,7 @@
 :orphan:
 
 WiFiClientSecure Class
-----------------------
+======================
 
 `BearSSL::WiFiClientSecure` is the object which actually handles TLS encrypted WiFi connections to a remote server or client.  It extends `WiFiClient` and so can be used with minimal changes to code that does unsecured communications.
 
@@ -117,3 +117,30 @@ setSSLVersion(uint32_t min, uint32_t max)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Valid values for min and max are `BR_TLS10`, `BR_TLS11`, `BR_TLS12`.  Min and max may be set to the same value if only a single TLS version is desired.
+
+
+ESP32 Compatibility
+===================
+Simple ESP32 ``WiFiClientSecure`` compatibility is built-in, allow for some sketches to run without any modification.
+The following methods are implemented:
+
+.. code :: cpp
+
+    void setCACert(const char *rootCA);
+    void setCertificate(const char *client_ca);
+    void setPrivateKey(const char *private_key);
+    bool loadCACert(Stream& stream, size_t size);
+    bool loadCertificate(Stream& stream, size_t size);
+    bool loadPrivateKey(Stream& stream, size_t size);
+    int connect(IPAddress ip, uint16_t port, int32_t timeout);
+    int connect(const char *host, uint16_t port, int32_t timeout);
+    int connect(IPAddress ip, uint16_t port, const char *rootCABuff, const char *cli_cert, const char *cli_key);
+    int connect(const char *host, uint16_t port, const char *rootCABuff, const char *cli_cert, const char *cli_key);
+
+Note that the SSL backend is very different between Arduino-Pico and ESP32-Arduino (BearSSL vs. mbedTLS).  This means
+that, for instance, the SSL connection will check valid dates of certificates (and hence require system time to be
+set on the Pico, which is automatically done in this case).
+
+TLS-Pre Shared Keys (PSK) is not supported by BearSSL, and hence not implemented here.  Neither is ALPN.
+
+For more advanced control, it is recommended to port to the native Pico calls which allows much more flexibility and control.

--- a/docs/wifintp.rst
+++ b/docs/wifintp.rst
@@ -39,3 +39,20 @@ returns a sane value before continuing a sketch:
       Serial.print("Current time: ");
       Serial.print(asctime(&timeinfo));
     }
+
+bool NTP.waitSet(uint32_t timeout)
+----------------------------------
+This call will wait up to timeout milliseconds for the time to be set, and returns
+success or failure.  It will also begin NTP with a default "pool.ntp.org" server if
+it is not already running.  Using this method, the above code becomes:
+
+.. code :: cpp
+
+    void setClock() {
+      NTP.begin("pool.ntp.org", "time.nist.gov");
+      NTP.waitSet();
+      struct tm timeinfo;
+      gmtime_r(&now, &timeinfo);
+      Serial.print("Current time: ");
+      Serial.print(asctime(&timeinfo));
+    }

--- a/libraries/WiFi/keywords.txt
+++ b/libraries/WiFi/keywords.txt
@@ -59,6 +59,7 @@ noLowPowerMode	KEYWORD2
 ping	KEYWORD2
 beginMulticast	KEYWORD2
 setTimeout	KEYWORD2
+waitSet	KEYWORD2
 
 
 #######################################

--- a/libraries/WiFi/src/WiFiClientSecure.h
+++ b/libraries/WiFi/src/WiFiClientSecure.h
@@ -19,6 +19,7 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 
 */
+#include "WiFi.h"
 #include "WiFiClient.h"
 #include "WiFiClientSecureBearSSL.h"
 

--- a/libraries/WiFi/src/WiFiNTP.h
+++ b/libraries/WiFi/src/WiFiNTP.h
@@ -20,6 +20,7 @@
 #pragma once
 
 #include <Arduino.h>
+#include <time.h>
 #include <lwip/apps/sntp.h>
 
 class NTPClass {
@@ -37,6 +38,7 @@ public:
             sntp_setserver(0, server);
             sntp_setoperatingmode(SNTP_OPMODE_POLL);
             sntp_init();
+            _running = true;
         }
     }
 
@@ -51,15 +53,17 @@ public:
         }
         sntp_setoperatingmode(SNTP_OPMODE_POLL);
         sntp_init();
+        _running = true;
     }
-
 
     void begin(const char *server, int timeout = 3600) {
         IPAddress addr;
         if (WiFi.hostByName(server, addr)) {
             begin(addr, timeout);
         }
+        _running = true;
     }
+
     void begin(const char *s1, const char *s2, int timeout = 3600) {
         IPAddress a1, a2;
         if (WiFi.hostByName(s1, a1)) {
@@ -69,7 +73,26 @@ public:
                 begin(a1, timeout);
             }
         }
+        _running = true;
     }
+
+    bool waitSet(uint32_t timeout = 10000) {
+        if (!running()) {
+            begin("pool.ntp.org");
+        }
+        uint32_t start = millis();
+        while ((time(nullptr) < 10000000) && (millis() - start < timeout)) {
+            delay(10);
+        }
+        return time(nullptr) < 10000000;
+    }
+
+    bool running() {
+        return _running;
+    }
+
+private:
+    bool _running = false;
 };
 
 // ESP8266 compat

--- a/libraries/WiFi/src/include/ClientContext.h
+++ b/libraries/WiFi/src/include/ClientContext.h
@@ -187,6 +187,10 @@ public:
     }
 
     void setTimeout(int timeout_ms) {
+        if (timeout_ms < 100) {
+            // Crude logic to allow for seconds or milliseconds to work.  Timeouts of < 100ms don't make much sense, so assume the user meant seconds, not milliseconds
+            timeout_ms *= 1000;
+        }
         _timeout_ms = timeout_ms;
     }
 


### PR DESCRIPTION
Simple sketches should work without modification, but some modes (listed
in the docs) are not possible to support on the Pico W with BearSSL.

Fixes #691