### PR TITLE
Report ::connected() as false when WiFi link drops

### DIFF
--- a/cores/rp2040/sdkoverride/cyw43_arch_threadsafe_background.c
+++ b/cores/rp2040/sdkoverride/cyw43_arch_threadsafe_background.c
@@ -36,7 +36,6 @@
 #define CYW43_WL_GPIO_LED_PIN 0
 #endif
 
-
 volatile bool __inLWIP = false;
 
 // note same code

--- a/libraries/Updater/src/Updater.cpp
+++ b/libraries/Updater/src/Updater.cpp
@@ -25,8 +25,6 @@
 #include <hardware/flash.h>
 #include <PicoOTA.h>
 
-#define DEBUG_UPDATER Serial
-
 #include <Updater_Signing.h>
 #ifndef ARDUINO_SIGNING
 #define ARDUINO_SIGNING 0

--- a/libraries/WiFi/src/WiFiClass.cpp
+++ b/libraries/WiFi/src/WiFiClass.cpp
@@ -96,6 +96,8 @@ int WiFiClass::begin(const char* ssid, const char *passphrase) {
     if (!_wifi.begin()) {
         return WL_IDLE_STATUS;
     }
+    // Enable CYW43 event debugging (make sure Debug Port is set)
+    //cyw43_state.trace_flags = 0xffff;
     while (!_calledESP && ((millis() - start < (uint32_t)2 * _timeout)) && !connected()) {
         delay(10);
     }
@@ -152,7 +154,7 @@ uint8_t WiFiClass::beginAP(const char *ssid, const char* passphrase) {
 #endif
 
 bool WiFiClass::connected() {
-    return (_apMode && _wifiHWInitted) || (_wifi.connected() && localIP().isSet());
+    return (_apMode && _wifiHWInitted) || (_wifi.connected() && localIP().isSet() && (cyw43_wifi_link_status(&cyw43_state, _apMode ? 1 : 0) == CYW43_LINK_JOIN));
 }
 
 /*  Change Ip configuration settings disabling the dhcp client

--- a/libraries/WiFi/src/WiFiMulti.cpp
+++ b/libraries/WiFi/src/WiFiMulti.cpp
@@ -37,6 +37,9 @@ WiFiMulti::~WiFiMulti() {
 
 bool WiFiMulti::addAP(const char *ssid, const char *pass) {
     struct _AP ap;
+    if (!ssid) {
+        return false;
+    }
     ap.ssid = strdup(ssid);
     if (!ap.ssid) {
         return false;
@@ -82,7 +85,11 @@ uint8_t WiFiMulti::run(uint32_t to) {
 
     // Connect!
     uint32_t start = millis();
-    WiFi.begin(hit->ssid, hit->pass);
+    if (hit->pass) {
+        WiFi.begin(hit->ssid, hit->pass);
+    } else {
+        WiFi.begin(hit->ssid);
+    }
     while (!WiFi.connected() && (millis() - start < to)) {
         delay(5);
     }

--- a/libraries/lwIP_CYW43/src/utility/CYW43shim.cpp
+++ b/libraries/lwIP_CYW43/src/utility/CYW43shim.cpp
@@ -26,6 +26,18 @@ extern "C" {
 #include "pico/cyw43_arch.h"
 #include <Arduino.h>
 
+// From cyw43_ctrl.c
+#define WIFI_JOIN_STATE_KIND_MASK (0x000f)
+#define WIFI_JOIN_STATE_ACTIVE  (0x0001)
+#define WIFI_JOIN_STATE_FAIL    (0x0002)
+#define WIFI_JOIN_STATE_NONET   (0x0003)
+#define WIFI_JOIN_STATE_BADAUTH (0x0004)
+#define WIFI_JOIN_STATE_AUTH    (0x0200)
+#define WIFI_JOIN_STATE_LINK    (0x0400)
+#define WIFI_JOIN_STATE_KEYED   (0x0800)
+#define WIFI_JOIN_STATE_ALL     (0x0e01)
+
+
 netif *CYW43::_netif = nullptr;
 
 CYW43::CYW43(int8_t cs, arduino::SPIClass& spi, int8_t intrpin) {
@@ -124,6 +136,7 @@ extern "C" void cyw43_cb_tcpip_set_link_down(cyw43_t *self, int itf) {
     if (CYW43::_netif) {
         netif_set_link_down(CYW43::_netif);
     }
+    self->wifi_join_state &= ~WIFI_JOIN_STATE_ACTIVE;
 }
 
 extern "C" int cyw43_tcpip_link_status(cyw43_t *self, int itf) {


### PR DESCRIPTION
There may be an issue in the CYW43 driver that causes a link to never be
reported as going down once it has connected, when it was disassociated or
when the wlan shuts off unexpectedly.

Work around it by clearing the internal link active in a TCP callback for
the CYW43 driver.

Reports disconnection properly now, as well as reconnection.

Fixes #762