### PR TITLE
fix typo in fs.rst regarding info64

### DIFF
--- a/docs/fs.rst
+++ b/docs/fs.rst
@@ -325,8 +325,8 @@ info64
 .. code:: cpp
 
     FSInfo64 fsinfo;
-    SDFS.info(fsinfo);
-    or LittleFS(fsinfo);
+    SDFS.info64(fsinfo);
+    or LittleFS.info64(fsinfo);
 
 Performs the same operation as ``info`` but allows for reporting greater than
 4GB for filesystem size/used/etc.  Should be used with the SD and SDFS


### PR DESCRIPTION
Example code for [`info64`](https://arduino-pico.readthedocs.io/en/latest/fs.html#info64) has the incorrect function calls