### PR TITLE
Move pico-sdk to RPI's original version

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,7 +3,7 @@
 	url = https://github.com/earlephilhower/ArduinoCore-API.git
 [submodule "pico-sdk"]
 	path = pico-sdk
-	url = https://github.com/earlephilhower/pico-sdk.git
+	url = https://github.com/raspberrypi/pico-sdk.git
 [submodule "system/pyserial"]
 	path = tools/pyserial
 	url = https://github.com/pyserial/pyserial.git


### PR DESCRIPTION
No need to use my own fork, we're using the default upstream code.