### PR TITLE
fix: 'I2S::operator=(const I2S&)' is implicitly deleted (#1555)

### DIFF
--- a/libraries/I2S/src/I2S.h
+++ b/libraries/I2S/src/I2S.h
@@ -146,6 +146,6 @@ private:
     PIO _pio, _pioMCLK;
     int _sm, _smMCLK;
 
-    const int I2SSYSCLK_44_1 = 135600; // 44.1, 88.2 kHz sample rates
-    const int I2SSYSCLK_8 = 147600;  // 8k, 16, 32, 48, 96, 192 kHz
+    static const int I2SSYSCLK_44_1 = 135600; // 44.1, 88.2 kHz sample rates
+    static const int I2SSYSCLK_8 = 147600;  // 8k, 16, 32, 48, 96, 192 kHz
 };


### PR DESCRIPTION
Regression in #1555 
```
C:\Users\linus\Projekte\arduino-pico\libraries\I2S\src/I2S.h:26:7: note: 'I2S& I2S::operator=(const I2S&)' is implicitly deleted because the default definition would be ill-formed:  
   26 | class I2S : public Stream {
      |       ^~~
C:\Users\linus\Projekte\arduino-pico\libraries\I2S\src/I2S.h:26:7: error: non-static const member 'const int I2S::I2SSYSCLK_44_1', cannot use default assignment operator
C:\Users\linus\Projekte\arduino-pico\libraries\I2S\src/I2S.h:26:7: error: non-static const member 'const int I2S::I2SSYSCLK_8', cannot use default assignment operator
*** [.pio\build\rpipicow\src\main.cpp.o] Error 1
```
Making them static seems obvious to me, but I'm not sure if my fix is "best practice". If you have any other idea, feel free to do that. 

Context, why I really need an assignment operator:
We only know in begin() (and not already in the constructor) if we need an input or an output:
https://github.com/pschatzmann/arduino-audio-tools/blob/09773b0f7556d220a3fe581343461660bb8f921b/src/AudioI2S/I2SRP2040.h#L43-L49