### PR TITLE
Move analogReadTemp() to C++-only

### DIFF
--- a/cores/rp2040/Arduino.h
+++ b/cores/rp2040/Arduino.h
@@ -75,7 +75,9 @@ void noInterrupts();
 
 // ADC RP2040-specific calls
 void analogReadResolution(int bits);
+#ifdef __cplusplus
 float analogReadTemp(float vref = 3.3);  // Returns core temp in Centigrade
+#endif
 
 // PWM RP2040-specific calls
 void analogWriteFreq(uint32_t freq);

--- a/libraries/I2S/src/pio_i2s.pio.h
+++ b/libraries/I2S/src/pio_i2s.pio.h
@@ -16,16 +16,16 @@
 #define pio_i2s_out_wrap 7
 
 static const uint16_t pio_i2s_out_program_instructions[] = {
-            //     .wrap_target
-    0xa822, //  0: mov    x, y            side 1     
-    0x6001, //  1: out    pins, 1         side 0     
-    0x0841, //  2: jmp    x--, 1          side 1     
-    0x7001, //  3: out    pins, 1         side 2     
-    0xb822, //  4: mov    x, y            side 3     
-    0x7001, //  5: out    pins, 1         side 2     
-    0x1845, //  6: jmp    x--, 5          side 3     
-    0x6001, //  7: out    pins, 1         side 0     
-            //     .wrap
+    //     .wrap_target
+    0xa822, //  0: mov    x, y            side 1
+    0x6001, //  1: out    pins, 1         side 0
+    0x0841, //  2: jmp    x--, 1          side 1
+    0x7001, //  3: out    pins, 1         side 2
+    0xb822, //  4: mov    x, y            side 3
+    0x7001, //  5: out    pins, 1         side 2
+    0x1845, //  6: jmp    x--, 5          side 3
+    0x6001, //  7: out    pins, 1         side 0
+    //     .wrap
 };
 
 #if !PICO_NO_HARDWARE
@@ -51,16 +51,16 @@ static inline pio_sm_config pio_i2s_out_program_get_default_config(uint offset) 
 #define pio_lsbj_out_wrap 7
 
 static const uint16_t pio_lsbj_out_program_instructions[] = {
-            //     .wrap_target
-    0xa822, //  0: mov    x, y            side 1     
-    0x7001, //  1: out    pins, 1         side 2     
-    0x1841, //  2: jmp    x--, 1          side 3     
-    0x7001, //  3: out    pins, 1         side 2     
-    0xb822, //  4: mov    x, y            side 3     
-    0x6001, //  5: out    pins, 1         side 0     
-    0x0845, //  6: jmp    x--, 5          side 1     
-    0x6001, //  7: out    pins, 1         side 0     
-            //     .wrap
+    //     .wrap_target
+    0xa822, //  0: mov    x, y            side 1
+    0x7001, //  1: out    pins, 1         side 2
+    0x1841, //  2: jmp    x--, 1          side 3
+    0x7001, //  3: out    pins, 1         side 2
+    0xb822, //  4: mov    x, y            side 3
+    0x6001, //  5: out    pins, 1         side 0
+    0x0845, //  6: jmp    x--, 5          side 1
+    0x6001, //  7: out    pins, 1         side 0
+    //     .wrap
 };
 
 #if !PICO_NO_HARDWARE
@@ -86,16 +86,16 @@ static inline pio_sm_config pio_lsbj_out_program_get_default_config(uint offset)
 #define pio_i2s_in_wrap 7
 
 static const uint16_t pio_i2s_in_program_instructions[] = {
-            //     .wrap_target
-    0xa022, //  0: mov    x, y            side 0     
-    0x4801, //  1: in     pins, 1         side 1     
-    0x0041, //  2: jmp    x--, 1          side 0     
-    0x5801, //  3: in     pins, 1         side 3     
-    0xb022, //  4: mov    x, y            side 2     
-    0x5801, //  5: in     pins, 1         side 3     
-    0x1045, //  6: jmp    x--, 5          side 2     
-    0x4801, //  7: in     pins, 1         side 1     
-            //     .wrap
+    //     .wrap_target
+    0xa022, //  0: mov    x, y            side 0
+    0x4801, //  1: in     pins, 1         side 1
+    0x0041, //  2: jmp    x--, 1          side 0
+    0x5801, //  3: in     pins, 1         side 3
+    0xb022, //  4: mov    x, y            side 2
+    0x5801, //  5: in     pins, 1         side 3
+    0x1045, //  6: jmp    x--, 5          side 2
+    0x4801, //  7: in     pins, 1         side 1
+    //     .wrap
 };
 
 #if !PICO_NO_HARDWARE


### PR DESCRIPTION
Now that we have a default parameter, need to only allow it in C++ since default values are not part of C spec.  Should not affect any users since only legacy code is in C.