### PR TITLE
Always apply 5M speed to CMSIS_DAP TCL script

### DIFF
--- a/lib/picoprobe_cmsis_dap.tcl
+++ b/lib/picoprobe_cmsis_dap.tcl
@@ -1,2 +1,3 @@
 source [find interface/cmsis-dap.cfg]
+adapter speed 5000
 source [find target/rp2040.cfg]


### PR DESCRIPTION
Still need it on the command line in platform.txt for upload/etc., but make the debug script in lib/picoprobe_cmsis_dap.tcl include the adapter speed setting.