### PR TITLE
Ensure HID reports aren't dropped

### DIFF
--- a/cores/rp2040/RP2040USB.cpp
+++ b/cores/rp2040/RP2040USB.cpp
@@ -394,6 +394,18 @@ void __USBStart() {
 }
 
 
+bool __USBHIDReady() {
+    uint32_t start = millis();
+    const uint32_t timeout = 500;
+
+    while (((millis() - start) < timeout) && tud_ready() && !tud_hid_ready()) {
+        tud_task();
+        delay(1);
+    }
+    return tud_hid_ready();
+}
+
+
 // Invoked when received GET_REPORT control request
 // Application must fill buffer report's content and return its length.
 // Return zero will cause the stack to STALL request

--- a/cores/rp2040/RP2040USB.h
+++ b/cores/rp2040/RP2040USB.h
@@ -45,3 +45,6 @@ int __USBGetJoystickReportID();
 
 // Called by main() to init the USB HW/SW.
 void __USBStart();
+
+// Helper class for HID report sending with wait and timeout
+bool __USBHIDReady();

--- a/libraries/Joystick/src/Joystick.cpp
+++ b/libraries/Joystick/src/Joystick.cpp
@@ -40,7 +40,7 @@ Joystick_::Joystick_(void) {
 void Joystick_::send_now(void) {
     CoreMutex m(&__usb_mutex);
     tud_task();
-    if (tud_hid_ready()) {
+    if (__USBHIDReady()) {
         tud_hid_n_report(0, __USBGetJoystickReportID(), &data, sizeof(data));
     }
     tud_task();

--- a/libraries/Keyboard/src/Keyboard.cpp
+++ b/libraries/Keyboard/src/Keyboard.cpp
@@ -40,7 +40,7 @@ Keyboard_::Keyboard_(void) {
 void Keyboard_::sendReport(KeyReport* keys) {
     CoreMutex m(&__usb_mutex);
     tud_task();
-    if (tud_hid_ready()) {
+    if (__USBHIDReady()) {
         tud_hid_keyboard_report(__USBGetKeyboardReportID(), keys->modifiers, keys->keys);
     }
     tud_task();
@@ -49,7 +49,7 @@ void Keyboard_::sendReport(KeyReport* keys) {
 void Keyboard_::sendConsumerReport(uint16_t key) {
     CoreMutex m(&__usb_mutex);
     tud_task();
-    if (tud_hid_ready()) {
+    if (__USBHIDReady()) {
         tud_hid_report(__USBGetKeyboardReportID() + 1, &key, sizeof(key));
     }
     tud_task();

--- a/libraries/Mouse/src/Mouse.cpp
+++ b/libraries/Mouse/src/Mouse.cpp
@@ -44,7 +44,7 @@ Mouse_::Mouse_(void) {
 void Mouse_::move(int x, int y, signed char wheel) {
     CoreMutex m(&__usb_mutex);
     tud_task();
-    if (tud_hid_ready()) {
+    if (__USBHIDReady()) {
         tud_hid_mouse_report(__USBGetMouseReportID(), _buttons, limit_xy(x), limit_xy(y), wheel, 0);
     }
     tud_task();


### PR DESCRIPTION
Fixes #1682

Make the HID report wait up to 500ms for an existing one to go out before giving up sending a report.