### PR TITLE
Fix I2s::available() to skip currently playing

### DIFF
--- a/libraries/I2S/src/AudioRingBuffer.cpp
+++ b/libraries/I2S/src/AudioRingBuffer.cpp
@@ -215,7 +215,10 @@ int AudioRingBuffer::available() {
     }
     int avail;
     avail = _wordsPerBuffer - _userOff;
-    avail += ((_bufferCount + _curBuffer - _userBuffer) % _bufferCount) * _wordsPerBuffer;
+    avail += ((_bufferCount + _curBuffer - _userBuffer) % _bufferCount) * _wordsPerBuffer /* total other buffers */ - _wordsPerBuffer /* minus the one currently being output */;
+    if (avail < 0) {
+        avail = 0; // Should never hit
+    }
     return avail;
 }
 


### PR DESCRIPTION
Fixes #963

The available space calculation didn't account for the fact that one of the buffers was currently being output, causing ::available() to be too large and ::write() to block in that case.