### PR TITLE
Add Keyboard LED callback for USB and BT (not BLE)

### DIFF
--- a/cores/rp2040/RP2040USB.cpp
+++ b/cores/rp2040/RP2040USB.cpp
@@ -383,6 +383,7 @@ void __USBStart() {
 // Invoked when received GET_REPORT control request
 // Application must fill buffer report's content and return its length.
 // Return zero will cause the stack to STALL request
+extern "C" uint16_t tud_hid_get_report_cb(uint8_t instance, uint8_t report_id, hid_report_type_t report_type, uint8_t* buffer, uint16_t reqlen) __attribute__((weak));
 extern "C" uint16_t tud_hid_get_report_cb(uint8_t instance, uint8_t report_id, hid_report_type_t report_type, uint8_t* buffer, uint16_t reqlen) {
     // TODO not implemented
     (void) instance;
@@ -396,6 +397,7 @@ extern "C" uint16_t tud_hid_get_report_cb(uint8_t instance, uint8_t report_id, h
 
 // Invoked when received SET_REPORT control request or
 // received data on OUT endpoint ( Report ID = 0, Type = 0 )
+extern "C" void tud_hid_set_report_cb(uint8_t instance, uint8_t report_id, hid_report_type_t report_type, uint8_t const* buffer, uint16_t bufsize) __attribute__((weak));
 extern "C" void tud_hid_set_report_cb(uint8_t instance, uint8_t report_id, hid_report_type_t report_type, uint8_t const* buffer, uint16_t bufsize) {
     // TODO set LED based on CAPLOCK, NUMLOCK etc...
     (void) instance;

--- a/libraries/Keyboard/examples/KeyboardPassword/KeyboardPassword.ino
+++ b/libraries/Keyboard/examples/KeyboardPassword/KeyboardPassword.ino
@@ -3,8 +3,20 @@
 
 #include <Keyboard.h>
 
+void ledCB(bool numlock, bool capslock, bool scrolllock, bool compose, bool kana, void *cbData) {
+  (void) numlock;
+  (void) scrolllock;
+  (void) compose;
+  (void) kana;
+  (void) cbData;
+  digitalWrite(LED_BUILTIN, capslock ? HIGH : LOW);
+}
+
 void setup() {
   Serial.begin(115200);
+  pinMode(LED_BUILTIN, OUTPUT);
+  digitalWrite(LED_BUILTIN, LOW);
+  Keyboard.onLED(ledCB);
   Keyboard.begin();
   delay(5000);
   Serial.printf("Arduino USB Password Typer\n");

--- a/libraries/Keyboard/src/Keyboard.cpp
+++ b/libraries/Keyboard/src/Keyboard.cpp
@@ -46,4 +46,14 @@ void Keyboard_::sendReport(KeyReport* keys) {
     tud_task();
 }
 
+extern "C" void tud_hid_set_report_cb(uint8_t instance, uint8_t report_id, hid_report_type_t report_type, uint8_t const* buffer, uint16_t bufsize) {
+    (void) report_id;
+    (void) instance;
+
+    if ((report_type == HID_REPORT_TYPE_OUTPUT) && (bufsize > 0) && (Keyboard._ledCB)) {
+        uint8_t const kbd_leds = buffer[0];
+        Keyboard._ledCB(kbd_leds & KEYBOARD_LED_NUMLOCK, kbd_leds & KEYBOARD_LED_CAPSLOCK, kbd_leds & KEYBOARD_LED_SCROLLLOCK, kbd_leds & KEYBOARD_LED_COMPOSE, kbd_leds & KEYBOARD_LED_KANA, Keyboard._ledCBdata);
+    }
+}
+
 Keyboard_ Keyboard;

--- a/libraries/Keyboard/src/Keyboard.h
+++ b/libraries/Keyboard/src/Keyboard.h
@@ -28,6 +28,7 @@
 class Keyboard_ : public HID_Keyboard {
 protected:
     virtual void sendReport(KeyReport* keys) override;
+
 public:
     Keyboard_(void);
 };

--- a/libraries/KeyboardBT/examples/BTKeyboardPassword/BTKeyboardPassword.ino
+++ b/libraries/KeyboardBT/examples/BTKeyboardPassword/BTKeyboardPassword.ino
@@ -3,9 +3,22 @@
 
 #include <KeyboardBT.h>
 
+void ledCB(bool numlock, bool capslock, bool scrolllock, bool compose, bool kana, void *cbData) {
+  (void) numlock;
+  (void) scrolllock;
+  (void) compose;
+  (void) kana;
+  (void) cbData;
+  digitalWrite(LED_BUILTIN, capslock ? HIGH : LOW);
+}
+
 void setup() {
   Serial.begin(115200);
   KeyboardBT.begin("PicoW Password");
+  pinMode(LED_BUILTIN, OUTPUT);
+  digitalWrite(LED_BUILTIN, LOW);
+  KeyboardBT.onLED(ledCB);
+  KeyboardBT.begin();
   delay(5000);
   Serial.printf("Arduino USB Password Typer\n");
   Serial.printf("Press BOOTSEL to enter your super-secure(not!) password\n\n");


### PR DESCRIPTION
BLE seems to require some kind of characteristic callback that is not yeet implemented here.  USB and BT tested and examples updated.