### PR TITLE
Fix: I2S::available() returning too many bytes

### DIFF
--- a/libraries/I2S/src/I2S.cpp
+++ b/libraries/I2S/src/I2S.cpp
@@ -204,13 +204,8 @@ int I2S::available() {
     } else {
         auto avail = _arb->available();
         avail *= 4; // 4 samples per 32-bits
-        if (_bps < 24) {
-            if (_isOutput) {
-                // 16- and 8-bit can have holding bytes available
-                avail += (32 - _isHolding) / 8;
-            } else {
-                avail += _isHolding / 8;
-            }
+        if (_bps < 24 && !_isOutput) {
+            avail += _isHolding / 8;
         }
         return avail;
     }


### PR DESCRIPTION
IMHO _isHolding should not be considered in available() when I2S is an output.
Because:
1. not all write methods use _holdWord. If only write(int32, bool) or write(uint8_t, size_t) are used, available() always returned 4 bytes too many.
2. If _arb->available() == 0, but there is space in _holdWord, and you write enough to fill _holdWord, then 4 Bytes get written to _arb. This would block. 

With this fix it's always guaranteed that you can write the amount of bytes that available() returned without it getting blocked.
It *might* be possible to sometimes write more. (If there is space in _holdWord or if a buffer finished playing since available() was called.)

MCVE for scenario 1:
Without this patch: LED never turns on because available() never returns 0.
With this patch: LED turns on.
(Tested without actually having a speaker connected.)
```ino
#include <Arduino.h>
#include <I2S.h>
I2S i2s = I2S(OUTPUT);

void setup() {
  pinMode(LED_BUILTIN, OUTPUT);
  digitalWrite(LED_BUILTIN, LOW);
  Serial.begin();
  while (!Serial);
  delay(1000);
  i2s.setBCLK(26);  // WS = 27
  i2s.setDATA(28);
  i2s.setBitsPerSample(16);
  i2s.setBuffers(16, 1024);
    if (!i2s.begin(sampleRate)) {
    while (true){
      Serial.println("fail");
    }
  }
  Serial.println("LED should turn on soon");
}

void loop() {
  while(i2s.available()){
    int32_t silence = 0;
    i2s.write(silence, false);
  }
  digitalWrite(LED_BUILTIN, HIGH);
}
```
