### PR TITLE
tools: makeboards.py: Allow disabling USB stack

### DIFF
--- a/tools/makeboards.py
+++ b/tools/makeboards.py
@@ -217,10 +217,10 @@ def MakeBoard(name, vendor_name, product_name, vid, pid, pwr, boarddefine, flash
         BuildExceptions(n)
         BuildDebugPort(n)
         BuildDebugLevel(n)
-        if a == "picodebug":
-            BuildWithoutUSBStack(n)
-        else:
+        if a != "picodebug":
             BuildUSBStack(n)
+        if a != "picoprobe":
+            BuildWithoutUSBStack(n)
         if name == "rpipicow":
             BuildCountry(n)
         BuildIPStack(n)


### PR DESCRIPTION
RP2040 supports USB but it's not granted that everyone wants to actually enable it on "regular" builds: allow building without USB support when unneeded to allow saving a few bytes of RAM.

------------------------------------------

I'm proposing this change because my project (having 3 round SPI displays, using 3 UARTs and, fun fact, leaves only one single free GPIO on my busy Pi Pico board) really needs every last byte of RAM that I can get and the only reason why I would ever need USB is to flash the board through the bootloader.

P.S.: That project is going to be open source, currently 90% complete, I'll publish the code somewhere when it reaches 100% completion :))

Cheers!