### PR TITLE
Updated WiFiMulti.cpp to work with FreeRTOS

### DIFF
--- a/libraries/WiFi/src/WiFiMulti.cpp
+++ b/libraries/WiFi/src/WiFiMulti.cpp
@@ -124,13 +124,13 @@ uint8_t WiFiMulti::run(uint32_t to) {
             // failure when using RTOS
             unsigned long tWifiDelayForRtos_start = millis();
             while (millis()-tWifiDelayForRtos_start <= 5) {
-		    if(millis()<tWifiDelayForRtos_start) {
-			    // millis wrapped around to zero. Rare to hit this
-			    // issue, but it will do this every 49 days.
-			    tWifiDelayForRtos_start = millis();
-		    }
-	    }
-	}
+                if(millis()<tWifiDelayForRtos_start) {
+                    // millis wrapped around to zero. Rare to hit this
+                    // issue, but it will do this every 49 days.
+                    tWifiDelayForRtos_start = millis();
+                }
+            }
+        }
         if (WiFi.status() == WL_CONNECTED) {
             return WL_CONNECTED;
         }


### PR DESCRIPTION
Modified WiFiMulti.cpp to work with FreeRTOS by removing delay and using a while loop.
