### PR TITLE
Using NO_USB definition would make rp2040 fifo uninitialized

### DIFF
--- a/cores/rp2040/main.cpp
+++ b/cores/rp2040/main.cpp
@@ -125,7 +125,6 @@ extern "C" int main() {
     }
 #endif
 
-#ifndef NO_USB
     if (!__isFreeRTOS) {
         if (setup1 || loop1) {
             rp2040.fifo.begin(2);
@@ -134,7 +133,6 @@ extern "C" int main() {
         }
         rp2040.fifo.registerCore();
     }
-#endif
 
     if (!__isFreeRTOS) {
         if (setup1 || loop1) {


### PR DESCRIPTION
Using PIO_FRAMEWORK_ARDUINO_NO_USB build flag would cause internal rp2040 fifo not being initialized correct.