### PR TITLE
Make USB, UART, SPI, and I2C objects non-copyable

### DIFF
--- a/cores/rp2040/SerialUART.h
+++ b/cores/rp2040/SerialUART.h
@@ -66,6 +66,10 @@ public:
     // Not to be called by users, only from the IRQ handler.  In public so that the C-language IQR callback can access it
     void _handleIRQ(bool inIRQ = true);
 
+    // Disallow copy or move, this object corresponds to a specific hardware device
+    SerialUART(const SerialUART&) = delete;
+    SerialUART& operator=(const SerialUART&) = delete;
+
 private:
     bool _running = false;
     uart_inst_t *_uart;

--- a/cores/rp2040/SerialUSB.h
+++ b/cores/rp2040/SerialUSB.h
@@ -44,6 +44,10 @@ public:
     using Print::write;
     operator bool() override;
 
+    // Disallow copy or move, this object corresponds to a specific hardware device
+    SerialUSB(const SerialUSB&) = delete;
+    SerialUSB& operator=(const SerialUSB&) = delete;
+
 private:
     bool _running = false;
 };

--- a/libraries/SPI/src/SPI.h
+++ b/libraries/SPI/src/SPI.h
@@ -70,6 +70,10 @@ public:
     virtual void attachInterrupt() override { /* noop */ }
     virtual void detachInterrupt() override { /* noop */ }
 
+    // Disallow copy or move, this object corresponds to a specific hardware device
+    SPIClassRP2040(const SPIClassRP2040&) = delete;
+    SPIClassRP2040& operator=(const SPIClassRP2040&) = delete;
+
 private:
     spi_cpol_t cpol();
     spi_cpha_t cpha();

--- a/libraries/Wire/src/Wire.h
+++ b/libraries/Wire/src/Wire.h
@@ -85,6 +85,10 @@ public:
     // IRQ callback
     void onIRQ();
 
+    // Disallow copy or move, this object corresponds to a specific hardware device
+    TwoWire(const TwoWire&) = delete;
+    TwoWire& operator=(const TwoWire&) = delete;
+
 private:
     i2c_inst_t *_i2c;
     pin_size_t _sda;


### PR DESCRIPTION
Objects that correspond to a single physical device shouldn't be copyable
as their states could end up becoming completely confused if the copy
changes them and the main global object is used later on.

Avoid it by removing the copy and copy move constructors of the
SPI, SerialUSB, SerialUART, and Wire objects.

This mirrors the Arduino MBED core (which uses template NonCopyable<>)