### PR TITLE
digitalRead/WriteFast to sio_hw->gpio

### DIFF
--- a/cores/rp2040/Arduino.h
+++ b/cores/rp2040/Arduino.h
@@ -68,8 +68,8 @@ void noInterrupts();
 #define portOutputRegister(port)    ((volatile uint32_t*) sio_hw->gpio_out)
 #define portInputRegister(port)     ((volatile uint32_t*) sio_hw->gpio_in)
 #define portModeRegister(port)      ((volatile uint32_t*) sio_hw->gpio_oe)
-#define digitalWriteFast(pin, val)  (val ? gpio_set_mask (1 << pin) : gpio_clr_mask(1 << pin))
-#define digitalReadFast(pin)        gpio_get(pin)
+#define digitalWriteFast(pin, val)  (val ? sio_hw->gpio_set = (1 << pin) : sio_hw->gpio_clr = (1 << pin))
+#define digitalReadFast(pin)        ((1 << pin) & sio_hw->gpio_in)
 
 // ADC RP2040-specific calls
 void analogReadResolution(int bits);


### PR DESCRIPTION
Per https://github.com/earlephilhower/arduino-pico/issues/1067:

#define digitalWriteFast(pin,val) (val ? gpio_set_mask(1 << pin) : gpio_clr_mask(1 << pin))
#define digitalReadFast(pin) gpio_get(pin)

gives an 8.76 MHz ring (at 250 MHz clock);

#define digitalWriteFast(pin,val) (val ? sio_hw->gpio_set = (1 << pin) : sio_hw->gpio_clr = (1 << pin))
#define digitalReadFast(pin) ((1 << pin) & sio_hw->gpio_in)

gives a12.9 MHz ring.