### PR TITLE
Avoid potential lockup w/Serial.read unconnected

### DIFF
--- a/cores/rp2040/SerialUSB.cpp
+++ b/cores/rp2040/SerialUSB.cpp
@@ -79,7 +79,7 @@ int SerialUSB::read() {
         return -1;
     }
 
-    if (tud_cdc_connected() && tud_cdc_available()) {
+    if (tud_cdc_available()) {
         return tud_cdc_read_char();
     }
     return -1;


### PR DESCRIPTION
Fixes #816

If a byte is available, return it even if the USB stack reports
disconnected.