### PR TITLE
Throw away UART bytes with errors in reception

### DIFF
--- a/cores/rp2040/SerialUART.cpp
+++ b/cores/rp2040/SerialUART.cpp
@@ -390,7 +390,12 @@ void __not_in_flash_func(SerialUART::_handleIRQ)(bool inIRQ) {
     // ICR is write-to-clear
     uart_get_hw(_uart)->icr = UART_UARTICR_RTIC_BITS | UART_UARTICR_RXIC_BITS;
     while (uart_is_readable(_uart)) {
-        auto val = uart_getc(_uart);
+        uint32_t raw = uart_get_hw(_uart)->dr;
+        if (raw & 0x700) {
+            // Framing, Parity, or Break.  Ignore this bad char
+            continue;
+        }
+        uint8_t val = raw & 0xff;
         auto next_writer = _writer + 1;
         if (next_writer == _fifoSize) {
             next_writer = 0;


### PR DESCRIPTION
Fixes #1021

The UART hardware will push characters into the receive FIFO even if there are parity, framing, or other errors.  These are invalid and shouldn't be returned to the application, so drop them if errors detected.

This will also avoid the glitch-induced initial garbage character.