### PR TITLE
Increase ClientContext write(Stream) to 256b chunk

### DIFF
--- a/libraries/WiFi/src/include/ClientContext.h
+++ b/libraries/WiFi/src/include/ClientContext.h
@@ -374,7 +374,7 @@ public:
             return 0;
         }
         size_t sent = 0;
-        uint8_t buff[128];
+        uint8_t buff[256];
         while (stream.available()) {
             // Stream only lets you read 1 byte at a time, so buffer in local copy
             size_t i;


### PR DESCRIPTION
Other parts of the core use temp 256 byte chunks to transmit/move/operate on data, so do the same here.  Will increase effective WebServer sendFile speeds.