### PR TITLE
LwipIntfDev - disconnect()/end() should not clear static IP settings

### DIFF
--- a/libraries/lwIP_Ethernet/src/LwipIntfDev.h
+++ b/libraries/lwIP_Ethernet/src/LwipIntfDev.h
@@ -400,7 +400,7 @@ void LwipIntfDev<RawDev>::end() {
     RawDev::end();
 
     netif_remove(&_netif);
-    memset(&_netif, 0, sizeof(_netif));
+
     _started = false;
 }
 


### PR DESCRIPTION
when I wrote the test sketch for WiFi libraries I wanted to do `begin` with DHCP, then `begin` with static IP and then again `begin` with DHCP.  I thought that `disconnect()` should clear the static IP for return to DHCP, but it turned out that all libraries I tested  preserved the static IP settings over disconnect() (except my WiFiEspAT). [I learned](https://github.com/esp8266/Arduino/pull/9020#issuecomment-1806789080) that the right way to return to DHCP is `config(0)` or `config(INADDR_NONE)`. And this really worked in all libraries and in modern Ethernet libraries (the ones with `config`) too.
So the user of the library can config the static IP and then `disconnect` and later `begin` again with the same static IP.

Now WiFiTest and ModernEthernetTest do an additional begin/disconnect to test if the library preserves the static IP over `disconnect`. And they reported the your library resets the static IP in `disconnect()`/`end()`. 

The fix is easy and with the previous PR with the `config` with one and two parameters, the config(INADDR_NONE) works to return to DHCP.

The tests are:
[WiFiTest](https://github.com/JAndrassy/NetApiHelpers/blob/master/examples/WiFiTest/WiFiTest.ino)
[ModernEthernetTest](https://github.com/JAndrassy/NetApiHelpers/blob/master/examples/ModernEthernetTest/ModernEthernetTest.ino)