### PR TITLE
Avoid rescanning/connecting on WiFiMulti.run

### DIFF
--- a/libraries/WiFi/src/WiFiMulti.cpp
+++ b/libraries/WiFi/src/WiFiMulti.cpp
@@ -58,6 +58,12 @@ bool WiFiMulti::addAP(const char *ssid, const char *pass) {
 }
 
 uint8_t WiFiMulti::run(uint32_t to) {
+
+    // If we're already connected, don't re-scan/etc.
+    if (WiFi.status() == WL_CONNECTED) {
+        return WL_CONNECTED;
+    }
+
     int cnt = WiFi.scanNetworks();
     if (!cnt) {
         return WL_DISCONNECTED;


### PR DESCRIPTION
If the WiFi network is already up, don't run the scan and connection
algorithm in WiFiMulti.