### PR TITLE
Handle swapped Wire IRQs properly

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -108,11 +108,27 @@ void TwoWire::begin() {
 }
 
 static void _handler0() {
+#if defined(__WIRE0_DEVICE)
+    if (__WIRE0_DEVICE == i2c0) {
+        Wire.onIRQ();
+    } else {
+        Wire1.onIRQ();
+    }
+#else
     Wire.onIRQ();
+#endif
 }
 
 static void _handler1() {
+#if defined(__WIRE1_DEVICE)
+    if (__WIRE1_DEVICE == i2c0) {
+        Wire.onIRQ();
+    } else {
+        Wire1.onIRQ();
+    }
+#else
     Wire1.onIRQ();
+#endif
 }
 
 // Slave mode


### PR DESCRIPTION
When we swap the Wire objects, we need the i2c0 IRQ shim to call Wire1.onIRQ, not the usual Wire.onIRQ.  Same for i2c1 IRQ shim.

Fixes #1607