### PR TITLE
Add timeout to WiFiClient constructor

### DIFF
--- a/libraries/WiFi/src/WiFiClient.cpp
+++ b/libraries/WiFi/src/WiFiClient.cpp
@@ -59,9 +59,9 @@ template<>
 WiFiClient* SList<WiFiClient>::_s_first = 0;
 
 
-WiFiClient::WiFiClient()
+WiFiClient::WiFiClient(int timeout)
     : _client(0), _owned(0) {
-    _timeout = 5000;
+    _timeout = timeout;
     WiFiClient::_add(this);
 }
 

--- a/libraries/WiFi/src/WiFiClient.h
+++ b/libraries/WiFi/src/WiFiClient.h
@@ -47,7 +47,7 @@ protected:
     WiFiClient(ClientContext* client);
 
 public:
-    WiFiClient();
+    WiFiClient(int timeout = 5000);
     virtual ~WiFiClient();
     WiFiClient(const WiFiClient&);
     WiFiClient& operator=(const WiFiClient&);


### PR DESCRIPTION
- The client has full support for timeouts, but no apparent way to set the timeout to anything but the default.
- This change keeps the same default in place (5000ms), but allows the user to override it.
- This can make it so reconnecting to Wifi-based TCP sockets can happen much quicker, which is crucial if you are trying to reconnect from your main loop, particularly when both cores are running in sub-second timed schedule loops.
- This will also make it more possible to employ the hardware WDT with a reasonable timeout without the board rebooting when a connection takes too long as there is no "yield to kick the watchdog" code in place.