### PR TITLE
CoreMutex add portYield

### DIFF
--- a/cores/rp2040/CoreMutex.cpp
+++ b/cores/rp2040/CoreMutex.cpp
@@ -30,12 +30,11 @@ CoreMutex::CoreMutex(mutex_t *mutex, uint8_t option) {
     _option = option;
     if (__isFreeRTOS) {
         auto m = __get_freertos_mutex_for_ptr(mutex);
-        if (__freertos_check_if_in_isr()) {
-            __freertos_mutex_take_from_isr(m);
-        } else {
-            if (!__freertos_mutex_try_take(m)) {
+        if (__freertos_check_if_in_isr() && !__freertos_mutex_take_from_isr(m)) {
                 return;
             }
+        else {
+            __freertos_mutex_take(m);
         }
     } else {
         uint32_t owner;
@@ -57,7 +56,7 @@ CoreMutex::~CoreMutex() {
         if (__isFreeRTOS) {
             auto m = __get_freertos_mutex_for_ptr(_mutex);
             if (__freertos_check_if_in_isr()) {
-                __freertos_mutex_give_from_isr(m);
+                __freertos_mutex_give_from_isr(m, true);
             } else {
                 __freertos_mutex_give(m);
             }

--- a/cores/rp2040/_freertos.h
+++ b/cores/rp2040/_freertos.h
@@ -43,10 +43,10 @@ extern "C" {
     extern SemaphoreHandle_t _freertos_recursive_mutex_create() __attribute__((weak));
 
     extern void __freertos_mutex_take(SemaphoreHandle_t mtx) __attribute__((weak));
-    extern void __freertos_mutex_take_from_isr(SemaphoreHandle_t mtx) __attribute__((weak));
+    extern int __freertos_mutex_take_from_isr(SemaphoreHandle_t mtx) __attribute__((weak));
     extern int __freertos_mutex_try_take(SemaphoreHandle_t mtx) __attribute__((weak));
     extern void __freertos_mutex_give(SemaphoreHandle_t mtx) __attribute__((weak));
-    extern void __freertos_mutex_give_from_isr(SemaphoreHandle_t mtx) __attribute__((weak));
+    extern void __freertos_mutex_give_from_isr(SemaphoreHandle_t mtx, bool portYield = false) __attribute__((weak));
 
     extern void __freertos_recursive_mutex_take(SemaphoreHandle_t mtx) __attribute__((weak));
     extern int __freertos_recursive_mutex_try_take(SemaphoreHandle_t mtx) __attribute__((weak));

--- a/libraries/FreeRTOS/src/variantHooks.cpp
+++ b/libraries/FreeRTOS/src/variantHooks.cpp
@@ -58,8 +58,8 @@ extern "C" {
         xSemaphoreTake(mtx, portMAX_DELAY);
     }
 
-    void __freertos_mutex_take_from_isr(SemaphoreHandle_t mtx) {
-        xSemaphoreTakeFromISR(mtx, NULL);
+    int __freertos_mutex_take_from_isr(SemaphoreHandle_t mtx) {
+        return xSemaphoreTakeFromISR(mtx, NULL);
     }
 
     int __freertos_mutex_try_take(SemaphoreHandle_t mtx) {
@@ -70,8 +70,15 @@ extern "C" {
         xSemaphoreGive(mtx);
     }
 
-    void __freertos_mutex_give_from_isr(SemaphoreHandle_t mtx) {
-        xSemaphoreGiveFromISR(mtx, NULL);
+    void __freertos_mutex_give_from_isr(SemaphoreHandle_t mtx, bool portYield) {
+        if (!portYield) {
+            xSemaphoreGiveFromISR(mtx, NULL);
+        }
+        else {
+            BaseType_t pxHigherPriorityTaskWoken;
+            xSemaphoreGiveFromISR(mtx, &pxHigherPriorityTaskWoken);
+            portYIELD_FROM_ISR(pxHigherPriorityTaskWoken);
+        }
     }
 
     void __freertos_recursive_mutex_take(SemaphoreHandle_t mtx) {


### PR DESCRIPTION
This is a PR wich includes :

The same update for Mutex/ISR for https://github.com/earlephilhower/arduino-pico/issues/1470
A possible way to implement a coreMutex_give_fromISR which includes a portYield option.
Not yet tested, can do that after june 5.