### PR TITLE
Allow full 8K stack for both cores, optionally

### DIFF
--- a/cores/rp2040/main.cpp
+++ b/cores/rp2040/main.cpp
@@ -44,6 +44,7 @@ void initVariant() __attribute__((weak));
 void initVariant() { }
 
 // Optional 2nd core setup and loop
+bool core1_separate_stack __attribute__((weak)) = false;
 extern void setup1() __attribute__((weak));
 extern void loop1() __attribute__((weak));
 extern "C" void main1() {
@@ -132,7 +133,11 @@ extern "C" int main() {
     if (!__isFreeRTOS) {
         if (setup1 || loop1) {
             delay(1); // Needed to make Picoprobe upload start 2nd core
-            multicore_launch_core1(main1);
+            if (core1_separate_stack) {
+                multicore_launch_core1_with_stack(main1, (uint32_t*)malloc(8192), 8192);
+            } else {
+                multicore_launch_core1(main1);
+            }
         }
         setup();
         while (true) {

--- a/docs/bearssl-server-secure-class.rst
+++ b/docs/bearssl-server-secure-class.rst
@@ -13,7 +13,7 @@ Similar to the `BearSSL::WiFiClientSecure` method, sets the receive and transmit
 Setting Server Certificates
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-TLS servers require a certificate identifying itself and containing its public key, and a private key they will use to encrypt information with.  The application author is responsible for generating this certificate and key, either using a self-signed generator or using a commercial certification authority.  **Do not re-use the certificates included in the examples provided.**
+TLS servers require a certificate identifying itself and containing its public key, and a private key they will use to encrypt information with.  The application author is responsible for generating this certificate and key, either using a self-signed generator or using a commercial certification authority.  **Do not reuse the certificates included in the examples provided.**
 
 This example command will generate a RSA 2048-bit key and certificate:
 

--- a/docs/multicore.rst
+++ b/docs/multicore.rst
@@ -16,6 +16,22 @@ not necessarily simultaneously!).
 See the ``Multicore.ino`` example in the ``rp2040`` example directory for a
 quick introduction.
 
+Stack Sizes
+-----------
+
+When the Pico is running in single core mode, core 0 has the full 8KB of stack
+space available to it.  When using multicore ``setup1``/``loop1`` the 8KB is split
+into two 4K stacks, one per core.  It is possible for core 0's stack to overwrite
+core 1's stack in this case, if you go beyond the 4K limitation.
+
+To allocate a separate 8K stack for core 1, resulting in 8K stacks being available
+for both cores, simply define the following variable in your sketch and set it
+to ``true``:
+
+.. code:: cpp
+
+    bool core1_separate_stack = true;
+
 Pausing Cores
 -------------
 

--- a/libraries/Joystick/examples/Joystick-AllFunctions/Joystick-AllFunctions.ino
+++ b/libraries/Joystick/examples/Joystick-AllFunctions/Joystick-AllFunctions.ino
@@ -20,9 +20,9 @@ void loop() {
       Joystick.button(i, true);
       delay(250);
       Joystick.button(i, false);
-      delay(10); //we need a short delay here, sending packets with less than 1ms leads to packet loss!
+      delay(10); // We need a short delay here, sending packets with less than 1ms leads to packet loss!
     }
-    //alternativ with manual send:
+    // Alternative with manual send:
     Joystick.useManualSend(true);
     Serial.println("Joystick buttons - manual send");
     for (uint8_t i = 1; i <= 32; i++) {
@@ -33,8 +33,8 @@ void loop() {
     }
     Joystick.useManualSend(false);
 
-    //iterate all joystick axis
-    //Note: although you can use 0-1023 here (10bit), internally 8bits are used (-127 to 127)
+    // Iterate all joystick axis
+    // Note: although you can use 0-1023 here (10bit), internally 8bits are used (-127 to 127)
     Serial.println("Joystick X");
     for (uint16_t i = 0; i < 1023; i++) {
       Joystick.X(i);
@@ -71,8 +71,8 @@ void loop() {
       delay(20);
     } Joystick.hat(-1);
 
-    //use int8 mode for the axis.
-    //Note: hat is not used differently.
+    // Use int8 mode for the axis.
+    // Note: hat is not used differently.
     Serial.println("Now all axis in 8bit mode, -127 to 127");
     Joystick.use8bit(true);
     Serial.println("Joystick X");

--- a/libraries/JoystickBLE/examples/BLEJoystick-AllFunctions/BLEJoystick-AllFunctions.ino
+++ b/libraries/JoystickBLE/examples/BLEJoystick-AllFunctions/BLEJoystick-AllFunctions.ino
@@ -20,9 +20,9 @@ void loop() {
       JoystickBLE.button(i, true);
       delay(250);
       JoystickBLE.button(i, false);
-      delay(10); //we need a short delay here, sending packets with less than 1ms leads to packet loss!
+      delay(10); // We need a short delay here, sending packets with less than 1ms leads to packet loss!
     }
-    //alternativ with manual send:
+    // Alternative with manual send:
     JoystickBLE.useManualSend(true);
     Serial.println("Joystick buttons - manual send");
     for (uint8_t i = 1; i <= 32; i++) {
@@ -33,8 +33,8 @@ void loop() {
     }
     JoystickBLE.useManualSend(false);
 
-    //iterate all joystick axis
-    //Note: although you can use 0-1023 here (10bit), internally 8bits are used (-127 to 127)
+    // Iterate all joystick axis
+    // Note: although you can use 0-1023 here (10bit), internally 8bits are used (-127 to 127)
     Serial.println("Joystick X");
     for (uint16_t i = 0; i < 1023; i++) {
       JoystickBLE.X(i);
@@ -71,8 +71,8 @@ void loop() {
       delay(20);
     } JoystickBLE.hat(-1);
 
-    //use int8 mode for the axis.
-    //Note: hat is not used differently.
+    // Use int8 mode for the axis.
+    // Note: hat is not used differently.
     Serial.println("Now all axis in 8bit mode, -127 to 127");
     JoystickBLE.use8bit(true);
     Serial.println("Joystick X");

--- a/libraries/JoystickBT/examples/BTJoystick-AllFunctions/BTJoystick-AllFunctions.ino
+++ b/libraries/JoystickBT/examples/BTJoystick-AllFunctions/BTJoystick-AllFunctions.ino
@@ -20,9 +20,9 @@ void loop() {
       JoystickBT.button(i, true);
       delay(250);
       JoystickBT.button(i, false);
-      delay(10); //we need a short delay here, sending packets with less than 1ms leads to packet loss!
+      delay(10); // We need a short delay here, sending packets with less than 1ms leads to packet loss!
     }
-    //alternativ with manual send:
+    // Alternative with manual send:
     JoystickBT.useManualSend(true);
     Serial.println("Joystick buttons - manual send");
     for (uint8_t i = 1; i <= 32; i++) {
@@ -33,8 +33,8 @@ void loop() {
     }
     JoystickBT.useManualSend(false);
 
-    //iterate all joystick axis
-    //Note: although you can use 0-1023 here (10bit), internally 8bits are used (-127 to 127)
+    // Iterate all joystick axis
+    // Note: although you can use 0-1023 here (10bit), internally 8bits are used (-127 to 127)
     Serial.println("Joystick X");
     for (uint16_t i = 0; i < 1023; i++) {
       JoystickBT.X(i);
@@ -71,8 +71,8 @@ void loop() {
       delay(20);
     } JoystickBT.hat(-1);
 
-    //use int8 mode for the axis.
-    //Note: hat is not used differently.
+    // Use int8 mode for the axis.
+    // Note: hat is not used differently.
     Serial.println("Now all axis in 8bit mode, -127 to 127");
     JoystickBT.use8bit(true);
     Serial.println("Joystick X");

--- a/libraries/lwIP_w5500/src/utility/w5500.h
+++ b/libraries/lwIP_w5500/src/utility/w5500.h
@@ -267,7 +267,7 @@ private:
     /**
         set the power mode of phy inside WIZCHIP. Refer to @ref PHYCFGR in W5500, @ref PHYSTATUS in
         W5200
-        @param pmode Settig value of power down mode.
+        @param pmode Setting value of power down mode.
     */
     int8_t wizphy_setphypmode(uint8_t pmode);
 
@@ -432,7 +432,7 @@ private:
     /* PHYCFGR register value */
     enum {
         PHYCFGR_RST         = ~(1 << 7),  //< For PHY reset, must operate AND mask.
-        PHYCFGR_OPMD        = (1 << 6),   // Configre PHY with OPMDC value
+        PHYCFGR_OPMD        = (1 << 6),   // Configure PHY with OPMDC value
         PHYCFGR_OPMDC_ALLA  = (7 << 3),
         PHYCFGR_OPMDC_PDOWN = (6 << 3),
         PHYCFGR_OPMDC_NA    = (5 << 3),


### PR DESCRIPTION
Fixes #1749

Defining a global true `bool core1_separate_stack = true` will separate the two cores' stacks, with core 0 using the scratch RAM while core 1 will use 8K from the heap.