### PR TITLE
Add WDT and sleep functions to RP2040 Helper

### DIFF
--- a/cores/rp2040/RP2040Support.h
+++ b/cores/rp2040/RP2040Support.h
@@ -319,7 +319,7 @@ public:
     }
 
     void wdt_reset() {
-        watchdog_reset();
+        watchdog_reboot();
     }
 
     const char *getChipID() {

--- a/cores/rp2040/RP2040Support.h
+++ b/cores/rp2040/RP2040Support.h
@@ -319,7 +319,7 @@ public:
     }
 
     void wdt_reset() {
-        watchdog_reboot();
+        watchdog_update();
     }
 
     const char *getChipID() {

--- a/cores/rp2040/RP2040Support.h
+++ b/cores/rp2040/RP2040Support.h
@@ -28,6 +28,7 @@
 #include <hardware/structs/systick.h>
 #include <pico/multicore.h>
 #include <pico/util/queue.h>
+#include <pico/sleep.h>
 #include "CoreMutex.h"
 #include "ccount.pio.h"
 #include <malloc.h>
@@ -312,6 +313,18 @@ public:
 
     inline void restart() {
         reboot();
+    }
+
+    void wdt_begin(uint32_t delay_ms) {
+        watchdog_enable(delay_ms, 1);
+    }
+
+    void wdt_reset() {
+        watchdog_reset();
+    }
+
+    void sleep_until_ms(uint32_t ms) {
+        sleep_ms(ms);
     }
 
     const char *getChipID() {

--- a/cores/rp2040/RP2040Support.h
+++ b/cores/rp2040/RP2040Support.h
@@ -28,7 +28,6 @@
 #include <hardware/structs/systick.h>
 #include <pico/multicore.h>
 #include <pico/util/queue.h>
-#include <pico/sleep.h>
 #include "CoreMutex.h"
 #include "ccount.pio.h"
 #include <malloc.h>
@@ -321,10 +320,6 @@ public:
 
     void wdt_reset() {
         watchdog_reset();
-    }
-
-    void sleep_until_ms(uint32_t ms) {
-        sleep_ms(ms);
     }
 
     const char *getChipID() {

--- a/docs/rp2040.rst
+++ b/docs/rp2040.rst
@@ -37,6 +37,25 @@ void rp2040.reboot()
 ~~~~~~~~~~~~~~~~~~~~
 Forces a hardware reboot of the Pico.
 
+void rp2040.sleep_until_ms(uint32_t ms)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Performs a low power sleep (WFE) for
+a desired amount of time, in ms.
+
+Hardware Watchdog
+_________________
+
+void rp2040.wdt_begin(uint32_t delay_ms)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Enables the hardware watchdog timer with a delay value of delay_ms
+microseconds. Note that on the RP2040, once this function has called, the
+hardware watchdog can _not_ be disabled.
+
+void rp2040.wdt_reset()
+~~~~~~~~~~~~~~~~
+Reloads the watchdog's counter with the amount of time set by wdt_begin.
+
+
 Memory Information
 ------------------
 

--- a/docs/rp2040.rst
+++ b/docs/rp2040.rst
@@ -37,11 +37,6 @@ void rp2040.reboot()
 ~~~~~~~~~~~~~~~~~~~~
 Forces a hardware reboot of the Pico.
 
-void rp2040.sleep_until_ms(uint32_t ms)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Performs a low power sleep (WFE) for
-a desired amount of time, in ms.
-
 Hardware Watchdog
 _________________
 


### PR DESCRIPTION
Addresses and resolves https://github.com/earlephilhower/arduino-pico/issues/861 by adding two function helpers for basic hardware watchdog access and one function for entering low-power sleep (WFE) mode.

cc @earlephilhower 