### PR TITLE
WiFiServer modernization

### DIFF
--- a/libraries/WebServer/src/WebServerTemplate.h
+++ b/libraries/WebServer/src/WebServerTemplate.h
@@ -90,7 +90,7 @@ void WebServerTemplate<ServerType, DefaultPort>::handleClient() {
             _currentClient = nullptr;
         }
 
-        _currentClient = new ClientType(_server.available());
+        _currentClient = new ClientType(_server.accept());
         if (!_currentClient) {
             if (_nullDelay) {
                 delay(1);

--- a/libraries/WiFi/examples/WiFiServer/WiFiServer.ino
+++ b/libraries/WiFi/examples/WiFiServer/WiFiServer.ino
@@ -34,7 +34,7 @@ void loop() {
   delay(1000);
   Serial.printf("--loop %d\n", ++i);
   delay(10);
-  WiFiClient client = server.available();
+  WiFiClient client = server.accept();
   if (!client) {
     return;
   }

--- a/libraries/WiFi/src/WiFiServer.cpp
+++ b/libraries/WiFi/src/WiFiServer.cpp
@@ -163,8 +163,16 @@ void WiFiServer::close() {
     _listen_pcb = nullptr;
 }
 
+void WiFiServer::end() {
+    close();
+}
+
 void WiFiServer::stop() {
     close();
+}
+
+WiFiServer::operator bool() {
+    return (status() != CLOSED);
 }
 
 template<typename T>

--- a/libraries/WiFi/src/WiFiServer.h
+++ b/libraries/WiFi/src/WiFiServer.h
@@ -75,10 +75,10 @@ protected:
 
 public:
     WiFiServer(const IPAddress& addr, uint16_t port);
-    WiFiServer(uint16_t port);
+    WiFiServer(uint16_t port = 23);
     virtual ~WiFiServer() {}
     WiFiClient accept(); // https://www.arduino.cc/en/Reference/EthernetServerAccept
-    WiFiClient available(uint8_t* status = nullptr);
+    WiFiClient available(uint8_t* status = nullptr) __attribute__((deprecated("Use accept().")));
 
     bool hasClient();
     // hasClientData():
@@ -95,8 +95,10 @@ public:
     bool getNoDelay();
     uint8_t status();
     uint16_t port() const;
+    void end();
     void close();
     void stop();
+    explicit operator bool();
 
     using ClientType = WiFiClient;
 

--- a/libraries/WiFi/src/WiFiServerSecureBearSSL.h
+++ b/libraries/WiFi/src/WiFiServerSecureBearSSL.h
@@ -31,7 +31,7 @@ class WiFiClientSecure;
 class WiFiServerSecure : public WiFiServer {
 public:
     WiFiServerSecure(IPAddress addr, uint16_t port);
-    WiFiServerSecure(uint16_t port);
+    WiFiServerSecure(uint16_t port = 22);
     WiFiServerSecure(const WiFiServerSecure &rhs);
     virtual ~WiFiServerSecure();
 
@@ -65,7 +65,7 @@ public:
 
     // If awaiting connection available and authenticated (i.e. client cert), return it.
     WiFiClientSecure accept(); // https://www.arduino.cc/en/Reference/EthernetServerAccept
-    WiFiClientSecure available(uint8_t* status = nullptr);
+    WiFiClientSecure available(uint8_t* status = nullptr) __attribute__((deprecated("Use accept().")));
 
     WiFiServerSecure& operator=(const WiFiServerSecure&) = default;
 


### PR DESCRIPTION
In new (this year's) WiFi libraries by Arduino in the Renesas Core they finally enhanced the WiFiServer API so now we know that the preferred method name to stop the server is `end`.  They added `begin` with parameter `port` which goes with a constructor without parameter. 
op bool for Server originates in the Ethernet library 2018 update.
And I recommend to mark method `available()` as deprecated. Users should be educated to use `accept()` as this is the correct name for that implementation.