### PR TITLE
Fix PicoProbe CMSIS restart of second core

### DIFF
--- a/platform.txt
+++ b/platform.txt
@@ -209,7 +209,7 @@ tools.picoprobe_cmsis_dap.cmd={runtime.platform.path}/system/openocd
 tools.picoprobe_cmsis_dap.upload.protocol=picoprobe_cmsis_dap
 tools.picoprobe_cmsis_dap.upload.params.verbose=
 tools.picoprobe_cmsis_dap.upload.params.quiet=
-tools.picoprobe_cmsis_dap.upload.pattern="{cmd}/bin/openocd" -f "interface/cmsis-dap.cfg" -f "target/rp2040.cfg" -s "{cmd}/share/openocd/scripts" -c "adapter speed 5000" -c "program {{build.path}/{build.project_name}.elf} verify" -c "reset init" -c "resume"
+tools.picoprobe_cmsis_dap.upload.pattern="{cmd}/bin/openocd" -f "interface/cmsis-dap.cfg" -f "target/rp2040.cfg" -s "{cmd}/share/openocd/scripts" -c "adapter speed 5000" -c "program {{build.path}/{build.project_name}.elf} verify" -c "reset init" -c "resume" -c "exit"
 
 #tools.picodebug.cmd={runtime.tools.pqt-openocd.path}
 tools.picodebug.cmd={runtime.platform.path}/system/openocd

--- a/platform.txt
+++ b/platform.txt
@@ -209,7 +209,7 @@ tools.picoprobe_cmsis_dap.cmd={runtime.platform.path}/system/openocd
 tools.picoprobe_cmsis_dap.upload.protocol=picoprobe_cmsis_dap
 tools.picoprobe_cmsis_dap.upload.params.verbose=
 tools.picoprobe_cmsis_dap.upload.params.quiet=
-tools.picoprobe_cmsis_dap.upload.pattern="{cmd}/bin/openocd" -f "interface/cmsis-dap.cfg" -f "target/rp2040.cfg" -s "{cmd}/share/openocd/scripts" -c "adapter speed 5000" -c "program {{build.path}/{build.project_name}.elf} verify reset exit"
+tools.picoprobe_cmsis_dap.upload.pattern="{cmd}/bin/openocd" -f "interface/cmsis-dap.cfg" -f "target/rp2040.cfg" -s "{cmd}/share/openocd/scripts" -c "adapter speed 5000" -c "program {{build.path}/{build.project_name}.elf} verify" -c "reset init" -c "resume"
 
 #tools.picodebug.cmd={runtime.tools.pqt-openocd.path}
 tools.picodebug.cmd={runtime.platform.path}/system/openocd


### PR DESCRIPTION
For some reason `program ... reset" causes OpenOCD to leave the chip in a state where the 2nd core does not come up properly, leading to problems in FreeRTOS and others.

Use a separate reset sequence after programming to work around the issue.

Fixes #1687