### PR TITLE
Clear LWIP started flag on LWIPIntfDev::end

### DIFF
--- a/libraries/lwIP_Ethernet/src/LwipIntfDev.h
+++ b/libraries/lwIP_Ethernet/src/LwipIntfDev.h
@@ -408,6 +408,7 @@ void LwipIntfDev<RawDev>::end() {
     RawDev::end();
     netif_remove(&_netif);
     memset(&_netif, 0, sizeof(_netif));
+    _started = false;
 }
 
 


### PR DESCRIPTION
When moving between different modes or even WiFi.begin/ends, any setting of the IPs will fail because the internal flag _started was not cleared. Clear _started on a ::end call.

Fixes #884