### PR TITLE
Allow re-setting identical pins without panic()

### DIFF
--- a/cores/rp2040/SerialUART.cpp
+++ b/cores/rp2040/SerialUART.cpp
@@ -40,6 +40,10 @@ bool SerialUART::setRX(pin_size_t pin) {
         return true;
     }
 
+    if (_rx == pin) {
+        return true;
+    }
+
     if (_running) {
         panic("FATAL: Attempting to set Serial%d.RX while running", uart_get_index(_uart) + 1);
     } else {
@@ -54,6 +58,10 @@ bool SerialUART::setTX(pin_size_t pin) {
                                   };
     if ((!_running) && ((1 << pin) & valid[uart_get_index(_uart)])) {
         _tx = pin;
+        return true;
+    }
+
+    if (_tx == pin) {
         return true;
     }
 
@@ -74,6 +82,10 @@ bool SerialUART::setRTS(pin_size_t pin) {
         return true;
     }
 
+    if (_rts == pin) {
+        return true;
+    }
+
     if (_running) {
         panic("FATAL: Attempting to set Serial%d.RTS while running", uart_get_index(_uart) + 1);
     } else {
@@ -88,6 +100,10 @@ bool SerialUART::setCTS(pin_size_t pin) {
                                   };
     if ((!_running) && ((pin == UART_PIN_NOT_DEFINED) || ((1 << pin) & valid[uart_get_index(_uart)]))) {
         _cts = pin;
+        return true;
+    }
+
+    if (_cts == pin) {
         return true;
     }
 

--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -206,6 +206,10 @@ bool SPIClassRP2040::setRX(pin_size_t pin) {
         return true;
     }
 
+    if (_RX == pin) {
+        return true;
+    }
+
     if (_running) {
         panic("FATAL: Attempting to set SPI%s.RX while running", spi_get_index(_spi) ? "1" : "");
     } else {
@@ -220,6 +224,10 @@ bool SPIClassRP2040::setCS(pin_size_t pin) {
                                   };
     if ((!_running) && ((1 << pin) & valid[spi_get_index(_spi)])) {
         _CS = pin;
+        return true;
+    }
+
+    if (_CS == pin) {
         return true;
     }
 
@@ -240,6 +248,10 @@ bool SPIClassRP2040::setSCK(pin_size_t pin) {
         return true;
     }
 
+    if (_SCK == pin) {
+        return true;
+    }
+
     if (_running) {
         panic("FATAL: Attempting to set SPI%s.SCK while running", spi_get_index(_spi) ? "1" : "");
     } else {
@@ -254,6 +266,10 @@ bool SPIClassRP2040::setTX(pin_size_t pin) {
                                   };
     if ((!_running) && ((1 << pin) & valid[spi_get_index(_spi)])) {
         _TX = pin;
+        return true;
+    }
+
+    if (_TX == pin) {
         return true;
     }
 

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -56,6 +56,10 @@ bool TwoWire::setSDA(pin_size_t pin) {
         return true;
     }
 
+    if (_sda == pin) {
+        return true;
+    }
+
     if (_running) {
         panic("FATAL: Attempting to set Wire%s.SDA while running", i2c_hw_index(_i2c) ? "1" : "");
     } else {
@@ -70,6 +74,10 @@ bool TwoWire::setSCL(pin_size_t pin) {
                                   };
     if ((!_running) && ((1 << pin) & valid[i2c_hw_index(_i2c)])) {
         _scl = pin;
+        return true;
+    }
+
+    if (_scl == pin) {
         return true;
     }
 


### PR DESCRIPTION
Setting a pin to the current value is a no-op, not fatal.

Fixes #1652