### PR TITLE
Ensure OTA errors are sent in single UDP packet

### DIFF
--- a/libraries/ArduinoOTA/src/ArduinoOTA.cpp
+++ b/libraries/ArduinoOTA/src/ArduinoOTA.cpp
@@ -248,7 +248,7 @@ void ArduinoOTAClass::_runUpdate() {
         OTA_DEBUG.println("LittleFS Begin Error");
 #endif
         _udp_ota->append("ERR: ", 5);
-        _udp_ota->append("no filesystem", 13);
+        _udp_ota->append("No Filesystem", 13);
         _udp_ota->send(ota_ip, _ota_udp_port);
         delay(100);
         _udp_ota->listen(IP_ADDR_ANY, _port);

--- a/libraries/Updater/src/Updater.cpp
+++ b/libraries/Updater/src/Updater.cpp
@@ -412,30 +412,37 @@ void UpdaterClass::_setError(int error) {
 }
 
 void UpdaterClass::printError(Print &out) {
-    out.printf_P(PSTR("ERROR[%u]: "), _error);
+    String err;
+    err = "ERROR[";
+    err += _error;
+    err += "]: ";
     if (_error == UPDATE_ERROR_OK) {
-        out.println(F("No Error"));
+        err += "No Error";
     } else if (_error == UPDATE_ERROR_WRITE) {
-        out.println(F("Flash Write Failed"));
+        err += "Flash Write Failed";
     } else if (_error == UPDATE_ERROR_ERASE) {
-        out.println(F("Flash Erase Failed"));
+        err += "Flash Erase Failed";
     } else if (_error == UPDATE_ERROR_READ) {
-        out.println(F("Flash Read Failed"));
+        err += "Flash Read Failed";
     } else if (_error == UPDATE_ERROR_SPACE) {
-        out.println(F("Not Enough Space"));
+        err += "Not Enough Space";
     } else if (_error == UPDATE_ERROR_SIZE) {
-        out.println(F("Bad Size Given"));
+        err += "Bad Size Given";
     } else if (_error == UPDATE_ERROR_STREAM) {
-        out.println(F("Stream Read Timeout"));
+        err += "Stream Read Timeout";
     } else if (_error == UPDATE_ERROR_NO_DATA) {
-        out.println(F("No data supplied"));
+        err += "No data supplied";
     } else if (_error == UPDATE_ERROR_MD5) {
-        out.printf_P(PSTR("MD5 Failed: expected:%s, calculated:%s\n"), _target_md5.c_str(), _md5.toString().c_str());
+        err += "MD5 Failed: expected:";
+        err += _target_md5.c_str();
+        err += " calculated:";
+        err += _md5.toString();
     } else if (_error == UPDATE_ERROR_SIGN) {
-        out.println(F("Signature verification failed"));
+        err += "Signature verification failed";
     } else {
-        out.println(F("UNKNOWN"));
+        err += "UNKNOWN";
     }
+    out.println(err.c_str());
 }
 
 UpdaterClass Update;


### PR DESCRIPTION
OTA text error messages were getting lost because they were sent in
multiple UDP packets, one per print(). Now collect the full error and
report in a single print, allowing text messages to appear in ESPOTA.