### PR TITLE
Allow FreeRTOS to ::printf

### DIFF
--- a/cores/rp2040/_freertos.cpp
+++ b/cores/rp2040/_freertos.cpp
@@ -28,7 +28,7 @@ typedef struct {
 } FMMap;
 
 static FMMap *_map = nullptr;
-extern "C" SemaphoreHandle_t __get_freertos_mutex_for_ptr(mutex_t *m) {
+SemaphoreHandle_t __get_freertos_mutex_for_ptr(mutex_t *m, bool recursive) {
     if (!_map) {
         _map = (FMMap *)calloc(sizeof(FMMap), 16);
     }
@@ -42,7 +42,12 @@ extern "C" SemaphoreHandle_t __get_freertos_mutex_for_ptr(mutex_t *m) {
     for (int i = 0; i < 16; i++) {
         if (_map[i].src == nullptr) {
             // Make a new mutex
-            SemaphoreHandle_t fm = __freertos_mutex_create();
+            SemaphoreHandle_t fm;
+            if (recursive) {
+                fm = _freertos_recursive_mutex_create();
+            } else {
+                fm = __freertos_mutex_create();
+            }
             if (fm == nullptr) {
                 return nullptr;
             }

--- a/cores/rp2040/_freertos.h
+++ b/cores/rp2040/_freertos.h
@@ -59,8 +59,8 @@ extern "C" {
     extern void vTaskPreemptionEnable(TaskHandle_t p) __attribute__((weak));
 #endif
 
-    extern SemaphoreHandle_t __get_freertos_mutex_for_ptr(mutex_t *m);
 }
+extern SemaphoreHandle_t __get_freertos_mutex_for_ptr(mutex_t *m, bool recursive = false);
 
 // Halt the FreeRTOS PendSV task switching magic
 extern "C" int __holdUpPendSV;


### PR DESCRIPTION
The stdin/stdout FILEs have an internal mutex which needs to be initted to a FreeRTOS one, or any sketch with ::printf will hang.  Automatically create and acquire/release the shadowed mutex.

Requires new build of pico-quick-toolchain to function properly.  Tested on preliminary local build.