### PR TITLE
Increase WiFi.begin() default timeout to 15s

### DIFF
--- a/libraries/WiFi/src/WiFiClass.h
+++ b/libraries/WiFi/src/WiFiClass.h
@@ -381,7 +381,7 @@ public:
     void feedWatchdog();
 
 private:
-    int _timeout = 10000;
+    int _timeout = 15000;
     String _ssid;
     String _password;
     bool _wifiHWInitted = false;


### PR DESCRIPTION
Fixes #1031, or at least covers the case of slower associations.