### PR TITLE
Allow MCLK multiplier to be set on all I2S devices

### DIFF
--- a/libraries/I2S/src/I2S.cpp
+++ b/libraries/I2S/src/I2S.cpp
@@ -134,7 +134,7 @@ bool I2S::setSysClk(int samplerate) { // optimise sys_clk for desired samplerate
 }
 
 bool I2S::setMCLKmult(int mult) {
-    if (_running || !_isOutput) {
+    if (_running) {
         return false;
     }
     if ((mult % 64) == 0) {


### PR DESCRIPTION
As discussed in #1765.