### PR TITLE
Avoid infinite loop in BLE HID send

### DIFF
--- a/libraries/HID_Bluetooth/src/PicoBluetoothBLEHID.h
+++ b/libraries/HID_Bluetooth/src/PicoBluetoothBLEHID.h
@@ -252,8 +252,10 @@ public:
     }
 
     bool send(void *rpt, int len) {
-        //wait for another report to be sent
-        while (_needToSend);
+        // Wait for another report to be sent
+        while (connected() && _needToSend) {
+            /* noop busy wait */
+        }
         _needToSend = true;
         _sendReport = rpt;
         _sendReportLen = len;


### PR DESCRIPTION
If the BLE connection is severed, don't wait for the needToSend flag to clear in the HID::send routine since it may never actually clear unless the BLE connection is restored.

Partial #1817