### PR TITLE
Unbreak FreeRTOS

### DIFF
--- a/cores/rp2040/SerialUSB.cpp
+++ b/cores/rp2040/SerialUSB.cpp
@@ -190,6 +190,7 @@ static void CheckSerialReset() {
         reset_usb_boot(0, 0);
         while (1); // WDT will fire here
     }
+    __holdUpPendSV = 0;
 }
 
 extern "C" void tud_cdc_line_state_cb(uint8_t itf, bool dtr, bool rts) {


### PR DESCRIPTION
USB changes caused FreeRTOS to not be able to swap tasks when the Serial port was connected.  Clear the "stop PendSV" flag after checking for reset signal.