### PR TITLE
Clean up CoreMutex and __isFreeRTOS definition

### DIFF
--- a/cores/rp2040/Arduino.h
+++ b/cores/rp2040/Arduino.h
@@ -84,12 +84,12 @@ void analogWriteFreq(uint32_t freq);
 void analogWriteRange(uint32_t range);
 void analogWriteResolution(int res);
 
-// FreeRTOS potential calls
-extern bool __isFreeRTOS;
-
 #ifdef __cplusplus
 } // extern "C"
 #endif
+
+// FreeRTOS potential calls
+extern bool __isFreeRTOS;
 
 // Ancient AVR defines
 #define HAVE_HWSERIAL0

--- a/cores/rp2040/CoreMutex.h
+++ b/cores/rp2040/CoreMutex.h
@@ -43,5 +43,5 @@ public:
 private:
     mutex_t *_mutex;
     bool _acquired;
-    u_int8_t _option;
+    uint8_t _option;
 };


### PR DESCRIPTION
See #1311 for more info.  __isFreeRTOS is C++ linkage and only used in the core proper (all C++).