### PR TITLE
Feather DVI peripheral fix

### DIFF
--- a/variants/adafruit_feather_dvi/pins_arduino.h
+++ b/variants/adafruit_feather_dvi/pins_arduino.h
@@ -37,8 +37,11 @@
 // Wire
 #define PIN_WIRE0_SDA  (2u)
 #define PIN_WIRE0_SCL  (3u)
+#define __WIRE0_DEVICE i2c1
+
 #define PIN_WIRE1_SDA  (31u)
 #define PIN_WIRE1_SCL  (31u)
+#define __WIRE1_DEVICE i2c0
 
 #define SERIAL_HOWMANY (2u)
 #define SPI_HOWMANY    (1u)

--- a/variants/adafruit_feather_dvi/pins_arduino.h
+++ b/variants/adafruit_feather_dvi/pins_arduino.h
@@ -9,6 +9,9 @@
 // NeoPixel
 #define PIN_NEOPIXEL   (4u)
 
+// 'Boot0' button also on GPIO #7
+#define PIN_BUTTON     (7u)
+
 // Serial
 #define PIN_SERIAL1_TX (0u)
 #define PIN_SERIAL1_RX (1u)
@@ -22,12 +25,14 @@
 #define PIN_SPI0_MOSI  (15u)
 #define PIN_SPI0_SCK   (14u)
 #define PIN_SPI0_SS    (13u)
+#define __SPI0_DEVICE  spi1
 
 // Not pinned out
 #define PIN_SPI1_MISO  (31u)
 #define PIN_SPI1_MOSI  (31u)
 #define PIN_SPI1_SCK   (31u)
 #define PIN_SPI1_SS    (31u)
+#define __SPI1_DEVICE  spi0
 
 // Wire
 #define PIN_WIRE0_SDA  (2u)


### PR DESCRIPTION
Fix SPI and Wire so even tho we are using the 'second' peripherals, they are usable as `SPI` and `Wire` :)