### PR TITLE
Fix PlatformIO intellisense

### DIFF
--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -53,7 +53,7 @@ for l in file_lines:
 
 def is_pio_build():
 	from SCons.Script import COMMAND_LINE_TARGETS
-	return "idedata" not in COMMAND_LINE_TARGETS and "_idedata" not in COMMAND_LINE_TARGETS
+	return all([x not in COMMAND_LINE_TARGETS for x in ["idedata", "_idedata", "__idedata"]])
 
 # get all activated macros
 flatten_cppdefines = env.Flatten(env['CPPDEFINES'])


### PR DESCRIPTION
Fixes issues observed in https://github.com/earlephilhower/arduino-pico/discussions/1615.

The `_idedata` has been changed to `__idedata` in newer PlatformIO core versions per https://github.com/platformio/platformio-core/commit/158aabbdf23ed1ff8f5e3f01fb4ef1723a78d3bb, first shipped in PIO core [v6.1.5](https://github.com/platformio/platformio-core/releases/tag/v6.1.5). This change has broken the logic to expand out the `-iprefix PATH @INCLUDEFILE` argument into its individual include paths, causing Intellisense breakages on some VSCode systems and other IDEs that didn't handle these arguments correctly or in which the path was corrupted.

This patch still has backwards compatibaility with older PlatformIO core versions since it checks for `idedata`, `_idedata` and `__idedata`.