### PR TITLE
Replace `std::bind` in `MDNSResponder` for UDP context

### DIFF
--- a/libraries/LEAmDNS/src/LEAmDNS_Helpers.cpp
+++ b/libraries/LEAmDNS/src/LEAmDNS_Helpers.cpp
@@ -161,7 +161,7 @@ bool MDNSResponder::_allocUDPContext(void) {
 
     if (m_pUDPContext->listen(IP4_ADDR_ANY, DNS_MQUERY_PORT)) {
         m_pUDPContext->setMulticastTTL(MDNS_MULTICAST_TTL);
-        m_pUDPContext->onRx(std::bind(&MDNSResponder::_callProcess, this));
+        m_pUDPContext->onRx([this] { this->_callProcess(); });
     } else {
         return false;
     }


### PR DESCRIPTION
When running Wi-Fi on the Pico W for a longer time, I hit a FreeRTOS fatal error due to memory allocation by `std::bind` in `MDNSResponder` (see the callstack below). I therefore applied the same fix as in #1815 and have not seen it happening since.

Maybe the same should be done for the remaining `std::bind` in ArduinoOTA?

```
sleep_until@0x1004ff3e (/sleep_until.dbgasm:43)
sleep_us@0x1004ff9c (/sleep_us.dbgasm:15)
sleep_ms@0x1004ffb6 (/sleep_ms.dbgasm:8)
rtosFatalError@0x1004a610 (~/.platformio/packages/framework-arduinopico/libraries/FreeRTOS/src/variantHooks.cpp:339)
xQueueSemaphoreTake@0x10048608 (~/.platformio/packages/framework-arduinopico/libraries/FreeRTOS/lib/FreeRTOS-Kernel/queue.c:1486)
xQueueTakeMutexRecursive@0x10048750 (~/.platformio/packages/framework-arduinopico/libraries/FreeRTOS/lib/FreeRTOS-Kernel/queue.c:695)
__freertos_recursive_mutex_take@0x1004a446 (~/.platformio/packages/framework-arduinopico/libraries/FreeRTOS/src/variantHooks.cpp:80)
__retarget_lock_acquire_recursive@0x1004d782 (~/.platformio/packages/framework-arduinopico/cores/rp2040/lock.cpp:150)
__malloc_lock@0x1009075c (/__malloc_lock.dbgasm:4)
_malloc_r@0x1008fdf8 (/_malloc_r.dbgasm:55)
malloc@0x1008fd76 (/malloc.dbgasm:6)
__wrap_malloc@0x1004e30a (~/.platformio/packages/framework-arduinopico/cores/rp2040/malloc-lock.cpp:30)
operator new@0x10053ae6 (Unknown Source:15)
esp8266::MDNSImplementation::MDNSResponder::_readRRAnswer@0x10047092 (~/.platformio/packages/framework-arduinopico/libraries/LEAmDNS/src/LEAmDNS_Transfer.cpp:474)
esp8266::MDNSImplementation::MDNSResponder::_parseQuery@0x100442fe (~/.platformio/packages/framework-arduinopico/libraries/LEAmDNS/src/LEAmDNS_Control.cpp:339)
esp8266::MDNSImplementation::MDNSResponder::_parseMessage@0x10044d54 (~/.platformio/packages/framework-arduinopico/libraries/LEAmDNS/src/LEAmDNS_Control.cpp:129)
esp8266::MDNSImplementation::MDNSResponder::_process@0x10045374 (~/.platformio/packages/framework-arduinopico/libraries/LEAmDNS/src/LEAmDNS_Control.cpp:75)
esp8266::MDNSImplementation::MDNSResponder::_callProcess@0x100453cc (~/.platformio/packages/framework-arduinopico/libraries/LEAmDNS/src/LEAmDNS_Helpers.cpp:140)
std::__invoke_impl<bool, bool (esp8266::MDNSImplementation::MDNSResponder::*&)(), esp8266::MDNSImplementation::MDNSResponder*&>@0x10045892 (~/.platformio/packages/toolchain-rp2040-earlephilhower/arm-none-eabi/include/c++/12.3.0/bits/invoke.h:74)
std::__invoke<bool (esp8266::MDNSImplementation::MDNSResponder::*&)(), esp8266::MDNSImplementation::MDNSResponder*&>@0x100458ac (~/.platformio/packages/toolchain-rp2040-earlephilhower/arm-none-eabi/include/c++/12.3.0/bits/invoke.h:96)
std::_Bind<bool (esp8266::MDNSImplementation::MDNSResponder::*(esp8266::MDNSImplementation::MDNSResponder*))()>::__call<bool, , 0u>(std::tuple<>&&, std::_Index_tuple<0u>)@0x100458ac (~/.platformio/packages/toolchain-rp2040-earlephilhower/arm-none-eabi/include/c++/12.3.0/functional:495)
```