### PR TITLE
Fix gcc search path in make-ota.sh

### DIFF
--- a/ota/make-ota.sh
+++ b/ota/make-ota.sh
@@ -3,7 +3,7 @@
 set -e # Exit on error
 
 export PICO_SDK_PATH="$(cd ../pico-sdk/; pwd)"
-export PATH="$(cd ../../system/arm-none-eabi/bin; pwd):$PATH"
+export PATH="$(cd ../system/arm-none-eabi/bin; pwd):$PATH"
 
 rm -rf build
 mkdir build


### PR DESCRIPTION
It seems it was using the system wide install I had in the past.

This change makes the paths consistent with `make-libpico.sh`
https://github.com/earlephilhower/arduino-pico/blob/0b56452c353e4fc5c8c0bd8e4383c2dc2d0a49c6/tools/libpico/make-libpico.sh#L5-L6