### PR TITLE
Avoid memory allocation in Ethernet callbacks

### DIFF
--- a/libraries/lwIP_Ethernet/src/LwipIntfDev.h
+++ b/libraries/lwIP_Ethernet/src/LwipIntfDev.h
@@ -310,7 +310,7 @@ bool LwipIntfDev<RawDev>::begin(const uint8_t* macAddress, const uint16_t mtu) {
         return false;
     }
 
-    _phID = __addEthernetPacketHandler(std::bind(&LwipIntfDev<RawDev>::handlePackets, this));
+    _phID = __addEthernetPacketHandler([this] { this->handlePackets(); });
 
     if (localIP().v4() == 0) {
         // IP not set, starting DHCP


### PR DESCRIPTION
std::bind can cause a memory allocation to occur during the periodic polling interrupt which is a very bad thing.  Use a lambda instead.

Fixes #1812