### PR TITLE
Allow changing USB HID poll rate

### DIFF
--- a/cores/rp2040/RP2040USB.cpp
+++ b/cores/rp2040/RP2040USB.cpp
@@ -83,6 +83,8 @@ static int __usb_task_irq;
   9, TUSB_DESC_INTERFACE, _itfnum, 0, 0, TUSB_CLASS_VENDOR_SPECIFIC, RESET_INTERFACE_SUBCLASS, RESET_INTERFACE_PROTOCOL, _stridx,
 
 
+int usb_hid_poll_interval __attribute__((weak)) = 10;
+
 const uint8_t *tud_descriptor_device_cb(void) {
     static tusb_desc_device_t usbd_desc_device = {
         .bLength = sizeof(tusb_desc_device_t),
@@ -263,7 +265,7 @@ void __SetupUSBDescriptor() {
         uint8_t hid_itf = __USBInstallSerial ? 2 : 0;
         uint8_t hid_desc[TUD_HID_DESC_LEN] = {
             // Interface number, string index, protocol, report descriptor len, EP In & Out address, size & polling interval
-            TUD_HID_DESCRIPTOR(hid_itf, 0, HID_ITF_PROTOCOL_NONE, hid_report_len, EPNUM_HID, CFG_TUD_HID_EP_BUFSIZE, 10)
+            TUD_HID_DESCRIPTOR(hid_itf, 0, HID_ITF_PROTOCOL_NONE, hid_report_len, EPNUM_HID, CFG_TUD_HID_EP_BUFSIZE, (uint8_t)usb_hid_poll_interval)
         };
 
         uint8_t msd_itf = interface_count - 1;
@@ -400,7 +402,7 @@ bool __USBHIDReady() {
 
     while (((millis() - start) < timeout) && tud_ready() && !tud_hid_ready()) {
         tud_task();
-        delay(1);
+        delayMicroseconds(1);
     }
     return tud_hid_ready();
 }

--- a/docs/usb.rst
+++ b/docs/usb.rst
@@ -14,12 +14,27 @@ from the IDE.
 The Arduino-Pico core includes ported versions of the basic Arduino
 ``Keyboard``, ``Mouse`` and ``Joystick`` libraries.  These libraries 
 allow you to emulate a keyboard, a gamepad or mouse (or all together) 
-with the Pico in your sketches.
+with the Pico in your sketches.  These libraries only are available
+when using the built-in USB, not the Adafruit library.
 
 See the examples and Arduino Reference at
 https://www.arduino.cc/reference/en/language/functions/usb/keyboard/
 and
 https://www.arduino.cc/reference/en/language/functions/usb/mouse
+
+HID Polling Interval
+--------------------
+By default, HID devices will request to be polled every 10ms (i.e. 100x
+per second).  If you have a higher performance need, you can override
+this value by creating a global variable in your main application, set
+to the polling period:
+
+.. code::  cpp
+
+    int usb_hid_poll_interval = 1; // Set HID poll interval to 1ms (1kHz)
+    void setup() {
+        ....
+    }
 
 Adafruit TinyUSB Arduino Support
 --------------------------------


### PR DESCRIPTION
Fixes #1769

Add a weak variable that can be overridden by the user to speed up or slow down the USB HID polling speed.