### PR TITLE
Make it compile with IPv6 enabled

### DIFF
--- a/libraries/LEAmDNS/src/LEAmDNS_Control.cpp
+++ b/libraries/LEAmDNS/src/LEAmDNS_Control.cpp
@@ -268,7 +268,11 @@ bool MDNSResponder::_parseQuery(const MDNSResponder::stcMDNS_MsgHeader& p_MsgHea
                     remote = m_pUDPContext->getRemoteAddress();
                     local = WiFi.localIP();
                     netmask = WiFi.subnetMask();
+#if LWIP_IPV6
+                    if (ip4_addr_netcmp(&remote.u_addr.ip4, &local.u_addr.ip4, &netmask.u_addr.ip4))
+#else
                     if (ip4_addr_netcmp(&remote, &local, &netmask))
+#endif
                         //                        ip_info IPInfo_Local;
                         //                        ip_info IPInfo_Remote;
                         //                        if (((IPInfo_Remote.ip.addr = m_pUDPContext->getRemoteAddress()))


### PR DESCRIPTION
ip_addr_t has different structure with LWIP_IPV6 enabled. This fix makes it compile, but doesn't enable MDNS over IPv6.