### PR TITLE
Fix OTA signing

### DIFF
--- a/libraries/Updater/src/Updater.cpp
+++ b/libraries/Updater/src/Updater.cpp
@@ -198,7 +198,7 @@ bool UpdaterClass::end(bool evenIfRemaining) {
 
         int binSize = _size;
         if (expectedSigLen > 0) {
-            _size -= (sigLen + sizeof(uint32_t) /* The siglen word */);
+            binSize -= (sigLen + sizeof(uint32_t) /* The siglen word */);
         }
         _hash->begin();
 #ifdef DEBUG_UPDATER

--- a/platform.txt
+++ b/platform.txt
@@ -110,7 +110,7 @@ recipe.hooks.sketch.prebuild.pattern="{runtime.tools.pqt-python3.path}/python3" 
 recipe.c.o.pattern="{compiler.path}{compiler.c.cmd}" {compiler.c.flags} {build.usbpid} {build.usbpwr} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DBOARD_NAME="{build.board}" -DARDUINO_ARCH_{build.arch} {compiler.c.extra_flags} {build.extra_flags} {build.debug_port} {build.debug_level} {build.flags.optimize} {includes} "{source_file}" -o "{object_file}"
 
 ## Compile c++ files
-recipe.cpp.o.pattern="{compiler.path}{compiler.cpp.cmd}" {compiler.cpp.flags} {build.usbpid} {build.usbpwr} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DBOARD_NAME="{build.board}" -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {build.debug_port} {build.debug_level} {build.flags.optimize} {includes} "{source_file}" -o "{object_file}"
+recipe.cpp.o.pattern="{compiler.path}{compiler.cpp.cmd}" -I "{build.path}/core" {compiler.cpp.flags} {build.usbpid} {build.usbpwr} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DBOARD_NAME="{build.board}" -DARDUINO_ARCH_{build.arch} {compiler.cpp.extra_flags} {build.extra_flags} {build.debug_port} {build.debug_level} {build.flags.optimize} {includes} "{source_file}" -o "{object_file}"
 
 ## Compile S files
 recipe.S.o.pattern="{compiler.path}{compiler.S.cmd}" {compiler.S.flags} {build.usbpid} {build.usbpwr} -DF_CPU={build.f_cpu} -DARDUINO={runtime.ide.version} -DARDUINO_{build.board} -DBOARD_NAME="{build.board}" -DARDUINO_ARCH_{build.arch} {compiler.S.extra_flags} {build.extra_flags} {build.debug_port} {build.debug_level} {includes} "{source_file}" -o "{object_file}"


### PR DESCRIPTION
Force the builder to include the path where we build the signing header.

Undo a breaking bug in the Updater class (TBD fix in ESP8266)

Fixes #783