### PR TITLE
Use pipes between GCC stages

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -49,13 +49,13 @@ compiler.wrap="@{runtime.platform.path}/lib/platform_wrap.txt"
 compiler.libbearssl="{runtime.platform.path}/lib/libbearssl.a"
 
 compiler.c.cmd=arm-none-eabi-gcc
-compiler.c.flags=-c {compiler.warning_flags} {compiler.defines} {compiler.flags} -MMD {compiler.includes} -std=gnu17 -g
+compiler.c.flags=-c {compiler.warning_flags} {compiler.defines} {compiler.flags} -MMD {compiler.includes} -std=gnu17 -g -pipe
 compiler.c.elf.cmd=arm-none-eabi-g++
 compiler.c.elf.flags={compiler.warning_flags} {compiler.defines} {compiler.flags} {build.flags.optimize} -u _printf_float -u _scanf_float
 compiler.S.cmd=arm-none-eabi-gcc
 compiler.S.flags=-c {compiler.warning_flags} -g -x assembler-with-cpp -MMD {compiler.includes} -g {build.flags.cmsis}
 compiler.cpp.cmd=arm-none-eabi-g++
-compiler.cpp.flags=-c {compiler.warning_flags} {compiler.defines} {compiler.flags} -MMD {compiler.includes} {build.flags.rtti} -std=gnu++17 -g
+compiler.cpp.flags=-c {compiler.warning_flags} {compiler.defines} {compiler.flags} -MMD {compiler.includes} {build.flags.rtti} -std=gnu++17 -g -pipe
 
 compiler.ar.cmd=arm-none-eabi-ar
 compiler.ar.flags=rcs


### PR DESCRIPTION
Should speed builds up slightly, depending on the OS and virus scanning.