### PR TITLE
Fix UART wrong ::available() during wraparound

### DIFF
--- a/cores/rp2040/SerialUART.cpp
+++ b/cores/rp2040/SerialUART.cpp
@@ -292,7 +292,7 @@ int SerialUART::available() {
     } else {
         _pumpFIFO();
     }
-    return (_writer - _reader) % _fifoSize;
+    return (_fifoSize + _writer - _reader) % _fifoSize;
 }
 
 int SerialUART::availableForWrite() {


### PR DESCRIPTION
Fixes #735 .  Thanks to @ Haggarman for the find and fix.