### PR TITLE
pdm re-port(#1156)

### DIFF
--- a/libraries/PDM/src/PDM.h
+++ b/libraries/PDM/src/PDM.h
@@ -38,12 +38,19 @@ public:
 
     //PORTENTA_H7 min -12 max 51
     //NANO 33 BLE SENSe min 0 max 80
+    //NICLA_VISION min 0 max 8
     void setGain(int gain);
     void setBufferSize(int bufferSize);
     size_t getBufferSize();
 
     // private:
     void IrqHandler(bool halftranfer);
+
+    // Hardware peripherals used
+    uint _dmaChannel;
+    PIO _pio;
+    int _smIdx;
+    int _pgmOffset;
 
 private:
     int _dinPin;
@@ -56,11 +63,13 @@ private:
     int _gain;
     int _init;
 
+    int _cutSamples;
+
     // Hardware peripherals used
-    uint _dmaChannel;
-    PIO _pio;
-    int _smIdx;
-    int _pgmOffset;
+    // uint _dmaChannel;
+    // PIO _pio;
+    // int _smIdx;
+    // int _pgmOffset;
 
     PDMDoubleBuffer _doubleBuffer;
 

--- a/libraries/PDM/src/PDM.h
+++ b/libraries/PDM/src/PDM.h
@@ -46,12 +46,6 @@ public:
     // private:
     void IrqHandler(bool halftranfer);
 
-    // Hardware peripherals used
-    uint _dmaChannel;
-    PIO _pio;
-    int _smIdx;
-    int _pgmOffset;
-
 private:
     int _dinPin;
     int _clkPin;
@@ -66,10 +60,10 @@ private:
     int _cutSamples;
 
     // Hardware peripherals used
-    // uint _dmaChannel;
-    // PIO _pio;
-    // int _smIdx;
-    // int _pgmOffset;
+    uint _dmaChannel;
+    PIO _pio;
+    int _smIdx;
+    int _pgmOffset;
 
     PDMDoubleBuffer _doubleBuffer;
 

--- a/libraries/PDM/src/rp2040/PDM.cpp
+++ b/libraries/PDM/src/rp2040/PDM.cpp
@@ -20,7 +20,7 @@ uint8_t rawBuffer1[RAW_BUFFER_SIZE];
 uint8_t* rawBuffer[2] = {rawBuffer0, rawBuffer1};
 volatile int rawBufferIndex = 0;
 
-int decimation = 64;
+int decimation = 128;
 
 // final buffer is the one to be filled with PCM data
 int16_t* volatile finalBuffer;
@@ -45,6 +45,7 @@ PDMClass::PDMClass(int dinPin, int clkPin, int pwrPin) :
     _channels(-1),
     _samplerate(-1),
     _init(-1),
+    _cutSamples(100),
     _dmaChannel(0),
     _pio(nullptr),
     _smIdx(-1),
@@ -55,6 +56,12 @@ PDMClass::~PDMClass() {
 }
 
 int PDMClass::begin(int channels, int sampleRate) {
+
+    if (_init == 1) {
+        //ERROR: please call end first
+        return 0;
+    }
+
     //_channels = channels; // only one channel available
 
     // clear the final buffers
@@ -63,32 +70,45 @@ int PDMClass::begin(int channels, int sampleRate) {
     int finalBufferLength = _doubleBuffer.availableForWrite() / sizeof(int16_t);
     _doubleBuffer.swap(0);
 
-    int rawBufferLength = RAW_BUFFER_SIZE / (decimation / 8);
-    // Saturate number of samples. Remaining bytes are dropped.
-    if (rawBufferLength > finalBufferLength) {
-        rawBufferLength = finalBufferLength;
-    }
+  // The mic accepts an input clock from 1.2 to 3.25 Mhz
+  // Setup the decimation factor accordingly
+  if ((sampleRate * decimation * 2) > 3250000) {
+    decimation = 64;
+  }
 
-    /* Initialize Open PDM library */
-    filter.Fs = sampleRate;
-    filter.nSamples = rawBufferLength;
-    filter.LP_HZ = sampleRate / 2;
-    filter.HP_HZ = 10;
-    filter.In_MicChannels = 1;
-    filter.Out_MicChannels = 1;
-    filter.Decimation = decimation;
-    if (_gain == -1) {
-        _gain = FILTER_GAIN;
-    }
-    filter.filterGain = _gain;
-    Open_PDM_Filter_Init(&filter);
+  // Sanity check, abort if still over 3.25Mhz
+  if ((sampleRate * decimation * 2) > 3250000) {
+    //ERROR:  Sample rate too high, the mic would glitch
+    return -1;
+  }
+
+  int rawBufferLength = RAW_BUFFER_SIZE / (decimation / 8);
+  // Saturate number of samples. Remaining bytes are dropped.
+  if (rawBufferLength > finalBufferLength) {
+    rawBufferLength = finalBufferLength;
+  }
+
+  /* Initialize Open PDM library */
+  filter.Fs = sampleRate;
+  filter.MaxVolume = 1;
+  filter.nSamples = rawBufferLength;
+  filter.LP_HZ = sampleRate/2;
+  filter.HP_HZ = 10;
+  filter.In_MicChannels = 1;
+  filter.Out_MicChannels = 1;
+  filter.Decimation = decimation;
+  if(_gain == -1) {
+    _gain = FILTER_GAIN;
+  }
+  filter.filterGain = _gain;
+  Open_PDM_Filter_Init(&filter);
 
     // Configure PIO state machine
     float clkDiv = (float)clock_get_hz(clk_sys) / sampleRate / decimation / 2;
 
     if (!_pdmPgm.prepare(&_pio, &_smIdx, &_pgmOffset)) {
         // ERROR, no free slots
-        return -1;
+        return 0;
     }
     pdm_pio_program_init(_pio, _smIdx, _pgmOffset, _clkPin, _dinPin, clkDiv);
 
@@ -118,14 +138,30 @@ int PDMClass::begin(int channels, int sampleRate) {
                           true                // Start immediately
                          );
 
-    _init = 1;
+  _cutSamples = 100;
 
-    return 1;
+  _init = 1;
+
+  return 1;
 }
 
 void PDMClass::end() {
+
+    if ( _init!=1 ) {
+        return;
+    }
+
+    dma_channel_set_irq0_enabled(_dmaChannel, false);
     dma_channel_abort(_dmaChannel);
+    dma_channel_unclaim(_dmaChannel);
+    irq_remove_handler(DMA_IRQ_0, dmaHandler);
+    pio_remove_program(_pio,  &pdm_pio_program, _pgmOffset);
+    pio_sm_unclaim (_pio, _smIdx);
     pinMode(_clkPin, INPUT);
+    rawBufferIndex=0;
+    _pgmOffset=-1;
+
+    _init=0;
 }
 
 int PDMClass::available() {
@@ -163,7 +199,6 @@ void PDMClass::setBufferSize(int bufferSize) {
 }
 
 void PDMClass::IrqHandler(bool halftranfer) {
-    static int cutSamples = 100;
 
     // Clear the interrupt request.
     dma_hw->ints0 = 1u << _dmaChannel;
@@ -171,23 +206,24 @@ void PDMClass::IrqHandler(bool halftranfer) {
     int shadowIndex = rawBufferIndex ^ 1;
     dma_channel_set_write_addr(_dmaChannel, rawBuffer[shadowIndex], true);
 
-    if (_doubleBuffer.available()) {
-        // buffer overflow, stop
-        return end();
+  if (!_doubleBuffer.available()) {
+    // fill final buffer with PCM samples
+    if (filter.Decimation == 128) {
+      Open_PDM_Filter_128(rawBuffer[rawBufferIndex], finalBuffer, 1, &filter);
+    } else {
+      Open_PDM_Filter_64(rawBuffer[rawBufferIndex], finalBuffer, 1, &filter);
     }
 
-    // fill final buffer with PCM samples
-    Open_PDM_Filter_64(rawBuffer[rawBufferIndex], finalBuffer, 1, &filter);
-
-    if (cutSamples) {
-        memset(finalBuffer, 0, cutSamples);
-        cutSamples = 0;
+    if (_cutSamples) {
+      memset(finalBuffer, 0, _cutSamples);
+      _cutSamples = 0;
     }
 
     // swap final buffer and raw buffers' indexes
     finalBuffer = (int16_t*)_doubleBuffer.data();
     _doubleBuffer.swap(filter.nSamples * sizeof(int16_t));
     rawBufferIndex = shadowIndex;
+  }
 
     if (_onReceive) {
         _onReceive();

--- a/libraries/PDM/src/rp2040/PDM.cpp
+++ b/libraries/PDM/src/rp2040/PDM.cpp
@@ -155,7 +155,6 @@ void PDMClass::end() {
     dma_channel_abort(_dmaChannel);
     dma_channel_unclaim(_dmaChannel);
     irq_remove_handler(DMA_IRQ_0, dmaHandler);
-    pio_remove_program(_pio,  &pdm_pio_program, _pgmOffset);
     pio_sm_unclaim(_pio, _smIdx);
     pinMode(_clkPin, INPUT);
     rawBufferIndex = 0;


### PR DESCRIPTION
pulled in the changes from arduinocore-mdbed, leaving the dynamics of pio/sm and dma_channel assignment in arduino-pico untouched. Due to this, additional clean-up has to be done in `PDM::end` compared to arduino-mbed.  Begin and end can now be called as often as desired, but works almost ( fail in one of about every 50-100 end-begin cycles ). Error Scenario now is either all data returned by `PDM::read` is -128's or toally rubbish looking like a missing byte swap for the shorts or a mismatch in the byte index to build the shorts. For now, observed only when forcing a movement from one sm to another of the same pio by claiming the former sm. Forcing load of pdm_pio_program to new sm by resetting `_offset` in PIOProgram::prepare after `pio_remove_program` in  `PDM::end` doesn't help. Where is `pdm_pio_programm` after `PDM::end` ? But before diving to deep, please give me a hint if this PR makes sense to you.