### PR TITLE
pluggable_discovery: Allow the scanner thread to quit

### DIFF
--- a/tools/pluggable_discovery.py
+++ b/tools/pluggable_discovery.py
@@ -54,6 +54,7 @@ def scanner():
     scannerGo = True
 
 def main():
+    global scannerGo
     while True:
         cmdline = input()
         cmd = cmdline.split()[0]


### PR DESCRIPTION
When receiving a `QUIT` message, the main thread was trying to tell    the scanner thread to quit - however, what it was actually doing was creating a local variable that shadowed the global flag used by the scanner thread. Fix that by ensuring that the main thread uses the global variable instead.

Fixes #1028