### PR TITLE
Reduce unintialized_ram overhead to 0 in most cases

### DIFF
--- a/lib/memmap_default.ld
+++ b/lib/memmap_default.ld
@@ -218,11 +218,11 @@ SECTIONS
     } > RAM
 
     /* At most one of the following two will be engaged, depending on the SDK version */
-    .uninitialized_ram BLOCK(16k) (NOLOAD) : {
+    .uninitialized_ram MAX(0x20003000, .) (NOLOAD) : {
         *(.uninitialized_ram*)
     } > RAM
 
-    .uninitialized_data BLOCK(16k) (NOLOAD) : {
+    .uninitialized_data MAX(0x20003000, .) (NOLOAD) : {
         *(.uninitialized_data*)
     } > RAM
 


### PR DESCRIPTION
Use GNU LD MAX() to ensure the uninitialized RAM portions are after the OTA region.  For most apps this already happens, so there will be no overhead added.