### PR TITLE
Merge latest FreeRTOS/SMP upstream branch

### DIFF
--- a/cores/rp2040/main.cpp
+++ b/cores/rp2040/main.cpp
@@ -162,6 +162,7 @@ extern "C" void __register_impure_ptr(struct _reent *p) {
     }
 }
 
+extern "C" struct _reent *__wrap___getreent() __attribute__((weak));
 extern "C" struct _reent *__wrap___getreent() {
     if (get_core_num() == 0) {
         return _impure_ptr;

--- a/libraries/FreeRTOS/keywords.txt
+++ b/libraries/FreeRTOS/keywords.txt
@@ -36,6 +36,7 @@ pcTaskGetName KEYWORD2
 ulTaskNotifyTake	KEYWORD2
 vTaskNotifyGiveFromISR	KEYWORD2
 taskYIELD	KEYWORD2
+vTaskCoreAffinitySet	KEYWORD2
 vTaskSuspend	KEYWORD2
 vTaskResume	KEYWORD2
 xTaskResumeFromISR	KEYWORD2
@@ -43,6 +44,7 @@ xTaskGetTickCount	KEYWORD2
 xTaskGetTickCountFromISR	KEYWORD2
 uxTaskGetNumberOfTasks	KEYWORD2
 uxTaskGetStackHighWaterMark	KEYWORD2
+uxTaskGetSystemState	KEYWORD2
 
 # Instances (KEYWORD2)
 

--- a/libraries/FreeRTOS/src/FreeRTOSConfig.h
+++ b/libraries/FreeRTOS/src/FreeRTOSConfig.h
@@ -29,10 +29,7 @@
 #define configUSE_TASK_PREEMPTION_DISABLE 1
 
 #define configUSE_NEWLIB_REENTRANT 1
-#define configNEWLIB_REENTRANT_IS_DYNAMIC 0 /* Note that we have a different config option, portSET_IMPURE_PTR */
-#include <reent.h>
-extern void __register_impure_ptr(struct _reent *p);
-#define portSET_IMPURE_PTR(x) __register_impure_ptr(x)
+#define configNEWLIB_REENTRANT_IS_DYNAMIC 1
 
 /* Run time stats related definitions. */
 void vMainConfigureTimerForRunTimeStats(void);

--- a/libraries/FreeRTOS/src/tasks.c
+++ b/libraries/FreeRTOS/src/tasks.c
@@ -1,1 +1,14 @@
 #include "../lib/FreeRTOS-Kernel/tasks.c"
+
+//See https://github.com/FreeRTOS/FreeRTOS-Kernel/pull/496
+struct _reent* __wrap___getreent(void) {
+    // No lock needed because if this changes, we won't be running anymore.
+    TCB_t *pxCurTask = xTaskGetCurrentTaskHandle();
+    if (pxCurTask == NULL) {
+        // No task running. Return global struct.
+        return _GLOBAL_REENT;
+    } else {
+        // We have a task; return its reentrant struct.
+        return &pxCurTask->xNewLib_reent;
+    }
+}


### PR DESCRIPTION
Update to head of upstream FreeRTOS/SMP branch.  Very minor changes.

Remove the custom getreent implementation, use the one that was defined in the upstream FreeRTOS/smp branch (callback related vs. static vars).