### PR TITLE
Reduce stack usage of several components

### DIFF
--- a/libraries/SingleFileDrive/src/SingleFileDrive.cpp
+++ b/libraries/SingleFileDrive/src/SingleFileDrive.cpp
@@ -245,30 +245,29 @@ int32_t SingleFileDrive::read10(uint32_t lba, uint32_t offset, void* buffer, uin
     }
 
     uint32_t toread = bufsize;
-    char buff[512];
     uint8_t *curbuff = (uint8_t *)buffer;
 
     while (bufsize > 0) {
         if (lba == 0) {
-            bootSector(buff);
+            bootSector(_sectBuff);
         } else if ((lba == 128) || (lba == 256)) {
-            fatSector(buff);
+            fatSector(_sectBuff);
         } else if (lba == 384) {
-            directorySector(buff);
+            directorySector(_sectBuff);
         } else if (lba >= 640) {
             File f = LittleFS.open(_localFile, "r");
             f.seek((lba - 640) * 512);
-            f.read((uint8_t*)buff, 512);
+            f.read((uint8_t*)_sectBuff, 512);
             f.close();
         } else {
-            memset(buff, 0, sizeof(buff));
+            memset(_sectBuff, 0, sizeof(_sectBuff));
         }
 
         uint32_t cplen = 512 - offset;
         if (bufsize < cplen) {
             cplen = bufsize;
         }
-        memcpy(curbuff, buff + offset, cplen);
+        memcpy(curbuff, _sectBuff + offset, cplen);
         curbuff += cplen;
         offset = 0;
         lba++;

--- a/libraries/SingleFileDrive/src/SingleFileDrive.h
+++ b/libraries/SingleFileDrive/src/SingleFileDrive.h
@@ -50,6 +50,8 @@ private:
     char *_localFile = nullptr;
     char *_dosFile = nullptr;
 
+    char _sectBuff[512]; // Read sector region
+
     void (*_cbDelete)(uint32_t) = nullptr;
     uint32_t _cbDeleteData = 0;
 

--- a/libraries/WebServer/examples/AdvancedWebServer/AdvancedWebServer.ino
+++ b/libraries/WebServer/examples/AdvancedWebServer/AdvancedWebServer.ino
@@ -32,6 +32,7 @@
 #include <WiFiClient.h>
 #include <WebServer.h>
 #include <LEAmDNS.h>
+#include <StreamString.h>
 
 #ifndef STASSID
 #define STASSID "your-ssid"
@@ -48,14 +49,13 @@ const int led = LED_BUILTIN;
 void handleRoot() {
   static int cnt = 0;
   digitalWrite(led, 1);
-  char temp[400];
   int sec = millis() / 1000;
   int min = sec / 60;
   int hr = min / 60;
 
-  snprintf(temp, 400,
-
-           "<html>\
+  StreamString temp;
+  temp.reserve(500); // Preallocate a large chunk to avoid memory fragmentation
+  temp.printf("<html>\
   <head>\
     <meta http-equiv='refresh' content='5'/>\
     <title>Pico-W Demo</title>\
@@ -70,9 +70,7 @@ void handleRoot() {
     <p>Page Count: %d</p>\
     <img src=\"/test.svg\" />\
   </body>\
-</html>",
-
-           hr, min % 60, sec % 60, rp2040.getFreeHeap(), ++cnt);
+</html>", hr, min % 60, sec % 60, rp2040.getFreeHeap(), ++cnt);
   server.send(200, "text/html", temp);
   digitalWrite(led, 0);
 }

--- a/libraries/WiFi/src/dhcpserver/dhcpserver.c
+++ b/libraries/WiFi/src/dhcpserver/dhcpserver.c
@@ -184,8 +184,8 @@ static void dhcp_server_process(void *arg, struct udp_pcb *upcb, struct pbuf *p,
     (void)src_addr;
     (void)src_port;
 
-    // This is around 548 bytes
-    dhcp_msg_t dhcp_msg;
+    // This is around 548 bytes, so make static so it will live in the heap, not the stack (too large)
+    static dhcp_msg_t dhcp_msg;
 
 #define DHCP_MIN_SIZE (240 + 3)
     if (p->tot_len < DHCP_MIN_SIZE) {


### PR DESCRIPTION
Only 4K total stack, so allocating 400 bytes for a local C string or 600 bytes for a DHCP response is dangerous.  Use static allocations instead on the heap.