### PR TITLE
fix for invalid __channelCount in ~AudioBufferManager()

### DIFF
--- a/libraries/AudioBufferManager/src/AudioBufferManager.cpp
+++ b/libraries/AudioBufferManager/src/AudioBufferManager.cpp
@@ -78,8 +78,8 @@ AudioBufferManager::~AudioBufferManager() {
             dma_channel_abort(_channelDMA[i]);
             dma_channel_unclaim(_channelDMA[i]);
             dma_channel_acknowledge_irq0(_channelDMA[i]);
+            __channelCount--;
         }
-        __channelCount--;
         if (!__channelCount) {
             irq_set_enabled(DMA_IRQ_0, false);
             // TODO - how can we know if there are no other parts of the core using DMA0 IRQ??


### PR DESCRIPTION
**AudioOutputPWM** method from [ESP8266Audio](https://github.com/earlephilhower/ESP8266Audio) library plays very first audio file just fine,
but gets stuck on a second one.

This is the gdb batcktrace:

```
(gdb) bt
#0  dma_channel_get_irq0_status (channel=3)
    at /home/user/Arduino/hardware/pico/rp2040//pico-sdk/src/rp2_common/hardware_dma/include/hardware/dma.h:633
#1  AudioBufferManager::_irq ()
    at /home/user/Arduino/hardware/pico/rp2040/libraries/AudioBufferManager/src/AudioBufferManager.cpp:281
#2  0x20000cb8 in irq_handler_chain_slots ()
Backtrace stopped: previous frame identical to this frame (corrupt stack?)
(gdb)
```

It was found out that the issue is caused by ~AudioBufferManager() destructor that have not freed the irq resource properly after the first run.

This commit fixes the issue. 
**AudioOutputPWM** (ESP8266Audio) can play multiple of WAV files now.

