### PR TITLE
Remove redirects to ArduinoCore-API files

### DIFF
--- a/cores/rp2040/Client.h
+++ b/cores/rp2040/Client.h
@@ -1,1 +1,0 @@
-#include "api/Client.h"

--- a/cores/rp2040/HardwareSerial.h
+++ b/cores/rp2040/HardwareSerial.h
@@ -1,1 +1,0 @@
-#include "api/HardwareSerial.h"

--- a/cores/rp2040/IPAddress.h
+++ b/cores/rp2040/IPAddress.h
@@ -1,1 +1,0 @@
-#include "api/IPAddress.h"

--- a/cores/rp2040/Interrupts.h
+++ b/cores/rp2040/Interrupts.h
@@ -1,1 +1,0 @@
-#include "api/Interrupts.h"

--- a/cores/rp2040/Print.h
+++ b/cores/rp2040/Print.h
@@ -1,1 +1,0 @@
-#include "api/Print.h"

--- a/cores/rp2040/Printable.h
+++ b/cores/rp2040/Printable.h
@@ -1,1 +1,0 @@
-#include "api/Printable.h"

--- a/cores/rp2040/Server.h
+++ b/cores/rp2040/Server.h
@@ -1,1 +1,0 @@
-#include "api/Server.h"

--- a/cores/rp2040/Stream.h
+++ b/cores/rp2040/Stream.h
@@ -1,1 +1,0 @@
-#include "api/Stream.h"

--- a/cores/rp2040/Udp.h
+++ b/cores/rp2040/Udp.h
@@ -1,1 +1,0 @@
-#include "api/Udp.h"

--- a/lib/platform_inc.txt
+++ b/lib/platform_inc.txt
@@ -1,6 +1,7 @@
--iwithprefixbefore/cores/rp2040/api/deprecated-avr-comp/
--iwithprefixbefore/include/pico_base/
--iwithprefixbefore/pico-sdk/lib/tinyusb/src/
+-iwithprefixbefore/cores/rp2040/api
+-iwithprefixbefore/cores/rp2040/api/deprecated-avr-comp
+-iwithprefixbefore/include/pico_base
+-iwithprefixbefore/pico-sdk/lib/tinyusb/src
 -iwithprefixbefore/pico-sdk/src/boards/include
 -iwithprefixbefore/pico-sdk/src/common/pico_base/include
 -iwithprefixbefore/pico-sdk/src/common/pico_binary_info/include


### PR DESCRIPTION
Use the platform_instead.