### PR TITLE
LwipIntfDev - added macAddress getter and DNS IP getter and setter

### DIFF
--- a/libraries/WiFi/src/WiFiClass.cpp
+++ b/libraries/WiFi/src/WiFiClass.cpp
@@ -327,6 +327,15 @@ IPAddress WiFiClass::gatewayIP() {
 }
 
 /*
+    Get the DNS ip address.
+
+    return: IPAddress DNS Server IP
+*/
+IPAddress WiFiClass::dnsIP(uint8_t dns_no) {
+    return _wifi.dnsIP(dns_no);
+}
+
+/*
     Return the current SSID associated with the network
 
     return: ssid string

--- a/libraries/WiFi/src/WiFiClass.h
+++ b/libraries/WiFi/src/WiFiClass.h
@@ -262,6 +262,13 @@ public:
     IPAddress gatewayIP();
 
     /*
+        Get the DNS ip address.
+
+        return: IPAddress DNS Server IP
+    */
+    IPAddress dnsIP(uint8_t dns_no = 0);
+
+    /*
         Return the current SSID associated with the network
 
         return: ssid string

--- a/libraries/lwIP_Ethernet/src/LwipIntfDev.h
+++ b/libraries/lwIP_Ethernet/src/LwipIntfDev.h
@@ -73,6 +73,10 @@ public:
         return &_netif;
     }
 
+    uint8_t* macAddress(uint8_t* mac) {
+        memcpy(mac, &_netif.hwaddr, 6);
+        return mac;
+    }
     IPAddress localIP() const {
         return IPAddress(ip4_addr_get_u32(ip_2_ip4(&_netif.ip_addr)));
     }
@@ -81,6 +85,17 @@ public:
     }
     IPAddress gatewayIP() const {
         return IPAddress(ip4_addr_get_u32(ip_2_ip4(&_netif.gw)));
+    }
+    IPAddress dnsIP(int n = 0) const {
+        return IPAddress(dns_getserver(n));
+    }
+    void setDNS(IPAddress dns1, IPAddress dns2 = INADDR_ANY) {
+        if (dns1.isSet()) {
+            dns_setserver(0, dns1);
+        }
+        if (dns2.isSet()) {
+            dns_setserver(1, dns2);
+        }
     }
 
     // 1. Currently when no default is set, esp8266-Arduino uses the first


### PR DESCRIPTION
and dnsIP(n) getter in WiFiClass too

the networking libraries API unification ['control center'](https://github.com/JAndrassy/Arduino-Networking-API/blob/main/ArduinoNetAPILibs.md)

[WiFiTest](https://github.com/JAndrassy/NetApiHelpers/blob/master/examples/WiFiTest/WiFiTest.ino)
[ModernEthernetTest](https://github.com/JAndrassy/NetApiHelpers/blob/master/examples/ModernEthernetTest/ModernEthernetTest.ino)
