### PR TITLE
Modified LowPowerMode functions in WiFiClass.cpp/.h for better connection stability

### DIFF
--- a/libraries/WiFi/keywords.txt
+++ b/libraries/WiFi/keywords.txt
@@ -57,7 +57,8 @@ beginEnterprise	KEYWORD2
 setHostname	KEYWORD2
 end	KEYWORD2
 getTime	KEYWORD2
-lowPowerMode	KEYWORD2
+aggressiveLowPowerMode	KEYWORD2
+defaultLowPowerMode	KEYWORD2
 noLowPowerMode	KEYWORD2
 ping	KEYWORD2
 beginMulticast	KEYWORD2

--- a/libraries/WiFi/src/WiFiClass.cpp
+++ b/libraries/WiFi/src/WiFiClass.cpp
@@ -99,6 +99,7 @@ int WiFiClass::begin(const char* ssid, const char *passphrase) {
     if (!_wifi.begin()) {
         return WL_IDLE_STATUS;
     }
+    noLowPowerMode();
     // Enable CYW43 event debugging (make sure Debug Port is set)
     //cyw43_state.trace_flags = 0xffff;
     while (!_calledESP && ((millis() - start < (uint32_t)2 * _timeout)) && !connected()) {
@@ -134,6 +135,7 @@ uint8_t WiFiClass::beginAP(const char *ssid, const char* passphrase) {
     if (!_wifi.begin()) {
         return WL_IDLE_STATUS;
     }
+    noLowPowerMode();
     IPAddress gw = _wifi.gatewayIP();
     if (!gw.isSet()) {
         gw = IPAddress(192, 168, 42, 1);

--- a/libraries/WiFi/src/WiFiClass.cpp
+++ b/libraries/WiFi/src/WiFiClass.cpp
@@ -565,12 +565,17 @@ unsigned long WiFiClass::getTime() {
     return millis();
 }
 
-void WiFiClass::lowPowerMode() {
+void WiFiClass::aggressiveLowPowerMode() {
     cyw43_wifi_pm(&cyw43_state, CYW43_AGGRESSIVE_PM);
 }
 
-void WiFiClass::noLowPowerMode() {
+void WiFiClass::defaultLowPowerMode() {
     cyw43_wifi_pm(&cyw43_state, CYW43_DEFAULT_PM);
+}
+
+// The difference between the default CYW43_DEFAULT_PM (0xA11142) and not low power (0xA11140) is that it changed from "Powersave mode on specified interface with High throughput" to "No Powersave mode". All other parameters stayed the same.
+void WiFiClass::noLowPowerMode() {
+    cyw43_wifi_pm(&cyw43_state, 0xA11140);
 }
 
 int WiFiClass::ping(const char* hostname, uint8_t ttl) {

--- a/libraries/WiFi/src/WiFiClass.h
+++ b/libraries/WiFi/src/WiFiClass.h
@@ -368,7 +368,8 @@ public:
 
     unsigned long getTime();
 
-    void lowPowerMode();
+    void aggressiveLowPowerMode();
+    void defaultLowPowerMode();
     void noLowPowerMode();
 
     int ping(const char* hostname, uint8_t ttl = 128);


### PR DESCRIPTION
I was not very happy with pico-w WiFi stability, with huge WiFi traffic around the connection from my AP to pico-w was really unstable. 
After some testing I discovered, that something (probably inside cyw43-driver) is periodically delaying wifi operations.
The ping response suffered from periodical delay which went up to 10 seconds in some cases (see the screenshot of ping from my server to pico-w):
![pico-w_ping_pm_CYW43_DEFAULT_PMm](https://user-images.githubusercontent.com/6217613/208090478-c3c1bdc2-aa77-468d-95b3-f28e45eeb3e2.png)
After some research I found that the delay is caused by the power saving behavior of the WiFi chip.
There are existing two functions inside the arduino-pico WiFiClass: lowPowerMode() and noLowPowerMode(). 
Both of them are unfortunately using power saving modes (CYW43_AGGRESSIVE_PM and CYW43_DEFAULT_PM).
After reading this: https://forums.raspberrypi.com/viewtopic.php?t=340050#p2037055
and this: https://raspberrypi.github.io/pico-sdk-doxygen/group__cyw43__driver.html#ga808eabf2e62d713990ad2994596cb7d3
I modified WiFiClass power mode functions to allow real no low power functionality (using 0xA11140 value instead of parameters defined above).
Using modified noLowPowerMode() function the connection is much stable (see the ping):
![pico-w_ping_pm_0xA11140m](https://user-images.githubusercontent.com/6217613/208090430-4e0375d9-dcd2-4b3f-addc-ca55cf35159b.png)
The noLowPowerMode() function must be called after the WiFi.begin(...) function.
Hope this helps other people.
