### PR TITLE
Properly disable Ethernet IRQ, don't drop packets

### DIFF
--- a/cores/rp2040/sdkoverride/cyw43_arch_threadsafe_background.c
+++ b/cores/rp2040/sdkoverride/cyw43_arch_threadsafe_background.c
@@ -145,7 +145,7 @@ static void gpio_irq_handler(void) {
 static void low_priority_irq_handler(void) {
     assert(cyw43_core_num == get_core_num());
     if (recursive_mutex_try_enter(&cyw43_mutex, NULL)) {
-        if (recursive_mutex_enter_count(&cyw43_mutex) != 1) {
+        if (__inLWIP || (recursive_mutex_enter_count(&cyw43_mutex) != 1)) {
             low_priority_irq_missed = true;
             CYW43_STAT_INC(PENDSV_DISABLED_COUNT);
         } else {


### PR DESCRIPTION
Fix #944