### PR TITLE
Remove extra SPI byte flip

### DIFF
--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -135,7 +135,6 @@ void SPIClassRP2040::transfer(void *buf, size_t count) {
     uint8_t *buff = reinterpret_cast<uint8_t *>(buf);
     for (size_t i = 0; i < count; i++) {
         *buff = transfer(*buff);
-        *buff = (_spis.getBitOrder() == MSBFIRST) ? *buff : reverseByte(*buff);
         buff++;
     }
     DEBUGSPI("SPI::transfer completed\n");


### PR DESCRIPTION
For #1201. See issue thread for more info.

This PR simply removes line of code that was doing the extra byte flipping.