### PR TITLE
Fix memcpy to unallocated memory in EEPROM.cpp

### DIFF
--- a/libraries/EEPROM/src/EEPROM.cpp
+++ b/libraries/EEPROM/src/EEPROM.cpp
@@ -54,7 +54,7 @@ void EEPROMClass::begin(size_t size) {
     } else if (!_data) {
         _data = new uint8_t[size];
     }
-    
+
     _size = size;
 
     memcpy(_data, _sector, _size);

--- a/libraries/EEPROM/src/EEPROM.cpp
+++ b/libraries/EEPROM/src/EEPROM.cpp
@@ -45,7 +45,7 @@ void EEPROMClass::begin(size_t size) {
         size = 4096;
     }
 
-    _size = (size + 255) & (~255);  // Flash writes limited to 256 byte boundaries
+    size = (size + 255) & (~255);  // Flash writes limited to 256 byte boundaries
 
     // In case begin() is called a 2nd+ time, don't reallocate if size is the same
     if (_data && size != _size) {
@@ -54,6 +54,8 @@ void EEPROMClass::begin(size_t size) {
     } else if (!_data) {
         _data = new uint8_t[size];
     }
+    
+    _size = size;
 
     memcpy(_data, _sector, _size);
 


### PR DESCRIPTION
The memcpy to unallocated memory in EEPROMClass::begin() was done in two cases: 
1) The 'size' parameter was not multiple of 256.
2) The begin() was called two times and the 2nd call 'size' was greater than 1st time 'size'. (e.g. 1st size=256, 2nd size=512)

This simple change fixes both of them.