### PR TITLE
Fix sending of IPv6 UDP packets

### DIFF
--- a/libraries/WiFi/src/include/UdpContext.h
+++ b/libraries/WiFi/src/include/UdpContext.h
@@ -50,6 +50,11 @@ public:
         , _tx_buf_cur(0)
         , _tx_buf_offset(0) {
         _pcb = udp_new();
+#if LWIP_IPV6
+        // local_ip defaults to 0.0.0.0
+        // which is problematic for sending IPv6 packets
+        ip_addr_set_ipaddr(&_pcb->local_ip, IP_ANY_TYPE);
+#endif
 #ifdef LWIP_MAYBE_XCC
         _mcast_ttl = 1;
 #endif


### PR DESCRIPTION
Attempting to send UDP packets to IPv6 addresses resulted in `ERR_VAL` (-6) due to the `IP_ADDR_PCB_VERSION_MATCH(pcb, dst_ip)` check failing because `local_ip` defaults to the IPv4 address `0.0.0.0`