### PR TITLE
SPI debugging: tiny fix & log actual baudrate

### DIFF
--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -187,8 +187,8 @@ void SPIClassRP2040::beginTransaction(SPISettings settings) {
             spi_deinit(_spi);
         }
         DEBUGSPI("SPI: initting SPI\n");
-        uint actualBauds = spi_init(_spi, _spis.getClockFreq());
-        DEBUGSPI("SPI: actual baudrate=%u\n", actualBauds);
+        spi_init(_spi, _spis.getClockFreq());
+        DEBUGSPI("SPI: actual baudrate=%u\n", spi_get_baudrate(_spi));
         _initted = true;
     }
 }

--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -177,7 +177,7 @@ void SPIClassRP2040::transfer(const void *txbuf, void *rxbuf, size_t count) {
 }
 
 void SPIClassRP2040::beginTransaction(SPISettings settings) {
-    DEBUGSPI("SPI::beginTransaction(clk=%lu, bo=%s\n", _spis.getClockFreq(), (_spis.getBitOrder() == MSBFIRST) ? "MSB" : "LSB");
+    DEBUGSPI("SPI::beginTransaction(clk=%lu, bo=%s)\n", settings.getClockFreq(), (settings.getBitOrder() == MSBFIRST) ? "MSB" : "LSB");
     if (_initted && settings == _spis) {
         DEBUGSPI("SPI: Reusing existing initted SPI\n");
     } else {
@@ -187,7 +187,8 @@ void SPIClassRP2040::beginTransaction(SPISettings settings) {
             spi_deinit(_spi);
         }
         DEBUGSPI("SPI: initting SPI\n");
-        spi_init(_spi, _spis.getClockFreq());
+        uint actualBauds = spi_init(_spi, _spis.getClockFreq());
+        DEBUGSPI("SPI: actual baudrate=%u\n", actualBauds);
         _initted = true;
     }
 }


### PR DESCRIPTION
1. I think in the first log line, you want to log the parameters with which beginTransaction() got called, and not the old settings. (_spis are the previous settings)
2. I wanted to see which baudrate was actually set. The compiler optimizes `actualBauds` away if logging is disabled, right?