### PR TITLE
Clear compile errors if BT needed but not on

### DIFF
--- a/cores/rp2040/_needsbt.h
+++ b/cores/rp2040/_needsbt.h
@@ -1,0 +1,7 @@
+// Simple helper header to ensure pico libs support ?BT
+
+#ifndef ENABLE_CLASSIC
+#define ENABLE_CLASSIC 0
+#endif
+
+static_assert(ENABLE_CLASSIC, "This library needs Bluetooth enabled.  Use the 'Tools->IP/Bluetooth Stack' menu in the IDE to enable it.");

--- a/libraries/BTstackLib/src/BTstackLib.h
+++ b/libraries/BTstackLib/src/BTstackLib.h
@@ -1,6 +1,9 @@
 /**
     Arduino Wrapper for BTstack
 */
+
+#include <_needsbt.h>
+
 #ifndef __ARDUINO_BTSTACK_H
 #define __ARDUINO_BTSTACK_H
 

--- a/libraries/HID_Bluetooth/src/PicoBluetoothBLEHID.h
+++ b/libraries/HID_Bluetooth/src/PicoBluetoothBLEHID.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <_needsbt.h>
 #include <Arduino.h>
 #include <functional>
 #include <pico/cyw43_arch.h>

--- a/libraries/HID_Bluetooth/src/PicoBluetoothHID.h
+++ b/libraries/HID_Bluetooth/src/PicoBluetoothHID.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include <_needsbt.h>
 #include <Arduino.h>
 #include <functional>
 #include <pico/cyw43_arch.h>

--- a/libraries/SerialBT/src/SerialBT.h
+++ b/libraries/SerialBT/src/SerialBT.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <_needsbt.h>
 #include <Arduino.h>
 #include <api/HardwareSerial.h>
 #include <stdarg.h>


### PR DESCRIPTION
Fixes #1370

Adds a simple helper assertion to tell the user how to enable BT if it's not enabled, instead of some odd compilation warnings about undefined functions.