### PR TITLE
Move PicoW auto-reassignment of LED pin to code

### DIFF
--- a/variants/rpipicow/picow_digital.cpp
+++ b/variants/rpipicow/picow_digital.cpp
@@ -24,7 +24,12 @@ extern "C" void __pinMode(pin_size_t pin, PinMode mode);
 extern "C" void __digitalWrite(pin_size_t pin, PinStatus val);
 extern "C" PinStatus __digitalRead(pin_size_t pin);
 
+extern bool  __isPicoW;
+
 extern "C" void pinMode(pin_size_t pin, PinMode mode) {
+    if (!__isPicoW && (pin == PIN_LED)) {
+        pin = 25;  // Silently swap in the Pico's LED
+    }
     if (pin < 32) {
         __pinMode(pin, mode);
     } else {
@@ -33,6 +38,9 @@ extern "C" void pinMode(pin_size_t pin, PinMode mode) {
 }
 
 extern "C" void digitalWrite(pin_size_t pin, PinStatus val) {
+    if (!__isPicoW && (pin == PIN_LED)) {
+        pin = 25;  // Silently swap in the Pico's LED
+    }
     if (pin < 32) {
         __digitalWrite(pin, val);
     } else {
@@ -41,6 +49,9 @@ extern "C" void digitalWrite(pin_size_t pin, PinStatus val) {
 }
 
 extern "C" PinStatus digitalRead(pin_size_t pin) {
+    if (!__isPicoW && (pin == PIN_LED)) {
+        pin = 25;  // Silently swap in the Pico's LED
+    }
     if (pin < 32) {
         return __digitalRead(pin);
     } else {

--- a/variants/rpipicow/pins_arduino.h
+++ b/variants/rpipicow/pins_arduino.h
@@ -6,7 +6,7 @@
 extern bool  __isPicoW;
 
 // LEDs
-#define PIN_LED        (__isPicoW ? 32u : 25u)
+#define PIN_LED        (32u)
 
 // Serial
 #define PIN_SERIAL1_TX (0u)


### PR DESCRIPTION
Many examples require that LED_BUILTIN be defined as a constant, so we can't use a ternary operator to swap between Pico and PicoW LED pins.

Instead, do the check in the digitalWrite/digitalRead/pinMode calls to cover most of the uses.