### PR TITLE
Fix temperature reading resolution

### DIFF
--- a/cores/rp2040/wiring_analog.cpp
+++ b/cores/rp2040/wiring_analog.cpp
@@ -172,7 +172,7 @@ extern "C" float analogReadTemp(float vref) {
     adc_select_input(4); // Temperature sensor
     int v = adc_read();
     adc_set_temp_sensor_enabled(false);
-    float t = 27.0f - ((v * vref / pow(2, _readBits)) - 0.706f) / 0.001721f; // From the datasheet
+    float t = 27.0f - ((v * vref / 4096.0f) - 0.706f) / 0.001721f; // From the datasheet
     return t;
 }
 


### PR DESCRIPTION
`adc_read()` resolution is always 12 bits. Doesn't change with `analogReadResolution()`.

This is basically a partial reversal #1075.