### PR TITLE
Added function overload to pass name to setup().

### DIFF
--- a/libraries/BTstackLib/src/BTstackLib.cpp
+++ b/libraries/BTstackLib/src/BTstackLib.cpp
@@ -778,6 +778,10 @@ static hci_transport_config_uart_t config = {
 static btstack_packet_callback_registration_t hci_event_callback_registration;
 
 void BTstackManager::setup(void) {
+    setup("BTstack LE Shield");
+}
+
+void BTstackManager::setup(const char * name) {
 
     //#ifdef PIN_LED
     //    pinMode(PIN_LED, OUTPUT);
@@ -826,7 +830,6 @@ void BTstackManager::setup(void) {
     const uint8_t flags[] = { 0x02, 0x01, 0x02 };
     memcpy(&adv_data[pos], flags, sizeof(flags));
     pos += sizeof(flags);
-    const char * name = "BTstack LE Shield";
     adv_data[pos++] = strlen(name) + 1;
     adv_data[pos++] = 0x09;
     memcpy(&adv_data[pos], name, strlen(name));

--- a/libraries/BTstackLib/src/BTstackLib.h
+++ b/libraries/BTstackLib/src/BTstackLib.h
@@ -135,6 +135,7 @@ extern "C" {
     public:
         BTstackManager(void);
         void setup(void);
+        void setup(const char * name);
         void loop(void);
 
         void setPublicBdAddr(bd_addr_t addr);


### PR DESCRIPTION
Added a simple function overload to BTstackManager::setup()  to allow a name for the BT instance to be passed.

