### PR TITLE
AudioBufferManager(I2s, PWMAudio, ADCInput) xover

### DIFF
--- a/libraries/AudioBufferManager/src/AudioBufferManager.cpp
+++ b/libraries/AudioBufferManager/src/AudioBufferManager.cpp
@@ -257,7 +257,7 @@ void __not_in_flash_func(AudioBufferManager::_dmaIRQ)(int channel) {
             _active[1] = _takeFromList(&_filled);
         }
         _overunderflow = _overunderflow | (_active[1] == _silence);
-        dma_channel_set_read_addr(channel, _active[0]->buff, false);
+        dma_channel_set_read_addr(channel, _active[1]->buff, false);
     } else {
         if (_empty) {
             _addToList(&_filled, _active[0]);
@@ -266,7 +266,7 @@ void __not_in_flash_func(AudioBufferManager::_dmaIRQ)(int channel) {
         } else {
             _overunderflow = true;
         }
-        dma_channel_set_write_addr(channel, _active[0]->buff, false);
+        dma_channel_set_write_addr(channel, _active[1]->buff, false);
     }
     dma_channel_set_trans_count(channel, _wordsPerBuffer * (_dmaSize == DMA_SIZE_16 ? 2 : 1), false);
     dma_channel_acknowledge_irq0(channel);


### PR DESCRIPTION
The ABM had an off-by-one error in the DMA buffer swapover.  Instead of setting the DMA address to the newly added buffer in active[], it set it to the buffer that was currently running.

This would effectively disable the ping-pong and cause clicks/lost data.

Fixes #1491