### PR TITLE
Fix serial reset hang under FreeRTOS

### DIFF
--- a/cores/rp2040/SerialUSB.cpp
+++ b/cores/rp2040/SerialUSB.cpp
@@ -188,7 +188,7 @@ static void CheckSerialReset() {
         reset_block(RESETS_RESET_USBCTRL_BITS);
         unreset_block(RESETS_RESET_USBCTRL_BITS);
         // Delay a bit, so the PC can figure out that we have disconnected.
-        sleep_ms(3);
+        busy_wait_ms(3);
         reset_usb_boot(0, 0);
         while (1); // WDT will fire here
     }


### PR DESCRIPTION
The serial port reset logic was calling `sleep_ms()` which ended up doing a task switch...while the other core was frozen and everything was supposed to be locked.

Use `busy_wait_ms()` which is a tight loop to delay in the reset portion.

Fixes #1486