### PR TITLE
Return custom USB product and manufacturer

### DIFF
--- a/cores/rp2040/RP2040USB.cpp
+++ b/cores/rp2040/RP2040USB.cpp
@@ -301,15 +301,15 @@ void __SetupUSBDescriptor() {
 
 const uint16_t *tud_descriptor_string_cb(uint8_t index, uint16_t langid) {
     (void) langid;
-#define DESC_STR_MAX (20)
+#define DESC_STR_MAX (32)
     static uint16_t desc_str[DESC_STR_MAX];
 
     static char idString[PICO_UNIQUE_BOARD_ID_SIZE_BYTES * 2 + 1];
 
     static const char *const usbd_desc_str[] = {
         [USBD_STR_0] = "",
-        [USBD_STR_MANUF] = "Raspberry Pi",
-        [USBD_STR_PRODUCT] = "PicoArduino",
+        [USBD_STR_MANUF] = USB_MANUFACTURER,
+        [USBD_STR_PRODUCT] = USB_PRODUCT,
         [USBD_STR_SERIAL] = idString,
         [USBD_STR_CDC] = "Board CDC",
 #ifdef ENABLE_PICOTOOL_USB


### PR DESCRIPTION
Return the pre-existing USB_PRODUCT/MANUFACTURER to the USB host in the ID stage, allowing for reports like:

[1412958.589070] usb 1-6.3.4.1: New USB device found, idVendor=2e8a, idProduct=f00a, bcdDevice= 1.00
[1412958.589076] usb 1-6.3.4.1: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[1412958.589079] usb 1-6.3.4.1: Product: Pico W
[1412958.589080] usb 1-6.3.4.1: Manufacturer: Raspberry Pi
[1412958.589081] usb 1-6.3.4.1: SerialNumber: E6614C775B6C7F31

or

[1413190.272233] usb 1-6.3.4.1: New USB device found, idVendor=2e8a, idProduct=1037, bcdDevice= 1.00
[1413190.272239] usb 1-6.3.4.1: New USB device strings: Mfr=1, Product=2, SerialNumber=3
[1413190.272242] usb 1-6.3.4.1: Product: HunterCat NFC RP2040
[1413190.272243] usb 1-6.3.4.1: Manufacturer: ElectronicCats
[1413190.272244] usb 1-6.3.4.1: SerialNumber: E6614C775B6C7F31