### PR TITLE
Warn when `Serial.printf()` format is wrong

### DIFF
--- a/libraries/FreeRTOS/examples/Multicore-FreeRTOS/Multicore-FreeRTOS.ino
+++ b/libraries/FreeRTOS/examples/Multicore-FreeRTOS/Multicore-FreeRTOS.ino
@@ -30,7 +30,7 @@ void ps() {
   Serial.printf("# Tasks: %d\n", tasks);
   Serial.println("ID, NAME, STATE, PRIO, CYCLES");
   for (int i=0; i < tasks; i++) {
-    Serial.printf("%d: %-16s %-10s %d %lu\n", i, pxTaskStatusArray[i].pcTaskName, eTaskStateName[pxTaskStatusArray[i].eCurrentState], pxTaskStatusArray[i].uxCurrentPriority, pxTaskStatusArray[i].ulRunTimeCounter);
+    Serial.printf("%d: %-16s %-10s %d %lu\n", i, pxTaskStatusArray[i].pcTaskName, eTaskStateName[pxTaskStatusArray[i].eCurrentState], (int)pxTaskStatusArray[i].uxCurrentPriority, pxTaskStatusArray[i].ulRunTimeCounter);
   }
   delete[] pxTaskStatusArray;
 }

--- a/libraries/SingleFileDrive/examples/DataLoggerUSB/DataLoggerUSB.ino
+++ b/libraries/SingleFileDrive/examples/DataLoggerUSB/DataLoggerUSB.ino
@@ -69,7 +69,7 @@ void setup() {
     cnt++;
   }
 
-  Serial.printf("Starting acquisition at %d\n", cnt);
+  Serial.printf("Starting acquisition at %lu\n", cnt);
 }
 
 void loop() {

--- a/libraries/WiFi/examples/BearSSL_Sessions/BearSSL_Sessions.ino
+++ b/libraries/WiFi/examples/BearSSL_Sessions/BearSSL_Sessions.ino
@@ -113,7 +113,7 @@ void loop() {
   client.setTrustAnchors(&cert);
   fetchURL(&client, host, port, path);
   finish = millis();
-  Serial.printf("Total time: %dms\n", finish - start);
+  Serial.printf("Total time: %lums\n", finish - start);
 
   BearSSL::Session session;
   client.setSession(&session);
@@ -122,21 +122,21 @@ void loop() {
   client.setTrustAnchors(&cert);
   fetchURL(&client, host, port, path);
   finish = millis();
-  Serial.printf("Total time: %dms\n", finish - start);
+  Serial.printf("Total time: %lums\n", finish - start);
 
   Serial.printf("Connecting with the just initialized session...");
   start = millis();
   client.setTrustAnchors(&cert);
   fetchURL(&client, host, port, path);
   finish = millis();
-  Serial.printf("Total time: %dms\n", finish - start);
+  Serial.printf("Total time: %lums\n", finish - start);
 
   Serial.printf("Connecting again with the initialized session...");
   start = millis();
   client.setTrustAnchors(&cert);
   fetchURL(&client, host, port, path);
   finish = millis();
-  Serial.printf("Total time: %dms\n", finish - start);
+  Serial.printf("Total time: %lums\n", finish - start);
 
   delay(10000);  // Avoid DDOSing github
 }

--- a/libraries/WiFi/examples/BearSSL_Validation/BearSSL_Validation.ino
+++ b/libraries/WiFi/examples/BearSSL_Validation/BearSSL_Validation.ino
@@ -76,7 +76,7 @@ void fetchURL(BearSSL::WiFiClientSecure *client, const char *host, const uint16_
     } while (millis() < to);
   }
   client->stop();
-  Serial.printf("BSSL stack used: %d\n-------\n\n", stack_thunk_get_max_usage());
+  Serial.printf("BSSL stack used: %lu\n-------\n\n", stack_thunk_get_max_usage());
 }
 
 void fetchNoConfig() {

--- a/libraries/WiFi/examples/ScanNetworks/ScanNetworks.ino
+++ b/libraries/WiFi/examples/ScanNetworks/ScanNetworks.ino
@@ -24,7 +24,7 @@ const char *encToString(uint8_t enc) {
 
 void loop() {
   delay(5000);
-  Serial.printf("Beginning scan at %d\n", millis());
+  Serial.printf("Beginning scan at %lu\n", millis());
   auto cnt = WiFi.scanNetworks();
   if (!cnt) {
     Serial.printf("No networks found\n");
@@ -34,7 +34,7 @@ void loop() {
     for (auto i = 0; i < cnt; i++) {
       uint8_t bssid[6];
       WiFi.BSSID(i, bssid);
-      Serial.printf("%32s %5s %17s %2d %4d\n", WiFi.SSID(i), encToString(WiFi.encryptionType(i)), macToString(bssid), WiFi.channel(i), WiFi.RSSI(i));
+      Serial.printf("%32s %5s %17s %2d %4ld\n", WiFi.SSID(i), encToString(WiFi.encryptionType(i)), macToString(bssid), WiFi.channel(i), WiFi.RSSI(i));
     }
   }
   Serial.printf("\n--- Sleeping ---\n\n\n");

--- a/libraries/rp2040/examples/GetCycleCount/GetCycleCount.ino
+++ b/libraries/rp2040/examples/GetCycleCount/GetCycleCount.ino
@@ -6,7 +6,7 @@ void setup() {
   uint32_t a = rp2040.getCycleCount();
   delay(1000);
   uint32_t b = rp2040.getCycleCount();
-  Serial.printf("There are %d cycles in one second.\n\n\n", b - a);
+  Serial.printf("There are %lu cycles in one second.\n\n\n", b - a);
 
   delay(3000);
 
@@ -16,6 +16,6 @@ void setup() {
 }
 
 void loop() {
-  Serial.printf("%15u - %15llu\n", rp2040.getCycleCount(), rp2040.getCycleCount64());
+  Serial.printf("%15lu - %15llu\n", rp2040.getCycleCount(), rp2040.getCycleCount64());
   delay(1500);
 }


### PR DESCRIPTION
Let GCC check the format string to Print::printf().  Will catch when sketches use incorrect parameters to `Serial::printf()`.