### PR TITLE
Clear dirty flag after commiting EEPROM to flash

### DIFF
--- a/libraries/EEPROM/src/EEPROM.cpp
+++ b/libraries/EEPROM/src/EEPROM.cpp
@@ -125,7 +125,7 @@ bool EEPROMClass::commit() {
     rp2040.resumeOtherCore();
     interrupts();
     _dirty = false;
-    
+
     return true;
 }
 

--- a/libraries/EEPROM/src/EEPROM.cpp
+++ b/libraries/EEPROM/src/EEPROM.cpp
@@ -124,7 +124,8 @@ bool EEPROMClass::commit() {
     flash_range_program((intptr_t)_sector - (intptr_t)XIP_BASE, _data, _size);
     rp2040.resumeOtherCore();
     interrupts();
-
+    _dirty = false;
+    
     return true;
 }
 


### PR DESCRIPTION
Committing to flash doesn't clear the `_dirty` variable, so if `EEPROM.commit()` is called a second time, it will write the data again to flash even with no changes in the data since the previous commit.