### PR TITLE
make dma_claim_unused_channel() not panic in AudioBufferManager::begin()

### DIFF
--- a/libraries/AudioBufferManager/src/AudioBufferManager.cpp
+++ b/libraries/AudioBufferManager/src/AudioBufferManager.cpp
@@ -114,7 +114,7 @@ bool AudioBufferManager::begin(int dreq, volatile void *pioFIFOAddr) {
 
     // Get ping and pong DMA channels
     for (auto i = 0; i < 2; i++) {
-        _channelDMA[i] = dma_claim_unused_channel(true);
+        _channelDMA[i] = dma_claim_unused_channel(false);
         if (_channelDMA[i] == -1) {
             if (i == 1) {
                 dma_channel_unclaim(_channelDMA[0]);


### PR DESCRIPTION
If `dma_claim_unused_channel(true)` panics when none are available, then why have the check if it returned -1? 
I think you might mean `dma_claim_unused_channel(false)`, so that begin() can just return false.

Warning:
I'm sorry, but I haven't tested it. And to be honest, I'm not even completely sure what exactly these functions do. Please review carefully. I hope this is still useful.