### PR TITLE
Fix USB Mouse/Joystick HID report ID

### DIFF
--- a/cores/rp2040/RP2040USB.cpp
+++ b/cores/rp2040/RP2040USB.cpp
@@ -130,13 +130,13 @@ int __USBGetKeyboardReportID() {
 }
 
 int __USBGetMouseReportID() {
-    return __USBInstallKeyboard ? 2 : 1;
+    return __USBInstallKeyboard ? 3 : 1;
 }
 
 int __USBGetJoystickReportID() {
     int i = 1;
     if (__USBInstallKeyboard) {
-        i++;
+        i += 2;
     }
     if (__USBInstallMouse || __USBInstallAbsoluteMouse) {
         i++;


### PR DESCRIPTION
Fixes #1410

The USB Keyboard now has 2 reports (keyboard + consumer control), so when both Keyboard and Mouse libraries are included, the Mouse must be report 3, not 2.

Update the Mouse and Joystick report IDs appropriately.