### PR TITLE
Add HID consumer (aka media) keys for USB, BT

### DIFF
--- a/cores/rp2040/RP2040USB.cpp
+++ b/cores/rp2040/RP2040USB.cpp
@@ -157,7 +157,7 @@ void __SetupDescHIDReport() {
     //allocate memory for the HID report descriptors. We don't use them, but need the size here.
     uint8_t desc_hid_report_mouse[] = { TUD_HID_REPORT_DESC_MOUSE(HID_REPORT_ID(1)) };
     uint8_t desc_hid_report_joystick[] = { TUD_HID_REPORT_DESC_GAMEPAD(HID_REPORT_ID(1)) };
-    uint8_t desc_hid_report_keyboard[] = { TUD_HID_REPORT_DESC_KEYBOARD(HID_REPORT_ID(1)) };
+    uint8_t desc_hid_report_keyboard[] = { TUD_HID_REPORT_DESC_KEYBOARD(HID_REPORT_ID(1)), TUD_HID_REPORT_DESC_CONSUMER(HID_REPORT_ID(2)) };
     int size = 0;
 
     //accumulate the size of all used HID report descriptors
@@ -194,7 +194,7 @@ void __SetupDescHIDReport() {
         if (__USBInstallMouse) {
             //determine if we need an offset (USB keyboard is installed)
             if (__USBInstallKeyboard) {
-                uint8_t desc_local[] = { TUD_HID_REPORT_DESC_MOUSE(HID_REPORT_ID(2)) };
+                uint8_t desc_local[] = { TUD_HID_REPORT_DESC_MOUSE(HID_REPORT_ID(3)) };
                 memcpy(__hid_report + sizeof(desc_hid_report_keyboard), desc_local, sizeof(desc_local));
             } else {
                 memcpy(__hid_report, desc_hid_report_mouse, sizeof(desc_hid_report_mouse));
@@ -206,7 +206,7 @@ void __SetupDescHIDReport() {
             uint8_t reportid = 1;
             int offset = 0;
             if (__USBInstallKeyboard) {
-                reportid++;
+                reportid += 2;
                 offset += sizeof(desc_hid_report_keyboard);
             }
             if (__USBInstallMouse) {

--- a/libraries/Keyboard/examples/KeyboardPassword/KeyboardPassword.ino
+++ b/libraries/Keyboard/examples/KeyboardPassword/KeyboardPassword.ino
@@ -26,7 +26,19 @@ void setup() {
 void loop() {
   if (BOOTSEL) {
     Serial.println("Typing password for you...shhhh....");
+
+    Serial.println("First, mute the computer to be extra quiet");
+    Keyboard.consumerPress(KEY_MUTE);
+    delay(100);
+    Keyboard.consumerRelease();
+
     Keyboard.print("ThisPasswordIsWeakLikeABaby");
+
+    Serial.println("OK, unmute the computer since our secret is done");
+    Keyboard.consumerPress(KEY_MUTE);
+    delay(100);
+    Keyboard.consumerRelease();
+
     while (BOOTSEL);
   }
 }

--- a/libraries/Keyboard/src/Keyboard.cpp
+++ b/libraries/Keyboard/src/Keyboard.cpp
@@ -46,6 +46,16 @@ void Keyboard_::sendReport(KeyReport* keys) {
     tud_task();
 }
 
+void Keyboard_::sendConsumerReport(uint16_t key) {
+    CoreMutex m(&__usb_mutex);
+    tud_task();
+    if (tud_hid_ready()) {
+        tud_hid_report(__USBGetKeyboardReportID() + 1, &key, sizeof(key));
+    }
+    tud_task();
+}
+
+
 extern "C" void tud_hid_set_report_cb(uint8_t instance, uint8_t report_id, hid_report_type_t report_type, uint8_t const* buffer, uint16_t bufsize) {
     (void) report_id;
     (void) instance;

--- a/libraries/Keyboard/src/Keyboard.h
+++ b/libraries/Keyboard/src/Keyboard.h
@@ -28,6 +28,7 @@
 class Keyboard_ : public HID_Keyboard {
 protected:
     virtual void sendReport(KeyReport* keys) override;
+    virtual void sendConsumerReport(uint16_t key) override;
 
 public:
     Keyboard_(void);

--- a/libraries/KeyboardBLE/src/KeyboardBLE.cpp
+++ b/libraries/KeyboardBLE/src/KeyboardBLE.cpp
@@ -63,4 +63,9 @@ void KeyboardBLE_::sendReport(KeyReport* keys) {
     PicoBluetoothBLEHID.send(&data, sizeof(data));
 }
 
+void KeyboardBLE_::sendConsumerReport(uint16_t key) {
+    (void) key;
+    // TODO - Need some BLE-specific code to send 2nd report
+}
+
 KeyboardBLE_ KeyboardBLE;

--- a/libraries/KeyboardBLE/src/KeyboardBLE.h
+++ b/libraries/KeyboardBLE/src/KeyboardBLE.h
@@ -28,6 +28,7 @@
 class KeyboardBLE_ : public HID_Keyboard {
 private:
     virtual void sendReport(KeyReport* keys) override;
+    virtual void sendConsumerReport(uint16_t key) override;
 public:
     KeyboardBLE_(void);
     void begin(const char *localName = nullptr, const char *hidName = nullptr, const uint8_t *layout = KeyboardLayout_en_US);

--- a/libraries/KeyboardBT/src/KeyboardBT.cpp
+++ b/libraries/KeyboardBT/src/KeyboardBT.cpp
@@ -34,7 +34,7 @@ KeyboardBT_::KeyboardBT_(void) {
 
 #define REPORT_ID 0x01
 
-static const uint8_t desc_keyboard[] = {TUD_HID_REPORT_DESC_KEYBOARD(HID_REPORT_ID(REPORT_ID))};
+static const uint8_t desc_keyboard[] = {TUD_HID_REPORT_DESC_KEYBOARD(HID_REPORT_ID(REPORT_ID)), TUD_HID_REPORT_DESC_CONSUMER(HID_REPORT_ID(REPORT_ID + 1))};
 
 static void _hidReportCB(uint16_t cid, hid_report_type_t report_type, uint16_t report_id, int report_size, uint8_t *report) {
     (void) cid;
@@ -69,6 +69,10 @@ void KeyboardBT_::sendReport(KeyReport* keys) {
     data.reserved = 0;
     memcpy(data.keycode, keys->keys, sizeof(data.keycode));
     PicoBluetoothHID.send(REPORT_ID, &data, sizeof(data));
+}
+
+void KeyboardBT_::sendConsumerReport(uint16_t key) {
+    PicoBluetoothHID.send(REPORT_ID + 1, &key, sizeof(key));
 }
 
 KeyboardBT_ KeyboardBT;

--- a/libraries/KeyboardBT/src/KeyboardBT.h
+++ b/libraries/KeyboardBT/src/KeyboardBT.h
@@ -28,6 +28,7 @@
 class KeyboardBT_ : public HID_Keyboard {
 protected:
     virtual void sendReport(KeyReport* keys) override;
+    virtual void sendConsumerReport(uint16_t key) override;
 public:
     KeyboardBT_(void);
     void begin(const char *localName = nullptr, const char *hidName = nullptr, const uint8_t *layout = KeyboardLayout_en_US);


### PR DESCRIPTION
Allow sending thigns like KEY_MUTE or KEY_SCAN_NEXT from the USB and Bluetooth Classic keyboard libraries.

BLE requires some add'l magic, not yet discovered.