### PR TITLE
Hopefully fix I2S #1656

### DIFF
--- a/libraries/AudioBufferManager/src/AudioBufferManager.cpp
+++ b/libraries/AudioBufferManager/src/AudioBufferManager.cpp
@@ -73,11 +73,9 @@ AudioBufferManager::~AudioBufferManager() {
     if (_running) {
         _running = false;
         for (auto i = 0; i < 2; i++) {
-            dma_channel_set_irq0_enabled(_channelDMA[i], false);
+            dma_channel_cleanup(_channelDMA[i]);
             __channelMap[_channelDMA[i]] = nullptr;
-            dma_channel_abort(_channelDMA[i]);
             dma_channel_unclaim(_channelDMA[i]);
-            dma_channel_acknowledge_irq0(_channelDMA[i]);
             __channelCount--;
         }
         if (!__channelCount) {

--- a/libraries/I2S/src/I2S.cpp
+++ b/libraries/I2S/src/I2S.cpp
@@ -237,8 +237,6 @@ bool I2S::begin() {
     }
     _arb->setCallback(_cb);
     pio_sm_set_enabled(_pio, _sm, true);
-    digitalWrite(LED_BUILTIN, pio_sm_is_tx_fifo_empty(_pio,_sm));
-    //delay(1000);
     return true;
 }
 

--- a/libraries/I2S/src/I2S.cpp
+++ b/libraries/I2S/src/I2S.cpp
@@ -363,6 +363,8 @@ size_t I2S::write(int32_t val, bool sync) {
     if (!_running || !_isOutput) {
         return 0;
     }
+    //Serial.print("pio_sm_is_tx_fifo_empty(_pio,_sm): ");
+    Serial.println(pio_sm_is_tx_fifo_empty(_pio,_sm));
     return _arb->write(val, sync);
 }
 

--- a/libraries/I2S/src/I2S.cpp
+++ b/libraries/I2S/src/I2S.cpp
@@ -237,7 +237,8 @@ bool I2S::begin() {
     }
     _arb->setCallback(_cb);
     pio_sm_set_enabled(_pio, _sm, true);
-
+    digitalWrite(LED_BUILTIN, pio_sm_is_tx_fifo_empty(_pio,_sm));
+    //delay(1000);
     return true;
 }
 
@@ -364,7 +365,8 @@ size_t I2S::write(int32_t val, bool sync) {
         return 0;
     }
     //Serial.print("pio_sm_is_tx_fifo_empty(_pio,_sm): ");
-    Serial.println(pio_sm_is_tx_fifo_empty(_pio,_sm));
+    //Serial.println(pio_sm_is_tx_fifo_empty(_pio,_sm));
+    //digitalWrite(LED_BUILTIN, pio_sm_is_tx_fifo_empty(_pio,_sm));
     return _arb->write(val, sync);
 }
 


### PR DESCRIPTION
Closes #1656 (maybe)
At least my tests, that sometimes or always triggered the bug, seem to work reliably with this change.

**But I don't understand why.**
So I'm not sure if this actually fixes the bug or just changed something, so I can't reproduce it any more. I would really appreciate it if you could look at this closely.

It looks like [dma_channel_cleanup()](https://github.com/raspberrypi/pico-sdk/blob/6a7db34ff63345a7badec79ebea3aaef1712f374/src/rp2_common/hardware_dma/dma.c#L73-L83) does (almost) the same as what was done in ~AudioBufferManager() except it also disables chain_to:
```cpp
    // Disable CHAIN_TO, and disable channel, so that it ignores any further triggers 
    hw_write_masked( &dma_hw->ch[channel].al1_ctrl, (channel << DMA_CH0_CTRL_TRIG_CHAIN_TO_LSB) | (0u << DMA_CH0_CTRL_TRIG_EN_LSB), DMA_CH0_CTRL_TRIG_CHAIN_TO_BITS | DMA_CH0_CTRL_TRIG_EN_BITS );
```
And this looks like it does exactly the same as `dma_channel_acknowledge_irq0()` except for both irq0 and irq1, but I don't see why that would matter.
```cpp
    // finally clear the IRQ status, which may have been set during abort
    dma_hw->intr = 1u << channel;
```

