### PR TITLE
Update I2S.cpp

### DIFF
--- a/libraries/I2S/src/I2S.cpp
+++ b/libraries/I2S/src/I2S.cpp
@@ -217,6 +217,7 @@ size_t I2S::_writeNatural(int32_t s) {
     case 16:
         _holdWord |= s & 0xffff;
         if (_wasHolding) {
+            _holdWord = _holdWord<<1;
             auto ret = write(_holdWord, true);
             _holdWord = 0;
             _wasHolding = 0;


### PR DESCRIPTION
I found that there is a bug in this I2S driver, all data will be shifted to the right by one bit when writing.Stereo audio files cannot be played using this I2S driver. Through the logic analyzer, we can see that the transmitted data has changed.And I compared the I2S timing of playing the same audio file with ESP32. They are different. The level inversion of BCLK and WCLK of ESP32 is time difference, but RP2040 does not.There is also a problem with reading data using this I2S driver, the data for the right channel is always incorrect.I checked the I2S timing with a logic analyzer and found that the problem seems to be related to the shifting of the PIO. Logic analysis prompt “The initial (idle) state of the CLK line does not match the settings”.