### PR TITLE
Update PlayStereo.ino

### DIFF
--- a/libraries/PWMAudio/examples/PlayStereo/PlayStereo.ino
+++ b/libraries/PWMAudio/examples/PlayStereo/PlayStereo.ino
@@ -28,8 +28,8 @@ void cb() {
     double now = ((double)cnt) / (double)freq;
     int fl = freqL << 7; // Prescale by 128 to avoid FP math later on
     int fr = freqR << 7; // Prescale by 128 to avoid FP math later on
-    pwm.write((uint16_t)(al * sineTable[(int)(now * fl) & 127]));
-    pwm.write((uint16_t)(ar * sineTable[(int)(now * fr) & 127]));
+    pwm.write((int16_t)(al * sineTable[(int)(now * fl) & 127]));
+    pwm.write((int16_t)(ar * sineTable[(int)(now * fr) & 127]));
     cnt++;
   }
 }


### PR DESCRIPTION
The PWMAudio lib is expecting an int16_t value but the example passes a sample cast to uint16_t  So any values from the lookup table that are negative are recast to 0 i think. So half the sine wave in the case of the example is lost.