### PR TITLE
WiFi and Ethernet - config static IP auto gw,mask,dns as in Arduino libs

### DIFF
--- a/libraries/WiFi/src/WiFiClass.cpp
+++ b/libraries/WiFi/src/WiFiClass.cpp
@@ -193,7 +193,7 @@ bool WiFiClass::connected() {
     param local_ip: 	Static ip configuration
 */
 void WiFiClass::config(IPAddress local_ip) {
-    ip4_addr_set_u32(ip_2_ip4(&_wifi.getNetIf()->ip_addr), local_ip.v4());
+    _wifi.config(local_ip);
 }
 
 /*  Change Ip configuration settings disabling the dhcp client
@@ -202,8 +202,7 @@ void WiFiClass::config(IPAddress local_ip) {
     param dns_server:     IP configuration for DNS server 1
 */
 void WiFiClass::config(IPAddress local_ip, IPAddress dns_server) {
-    ip4_addr_set_u32(ip_2_ip4(&_wifi.getNetIf()->ip_addr), local_ip.v4());
-    dns_setserver(0, dns_server);
+    _wifi.config(local_ip, dns_server);
 }
 
 /*  Change Ip configuration settings disabling the dhcp client
@@ -213,9 +212,7 @@ void WiFiClass::config(IPAddress local_ip, IPAddress dns_server) {
     param gateway : 	Static gateway configuration
 */
 void WiFiClass::config(IPAddress local_ip, IPAddress dns_server, IPAddress gateway) {
-    ip4_addr_set_u32(ip_2_ip4(&_wifi.getNetIf()->ip_addr), local_ip.v4());
-    dns_setserver(0, dns_server);
-    ip4_addr_set_u32(ip_2_ip4(&_wifi.getNetIf()->gw), gateway.v4());
+    _wifi.config(local_ip, dns_server, gateway);
 }
 
 /*  Change Ip configuration settings disabling the dhcp client


### PR DESCRIPTION
The 'config' functions with not all parameters specified should use default values for gw IP, subnet mask and DNS server IP. The first Arduino Ethernet library has this (with begin), I guess the first Arduino WiFi library  had it too, but the default values were implemented in the firmware. Then WiFi101 and WiFiNINA are written base on WiFi lib's source code, but without the defaults implemented in firmware. (My PR are waiting to fix that.) The new [WiFiS3](https://github.com/arduino/ArduinoCore-renesas/blob/main/libraries/WiFiS3/src/WiFi.cpp#L151) and WiFiC3 libraries by Arduino have it right.

This PR adds the default values for gateway, subnet mask and DNS. The solution in LwipIntfDev is the same as in ESP8266 core. And the WiFi library now redirects all versions of `config` to LwipIntfDev.

Tested with Pico W and W5500