### PR TITLE
Check add'l binaries (GDB, OpenOCD, Picotool) run

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -139,6 +139,11 @@ jobs:
         git submodule update --init
         cd ..
         bash ./tests/build.sh
+    - name: Check misc binaries start up
+      run: |
+        .\system\openocd\bin\openocd.exe --version
+        .\system\picotool\picotool.exe help
+        .\system\arm-none-eabi\bin\arm-none-eabi-gdb.exe --version
 
 
 # Single build under macOS to ensure the Mac toolchain is good.
@@ -169,6 +174,11 @@ jobs:
         git submodule update --init
         cd ..
         bash ./tests/build.sh
+    - name: Check misc binaries start up
+      run: |
+        ./system/arm-none-eabi/bin/arm-none-eabi-gdb --version
+        ./system/openocd/bin/openocd --version
+        ./system/picotool/picotool help
 
 # Build a few examples with PlatformIO to test if integration works
   build-platformio:


### PR DESCRIPTION
For Mac and Windows builds, try to run the tools packaged in the pico-quick-toolchain release.  This should catch cases like seen in #1711