### PR TITLE
Don't return from reboot

### DIFF
--- a/cores/rp2040/RP2040Support.h
+++ b/cores/rp2040/RP2040Support.h
@@ -314,7 +314,10 @@ public:
     }
 
     void reboot() {
-        watchdog_reboot(0, 0, 100);
+        watchdog_reboot(0, 0, 10);
+        while (1) {
+            continue;
+        }
     }
 
     inline void restart() {


### PR DESCRIPTION
rp2040.reboot() would set a reboot timer for 100ms in the future, but then
return to user code and doing stuff until the timer expired.  Now wait
until the WDT fire.