### PR TITLE
Add PICO_FLASH_SIZE_BYTES to PIO

### DIFF
--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -126,7 +126,10 @@ env.Append(
         ("BOARD_NAME", '\\"%s\\"' % env.subst("$BOARD")),
         "ARM_MATH_CM0_FAMILY",
         "ARM_MATH_CM0_PLUS",
-        "TARGET_RP2040"
+        "TARGET_RP2040",
+        # at this point, the main.py builder script hasn't updated upload.maximum_size yet,
+        # so it's the  original value for the full flash.
+        ("PICO_FLASH_SIZE_BYTES", board.get("upload.maximum_size"))
     ],
 
     CPPPATH=[


### PR DESCRIPTION
Complementary to #1414 for PlatformIO's defines.

Tested with 
```ini
board = waveshare_rp2040_plus_16mb
board_build.filesystem_size = 1m
```
and it gives indeed the full 
```
-DPICO_FLASH_SIZE_BYTES=16777216
```
which is exactly `16*1024*1024`.