### PR TITLE
Only adjust SPI format when it changes

### DIFF
--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -123,10 +123,13 @@ uint16_t SPIClassRP2040::transfer16(uint16_t data) {
         return 0;
     }
     data = (_spis.getBitOrder() == MSBFIRST) ? data : reverse16Bit(data);
-    spi_set_format(_spi, 16, cpol(), cpha(), SPI_MSB_FIRST);
     DEBUGSPI("SPI::transfer16(%04x), cpol=%d, cpha=%d\n", data, cpol(), cpha());
-    spi_write16_read16_blocking(_spi, &data, &ret, 1);
-    spi_set_format(_spi, 8, cpol(), cpha(), SPI_MSB_FIRST);
+    uint8_t msb, lsb;
+    msb = (data >> 8) & 0xff;
+    lsb = data & 0xff;
+    spi_write_read_blocking(_spi, &msb, &msb, 1);
+    spi_write_read_blocking(_spi, &lsb, &lsb, 1);
+    ret = ((msb << 8) | (lsb & 0xff)) & 0xffff;
     ret = (_spis.getBitOrder() == MSBFIRST) ? ret : reverse16Bit(ret);
     DEBUGSPI("SPI: read back %02x\n", ret);
     return ret;


### PR DESCRIPTION
Avoid potential interaction with Pico SDK 1.5.1 update that causes hiccups in SPI transmissions.

Fixes #1760