### PR TITLE
Reassign Feather Scorpio I2C pins to correct buses

### DIFF
--- a/variants/adafruit_feather_scorpio/pins_arduino.h
+++ b/variants/adafruit_feather_scorpio/pins_arduino.h
@@ -30,10 +30,10 @@
 #define PIN_SPI1_SS    (31u)
 
 // Wire
-#define PIN_WIRE0_SDA  (2u)
-#define PIN_WIRE0_SCL  (3u)
-#define PIN_WIRE1_SDA  (31u)
-#define PIN_WIRE1_SCL  (31u)
+#define PIN_WIRE0_SDA (24u)
+#define PIN_WIRE0_SCL (25u)
+#define PIN_WIRE1_SDA (2u)
+#define PIN_WIRE1_SCL (3u)
 
 #define SERIAL_HOWMANY (2u)
 #define SPI_HOWMANY    (1u)


### PR DESCRIPTION
Referencing #1216 and basing it off these pinouts (https://learn.adafruit.com/introducing-feather-rp2040-scorpio/pinouts) as this board uses Wire1 for the "main" broken-out I2C pins, the stemma port included. Can confirm that's the case for mounted featherwings that use this board's I2C.

Basing Wire0's pins from the base RP2040 pindefs, which match with this board's as well. (Base RP2040 pinout: https://learn.adafruit.com/adafruit-feather-rp2040-pico/pinouts)

Sidenote: This also applies to the SPI pins (should be on SPI1, but otherwise SCK, MOSI, and MISO pins check out) but can't fully confirm the SS pin and it's originally commented as "Not pinned out."