### PR TITLE
CoreMutex portYield

### DIFF
--- a/cores/rp2040/CoreMutex.cpp
+++ b/cores/rp2040/CoreMutex.cpp
@@ -30,12 +30,11 @@ CoreMutex::CoreMutex(mutex_t *mutex, uint8_t option) {
     _option = option;
     if (__isFreeRTOS) {
         auto m = __get_freertos_mutex_for_ptr(mutex);
-        if (__freertos_check_if_in_isr()) {
-            __freertos_mutex_take_from_isr(m);
-        } else {
-            if (!__freertos_mutex_try_take(m)) {
-                return;
+        if (__freertos_check_if_in_isr() && !__freertos_mutex_take_from_isr(m)) {
+            	return;
             }
+        else {
+            __freertos_mutex_take(m);
         }
     } else {
         uint32_t owner;
@@ -57,7 +56,7 @@ CoreMutex::~CoreMutex() {
         if (__isFreeRTOS) {
             auto m = __get_freertos_mutex_for_ptr(_mutex);
             if (__freertos_check_if_in_isr()) {
-                __freertos_mutex_give_from_isr(m);
+                __freertos_mutex_give_from_isr(m, true);
             } else {
                 __freertos_mutex_give(m);
             }

--- a/cores/rp2040/_freertos.h
+++ b/cores/rp2040/_freertos.h
@@ -37,22 +37,26 @@ extern "C" {
     typedef QueueHandle_t SemaphoreHandle_t;
 #endif
 
+    extern void __freertos_idle_other_core() __attribute__((weak));
+    extern void __freertos_resume_other_core() __attribute__((weak));
+
+}
     extern bool __freertos_check_if_in_isr() __attribute__((weak));
 
     extern SemaphoreHandle_t __freertos_mutex_create() __attribute__((weak));
     extern SemaphoreHandle_t _freertos_recursive_mutex_create() __attribute__((weak));
 
     extern void __freertos_mutex_take(SemaphoreHandle_t mtx) __attribute__((weak));
-    extern void __freertos_mutex_take_from_isr(SemaphoreHandle_t mtx) __attribute__((weak));
+    extern int __freertos_mutex_take_from_isr(SemaphoreHandle_t mtx) __attribute__((weak));
     extern int __freertos_mutex_try_take(SemaphoreHandle_t mtx) __attribute__((weak));
     extern void __freertos_mutex_give(SemaphoreHandle_t mtx) __attribute__((weak));
     extern void __freertos_mutex_give_from_isr(SemaphoreHandle_t mtx) __attribute__((weak));
+    extern void __freertos_mutex_give_from_isr(SemaphoreHandle_t mtx, bool portYield) __attribute__((weak));
 
     extern void __freertos_recursive_mutex_take(SemaphoreHandle_t mtx) __attribute__((weak));
     extern int __freertos_recursive_mutex_try_take(SemaphoreHandle_t mtx) __attribute__((weak));
     extern void __freertos_recursive_mutex_give(SemaphoreHandle_t mtx) __attribute__((weak));
 
-    extern void __freertos_idle_other_core() __attribute__((weak));
-    extern void __freertos_resume_other_core() __attribute__((weak));
-}
+
+
 extern SemaphoreHandle_t __get_freertos_mutex_for_ptr(mutex_t *m, bool recursive = false);


### PR DESCRIPTION
This is a PR wich includes : 

- The same update for Mutex/ISR for https://github.com/earlephilhower/arduino-pico/issues/1470
- A possible way to implement a coreMutex_give_fromISR which includes a portYield option.

Not yet tested, can do that after june 5.