### PR TITLE
Update WiFiMulti.cpp to support FreeRTOS

### DIFF
--- a/libraries/WiFi/src/WiFiMulti.cpp
+++ b/libraries/WiFi/src/WiFiMulti.cpp
@@ -124,13 +124,13 @@ uint8_t WiFiMulti::run(uint32_t to) {
             // failure when using RTOS
             unsigned long tWifiDelayForRtos_start = millis();
             while (millis()-tWifiDelayForRtos_start <= 5) {
-		    if(millis()<tWifiDelayForRtos_start) {
-			    // millis wrapped around to zero. Rare to hit this
-			    // issue, but it will do this every 49 days.
-			    tWifiDelayForRtos_start = millis();
-		    }
-	    }
-	}
+                if(millis()<tWifiDelayForRtos_start) {
+                    // millis wrapped around to zero. Rare to hit this
+                    // issue, but it will do this every 49 days.
+                    tWifiDelayForRtos_start = millis();
+                }
+            }
+        }
         if (WiFi.status() == WL_CONNECTED) {
             return WL_CONNECTED;
         }

--- a/libraries/WiFi/src/WiFiMulti.cpp
+++ b/libraries/WiFi/src/WiFiMulti.cpp
@@ -121,16 +121,16 @@ uint8_t WiFiMulti::run(uint32_t to) {
         }
         while (!WiFi.connected() && (millis() - start < to)) {
             // Replaced delay(5); with the following to prevent
-			// failure when using RTOS
-			unsigned long tWifiDelayForRtos_start = millis();
+            // failure when using RTOS
+            unsigned long tWifiDelayForRtos_start = millis();
             while (millis()-tWifiDelayForRtos_start <= 5) {
-               if(millis()<tWifiDelayForRtos_start) {
-                // millis wrapped around to zero. Rare to hit this
-                // issue, but it will do this every 49 days.
-                tWifiDelayForRtos_start = millis();
-               }
-            }
-        }
+		    if(millis()<tWifiDelayForRtos_start) {
+			    // millis wrapped around to zero. Rare to hit this
+			    // issue, but it will do this every 49 days.
+			    tWifiDelayForRtos_start = millis();
+		    }
+	    }
+	}
         if (WiFi.status() == WL_CONNECTED) {
             return WL_CONNECTED;
         }

--- a/libraries/WiFi/src/WiFiMulti.cpp
+++ b/libraries/WiFi/src/WiFiMulti.cpp
@@ -123,8 +123,8 @@ uint8_t WiFiMulti::run(uint32_t to) {
             // Replaced delay(5); with the following to prevent
             // failure when using RTOS
             unsigned long tWifiDelayForRtos_start = millis();
-            while (millis()-tWifiDelayForRtos_start <= 5) {
-                if(millis()<tWifiDelayForRtos_start) {
+            while (millis() - tWifiDelayForRtos_start <= 5) {
+                if (millis() < tWifiDelayForRtos_start) {
                     // millis wrapped around to zero. Rare to hit this
                     // issue, but it will do this every 49 days.
                     tWifiDelayForRtos_start = millis();

--- a/libraries/WiFi/src/WiFiMulti.cpp
+++ b/libraries/WiFi/src/WiFiMulti.cpp
@@ -120,7 +120,16 @@ uint8_t WiFiMulti::run(uint32_t to) {
             WiFi.beginBSSID(j->ssid, j->bssid);
         }
         while (!WiFi.connected() && (millis() - start < to)) {
-            delay(5);
+            // Replaced delay(5); with the following to prevent
+			// failure when using RTOS
+			unsigned long tWifiDelayForRtos_start = millis();
+            while (millis()-tWifiDelayForRtos_start <= 5) {
+               if(millis()<tWifiDelayForRtos_start) {
+                // millis wrapped around to zero. Rare to hit this
+                // issue, but it will do this every 49 days.
+                tWifiDelayForRtos_start = millis();
+               }
+            }
         }
         if (WiFi.status() == WL_CONNECTED) {
             return WL_CONNECTED;

--- a/libraries/WiFi/src/WiFiMulti.cpp
+++ b/libraries/WiFi/src/WiFiMulti.cpp
@@ -58,6 +58,15 @@ bool WiFiMulti::addAP(const char *ssid, const char *pass) {
     return true;
 }
 
+void WiFiMulti::clearAPList() {
+    while (!_list.empty()) {
+        struct _AP ap = _list.front();
+        _list.pop_front();
+        free(ap.ssid);
+        free(ap.pass);
+    }
+}
+
 uint8_t WiFiMulti::run(uint32_t to) {
     struct _scanAP {
         char *ssid;

--- a/libraries/WiFi/src/WiFiMulti.h
+++ b/libraries/WiFi/src/WiFiMulti.h
@@ -31,6 +31,8 @@ public:
     ~WiFiMulti();
 
     bool addAP(const char *ssid, const char *pass = nullptr);
+	
+	void clearAPList();
 
     uint8_t run(uint32_t to = 10000);
 

--- a/libraries/WiFi/src/WiFiMulti.h
+++ b/libraries/WiFi/src/WiFiMulti.h
@@ -31,7 +31,7 @@ public:
     ~WiFiMulti();
 
     bool addAP(const char *ssid, const char *pass = nullptr);
-	
+
     void clearAPList();
 
     uint8_t run(uint32_t to = 10000);

--- a/libraries/WiFi/src/WiFiMulti.h
+++ b/libraries/WiFi/src/WiFiMulti.h
@@ -32,7 +32,7 @@ public:
 
     bool addAP(const char *ssid, const char *pass = nullptr);
 	
-	void clearAPList();
+    void clearAPList();
 
     uint8_t run(uint32_t to = 10000);
 


### PR DESCRIPTION
When used with FreeRTOS, the delay statement caused the code to stop responding as FreeRTOS was stuck. Replaced delay with another loop to do nothing for 5ms.

Attempting to fix astyle failed test.