### PR TITLE
add Serial.dtr() and Serial.rts() methods

### DIFF
--- a/cores/rp2040/SerialUSB.cpp
+++ b/cores/rp2040/SerialUSB.cpp
@@ -197,6 +197,14 @@ static void CheckSerialReset() {
     }
 }
 
+bool SerialUSB::dtr() {
+    return _dtr;
+}
+
+bool SerialUSB::rts() {
+    return _rts;
+}
+
 extern "C" void tud_cdc_line_state_cb(uint8_t itf, bool dtr, bool rts) {
     (void) itf;
     _dtr = dtr ? true : false;

--- a/cores/rp2040/SerialUSB.h
+++ b/cores/rp2040/SerialUSB.h
@@ -43,6 +43,8 @@ public:
     virtual size_t write(const uint8_t *p, size_t len) override;
     using Print::write;
     operator bool() override;
+    bool dtr();
+    bool rts();
 
     void ignoreFlowControl(bool ignore = true);
 

--- a/docs/serial.rst
+++ b/docs/serial.rst
@@ -55,3 +55,13 @@ void Serial.ignoreFlowControl(bool ignore)
 In some cases, the target application will not assert the DTR virtual line, thus preventing writing operations to succeed.
 
 For this reason, the SerialUSB::ignoreFlowControl() method disables the connection's state verification, enabling the program to write on the port, even though the data might be lost.
+
+bool Serial.dtr()
+~~~~~~~~~~~~~~~~~
+
+Returns the current state of the DTR virtual line. A USB CDC host (such as the Arduino serial monitor) typically raises the DTR pin when opening the device, and may lower it when closing the device.
+
+bool Serial.rts()
+~~~~~~~~~~~~~~~~~
+
+Returns the current state of the RTS virtual line.


### PR DESCRIPTION
Adds some more functionality present in other Arduino cores, allowing more fine-grained control over what to do when the USB host closes the connection or wants to indicate an EOF condition.

(C programmer disclaimer: any resemblance to an actual C++ programmer living or dead is purely coincidental, I have no idea whether the methods being added to the .h file should be virtual and/or override or any other such combination, feedback and mods to the PR welcome)