### PR TITLE
Universal analogReadTemp()

### DIFF
--- a/cores/rp2040/Arduino.h
+++ b/cores/rp2040/Arduino.h
@@ -73,7 +73,7 @@ void noInterrupts();
 
 // ADC RP2040-specific calls
 void analogReadResolution(int bits);
-float analogReadTemp();  // Returns core temp in Centigrade
+float analogReadTemp(float vref = 3.3);  // Returns core temp in Centigrade
 
 // PWM RP2040-specific calls
 void analogWriteFreq(uint32_t freq);

--- a/cores/rp2040/wiring_analog.cpp
+++ b/cores/rp2040/wiring_analog.cpp
@@ -172,7 +172,7 @@ extern "C" float analogReadTemp(float vref) {
     adc_select_input(4); // Temperature sensor
     int v = adc_read();
     adc_set_temp_sensor_enabled(false);
-    float t = 27.0f - ((v * vref / (float)_readBits) - 0.706f) / 0.001721f; // From the datasheet
+    float t = 27.0f - ((v * vref / pow(2,_readBits)) - 0.706f) / 0.001721f; // From the datasheet
     return t;
 }
 

--- a/cores/rp2040/wiring_analog.cpp
+++ b/cores/rp2040/wiring_analog.cpp
@@ -156,7 +156,7 @@ extern "C" int analogRead(pin_size_t pin) {
     return (_readBits < 12) ? adc_read() >> (12 - _readBits) : adc_read() << (_readBits - 12);
 }
 
-extern "C" float analogReadTemp() {
+extern "C" float analogReadTemp(float vref) {
     CoreMutex m(&_adcMutex);
 
     if (!m) {
@@ -172,7 +172,7 @@ extern "C" float analogReadTemp() {
     adc_select_input(4); // Temperature sensor
     int v = adc_read();
     adc_set_temp_sensor_enabled(false);
-    float t = 27.0f - ((v * 3.3f / 4096.0f) - 0.706f) / 0.001721f; // From the datasheet
+    float t = 27.0f - ((v * vref / (float)_readBits) - 0.706f) / 0.001721f; // From the datasheet
     return t;
 }
 

--- a/cores/rp2040/wiring_analog.cpp
+++ b/cores/rp2040/wiring_analog.cpp
@@ -172,7 +172,7 @@ extern "C" float analogReadTemp(float vref) {
     adc_select_input(4); // Temperature sensor
     int v = adc_read();
     adc_set_temp_sensor_enabled(false);
-    float t = 27.0f - ((v * vref / pow(2,_readBits)) - 0.706f) / 0.001721f; // From the datasheet
+    float t = 27.0f - ((v * vref / pow(2, _readBits)) - 0.706f) / 0.001721f; // From the datasheet
     return t;
 }
 


### PR DESCRIPTION
Fixes `analogReadTemp()` by automatically using the correct ADC resolution and optionally also a different reference voltage.

This does not introduce any breaking changes, everything will work like it did (except, if you wanted a wrong temperature reading on purpose) as the default Vref is 3.3 V.

Users can supply their own custom voltage directly in the `analogReadTemp(float vref)` call to make this change as simple as possible.

Tested it on my setup, works like expected with 3.0 V reference and 12-bit ADC.