### PR TITLE
Make the AudioRingBuffer list-based

### DIFF
--- a/libraries/I2S/keywords.txt
+++ b/libraries/I2S/keywords.txt
@@ -18,6 +18,7 @@ setBCLK	KEYWORD2
 setDATA	KEYWORD2
 setBitsPerSample	KEYWORD2
 setFrequency	KEYWORD2
+setBuffers	KEYWORD2
 
 read8	KEYWORD2
 read16	KEYWORD2

--- a/libraries/I2S/src/AudioRingBuffer.cpp
+++ b/libraries/I2S/src/AudioRingBuffer.cpp
@@ -236,7 +236,7 @@ void AudioRingBuffer::flush() {
 void __not_in_flash_func(AudioRingBuffer::_dmaIRQ)(int channel) {
     if (_isOutput) {
         if (_active[0] != _silence) {
-            _addToList(&_empty, _active[1]);
+            _addToList(&_empty, _active[0]);
         }
         _active[0] = _active[1];
         if (!_filled) {

--- a/libraries/I2S/src/I2S.cpp
+++ b/libraries/I2S/src/I2S.cpp
@@ -49,7 +49,7 @@ I2S::I2S(PinMode direction) {
     _arb = nullptr;
     _cb = nullptr;
     _buffers = 8;
-    _bufferWords = 16;
+    _bufferWords = 0;
     _silenceSample = 0;
 }
 
@@ -135,6 +135,9 @@ bool I2S::begin() {
     } else if (_bps == 16) {
         uint16_t a = _silenceSample & 0xffff;
         _silenceSample = (a << 16) | a;
+    }
+    if (!_bufferWords) {
+        _bufferWords = 16 * (_bps == 32 ? 2 : 1);
     }
     _arb = new AudioRingBuffer(_buffers, _bufferWords, _silenceSample, _isOutput ? OUTPUT : INPUT);
     _arb->begin(pio_get_dreq(_pio, _sm, _isOutput), _isOutput ? &_pio->txf[_sm] : (volatile void*)&_pio->rxf[_sm]);

--- a/libraries/I2S/src/I2S.cpp
+++ b/libraries/I2S/src/I2S.cpp
@@ -153,10 +153,13 @@ void I2S::end() {
 }
 
 int I2S::available() {
-    if (!_running || _isOutput) {
+    if (!_running) {
         return 0;
+    } else if (_isOutput) {
+        return availableForWrite(); // Do what I mean, not what I say
+    } else {
+        return _arb->available();
     }
-    return _arb->available();
 }
 
 int I2S::read() {


### PR DESCRIPTION
The ring buffer worked but had issues with IRQs and the available() procesing.  Because it was a pain to debug, move to a linked list setup where there are filled and empty buffers to work from, simplifying the underlying logic.

Allow I2S::available() to return free writing space in OUTPUT mode to make it saner.