### PR TITLE
Set Right and Left correctly for lsbj format

### DIFF
--- a/libraries/I2S/src/pio_i2s.pio
+++ b/libraries/I2S/src/pio_i2s.pio
@@ -50,17 +50,17 @@ right:
 
 ;                           +----- WCLK
 ;                           |+---- BCLK
-    mov x, y         side 0b11
-left:
-    out pins, 1      side 0b00
-    jmp x--, left    side 0b01
-    out pins, 1      side 0b00
-
     mov x, y         side 0b01
+left:
+    out pins, 1      side 0b10
+    jmp x--, left    side 0b11
+    out pins, 1      side 0b10
+
+    mov x, y         side 0b11
 right:
-    out pins, 1      side 0b10
-    jmp x--, right   side 0b11
-    out pins, 1      side 0b10
+    out pins, 1      side 0b00
+    jmp x--, right   side 0b01
+    out pins, 1      side 0b00
     ; Loop back to beginning...
 
 

--- a/libraries/I2S/src/pio_i2s.pio.h
+++ b/libraries/I2S/src/pio_i2s.pio.h
@@ -16,16 +16,16 @@
 #define pio_i2s_out_wrap 7
 
 static const uint16_t pio_i2s_out_program_instructions[] = {
-    //     .wrap_target
-    0xa822, //  0: mov    x, y            side 1
-    0x6001, //  1: out    pins, 1         side 0
-    0x0841, //  2: jmp    x--, 1          side 1
-    0x7001, //  3: out    pins, 1         side 2
-    0xb822, //  4: mov    x, y            side 3
-    0x7001, //  5: out    pins, 1         side 2
-    0x1845, //  6: jmp    x--, 5          side 3
-    0x6001, //  7: out    pins, 1         side 0
-    //     .wrap
+            //     .wrap_target
+    0xa822, //  0: mov    x, y            side 1     
+    0x6001, //  1: out    pins, 1         side 0     
+    0x0841, //  2: jmp    x--, 1          side 1     
+    0x7001, //  3: out    pins, 1         side 2     
+    0xb822, //  4: mov    x, y            side 3     
+    0x7001, //  5: out    pins, 1         side 2     
+    0x1845, //  6: jmp    x--, 5          side 3     
+    0x6001, //  7: out    pins, 1         side 0     
+            //     .wrap
 };
 
 #if !PICO_NO_HARDWARE
@@ -51,16 +51,16 @@ static inline pio_sm_config pio_i2s_out_program_get_default_config(uint offset) 
 #define pio_lsbj_out_wrap 7
 
 static const uint16_t pio_lsbj_out_program_instructions[] = {
-    //     .wrap_target
-    0xb822, //  0: mov    x, y            side 3
-    0x6001, //  1: out    pins, 1         side 0
-    0x0841, //  2: jmp    x--, 1          side 1
-    0x6001, //  3: out    pins, 1         side 0
-    0xa822, //  4: mov    x, y            side 1
-    0x7001, //  5: out    pins, 1         side 2
-    0x1845, //  6: jmp    x--, 5          side 3
-    0x7001, //  7: out    pins, 1         side 2
-    //     .wrap
+            //     .wrap_target
+    0xa822, //  0: mov    x, y            side 1     
+    0x7001, //  1: out    pins, 1         side 2     
+    0x1841, //  2: jmp    x--, 1          side 3     
+    0x7001, //  3: out    pins, 1         side 2     
+    0xb822, //  4: mov    x, y            side 3     
+    0x6001, //  5: out    pins, 1         side 0     
+    0x0845, //  6: jmp    x--, 5          side 1     
+    0x6001, //  7: out    pins, 1         side 0     
+            //     .wrap
 };
 
 #if !PICO_NO_HARDWARE
@@ -86,16 +86,16 @@ static inline pio_sm_config pio_lsbj_out_program_get_default_config(uint offset)
 #define pio_i2s_in_wrap 7
 
 static const uint16_t pio_i2s_in_program_instructions[] = {
-    //     .wrap_target
-    0xa022, //  0: mov    x, y            side 0
-    0x4801, //  1: in     pins, 1         side 1
-    0x0041, //  2: jmp    x--, 1          side 0
-    0x5801, //  3: in     pins, 1         side 3
-    0xb022, //  4: mov    x, y            side 2
-    0x5801, //  5: in     pins, 1         side 3
-    0x1045, //  6: jmp    x--, 5          side 2
-    0x4801, //  7: in     pins, 1         side 1
-    //     .wrap
+            //     .wrap_target
+    0xa022, //  0: mov    x, y            side 0     
+    0x4801, //  1: in     pins, 1         side 1     
+    0x0041, //  2: jmp    x--, 1          side 0     
+    0x5801, //  3: in     pins, 1         side 3     
+    0xb022, //  4: mov    x, y            side 2     
+    0x5801, //  5: in     pins, 1         side 3     
+    0x1045, //  6: jmp    x--, 5          side 2     
+    0x4801, //  7: in     pins, 1         side 1     
+            //     .wrap
 };
 
 #if !PICO_NO_HARDWARE
@@ -159,4 +159,3 @@ static inline void pio_i2s_in_program_init(PIO pio, uint sm, uint offset, uint d
 }
 
 #endif
-


### PR DESCRIPTION
The word select bit (WS) convention is inverted between I2S (down for left) and LSBJ (down for right). This inverts the behavior of this bit for the LSBJ format.

I am sorry about the whitespaces changes…