### PR TITLE
Increase FreeRTOS timer task stack to 1024

### DIFF
--- a/libraries/FreeRTOS/src/FreeRTOSConfig.h
+++ b/libraries/FreeRTOS/src/FreeRTOSConfig.h
@@ -49,7 +49,7 @@ unsigned long ulMainGetRunTimeCounterValue( void );
 #define configUSE_TIMERS				1
 #define configTIMER_TASK_PRIORITY		( 2 )
 #define configTIMER_QUEUE_LENGTH		5
-#define configTIMER_TASK_STACK_DEPTH	( 80 )
+#define configTIMER_TASK_STACK_DEPTH	( 1024 )
 
 /* Set the following definitions to 1 to include the API function, or zero
 to exclude the API function. */


### PR DESCRIPTION
PR to fix issue #751 FreeRTOS : configTIMER_TASK_STACK_DEPTH is too low which is causing system hang
Original value of configTIMER_TASK_STACK_DEPTH is 80 which is too low.
Proposal is to increase to 1024.