### PR TITLE
Print useful uf2conv error if executable not found

### DIFF
--- a/tools/uf2conv.py
+++ b/tools/uf2conv.py
@@ -240,6 +240,10 @@ def get_drives():
                                             "Format-Table -Property DeviceID, DriveType, Filesystem, VolumeName"],
                                             stdin = nul)
                 nul.close()
+            except FileNotFoundError:
+                print("ERROR: Unable to execute powershell or wmic commands, can't continue.")
+                print("ERROR: Please make sure either PowerShell or WMIC is installed and in your %PATH%.")
+                sys.exit(1)
             except:
                 print("Unable to build drive list");
                 sys.exit(1)


### PR DESCRIPTION
Fixes #1140

````
Converting to uf2, output size: 134144, start address: 0x2000
ERROR: Unable to execute powershell or wmic commands, can't continue.
ERROR: Please make sure either PowerShell or WMIC is installed and in
       your %PATH%.
````