### PR TITLE
Fix USB crashes in FreeRTOS

### DIFF
--- a/cores/rp2040/CoreMutex.cpp
+++ b/cores/rp2040/CoreMutex.cpp
@@ -33,7 +33,9 @@ CoreMutex::CoreMutex(mutex_t *mutex, uint8_t option) {
         if (_option & FromISR) {
             __freertos_mutex_take_from_isr(m);
         } else {
-            __freertos_mutex_take(m);
+            if (!__freertos_mutex_try_take(m)) {
+                return;
+            }
         }
     } else {
         uint32_t owner;

--- a/libraries/FreeRTOS/src/variantHooks.cpp
+++ b/libraries/FreeRTOS/src/variantHooks.cpp
@@ -380,9 +380,10 @@ static void __usb(void *param) {
     __usbInitted = true;
 
     while (true) {
-        if (mutex_try_enter(&__usb_mutex, NULL)) {
+        auto m = __get_freertos_mutex_for_ptr(&__usb_mutex);
+        if (xSemaphoreTake(m, 0)) {
             tud_task();
-            mutex_exit(&__usb_mutex);
+            xSemaphoreGive(m);
         }
         vTaskDelay(1 / portTICK_PERIOD_MS);
     }


### PR DESCRIPTION
Fixes #1402

The global USB mutex is auto-shadowed with a FreeRTOS semaphore while in FreeRTOS mode.  Unfortunately, while the core was using the proper FreeRTOS semaphore to lock access to the USB port, the actual FreeRTOS USB task was using the naked Pico SDK mutex, leading to cases where it could acquire the mutex even though some other FreeRTOS task actually owned the shadowed mutex.

Properly lock the shadowed Semaphore, not mutex_t, in the FreeRTOS USB periodic task.