### PR TITLE
I2S: reuse current PIO & SM settings on a second and further runs

### DIFF
--- a/libraries/I2S/src/I2S.cpp
+++ b/libraries/I2S/src/I2S.cpp
@@ -46,6 +46,7 @@ I2S::I2S(PinMode direction) {
     }
 #endif
     _freq = 48000;
+    _pio = nullptr;
     _arb = nullptr;
     _cb = nullptr;
     _buffers = 6;
@@ -145,7 +146,10 @@ bool I2S::begin() {
     } else {
         _i2s = new PIOProgram(_isOutput ? (_isLSBJ ? &pio_lsbj_out_swap_program : &pio_i2s_out_swap_program) : &pio_i2s_in_swap_program);
     }
-    _i2s->prepare(&_pio, &_sm, &off);
+    /* reuse current PIO & SM settings on a second run because PIOProgram class has no destructor implemented */
+    if (_pio == nullptr) {
+      _i2s->prepare(&_pio, &_sm, &off);
+    }
     if (_isOutput) {
         if (_isLSBJ) {
             pio_lsbj_out_program_init(_pio, _sm, off, _pinDOUT, _pinBCLK, _bps, _swapClocks);

--- a/libraries/I2S/src/I2S.cpp
+++ b/libraries/I2S/src/I2S.cpp
@@ -148,7 +148,7 @@ bool I2S::begin() {
     }
     /* reuse current PIO & SM settings on a second run because PIOProgram class has no destructor implemented */
     if (_pio == nullptr) {
-      _i2s->prepare(&_pio, &_sm, &off);
+        _i2s->prepare(&_pio, &_sm, &off);
     }
     if (_isOutput) {
         if (_isLSBJ) {


### PR DESCRIPTION
Since PIOProgram class destructor is not implemented - 'delete _i2s' operation has no any noticeable effect.
_i2s->prepare(&_pio, &_sm, &off) is trying to allocate new PIO & SM on every begin() call which causes troubles when multiple of WAV files being played.

