### PR TITLE
Adds definition for WIRE_INTERFACES_COUNT #1182

### DIFF
--- a/variants/generic/common.h
+++ b/variants/generic/common.h
@@ -7,6 +7,7 @@
 #define NUM_ANALOG_INPUTS   (4u)
 #define NUM_ANALOG_OUTPUTS  (0u)
 #define ADC_RESOLUTION      (12u)
+#define WIRE_INTERFACES_COUNT (2u)
 
 #ifdef PIN_LED
 #define LED_BUILTIN PIN_LED

--- a/variants/generic/common.h
+++ b/variants/generic/common.h
@@ -7,7 +7,7 @@
 #define NUM_ANALOG_INPUTS   (4u)
 #define NUM_ANALOG_OUTPUTS  (0u)
 #define ADC_RESOLUTION      (12u)
-#define WIRE_INTERFACES_COUNT (2u)
+#define WIRE_INTERFACES_COUNT (WIRE_HOWMANY)
 
 #ifdef PIN_LED
 #define LED_BUILTIN PIN_LED


### PR DESCRIPTION
so those libraries which rely on it can detect and use Wire1. e.g. u8g2 will not use Wire1 unless this is (a) defined and (b) >1. This constant is defined on other cores, e.g. for SAMD based boards.

This should resolve situations like that reported in #1182.

I am not entirely sure if `WIRE_INTERFACES_COUNT` should be defined in `common.h`, as in other cores it is defined in variant-specific headers, e.g.

https://github.com/search?q=repo%3Aarduino%2FArduinoCore-samd%20WIRE_INTERFACES_COUNT&type=code

However given that `generic/pins_arduino.h` defines pins for both I2C0 and I2C1, this doesn't seem unreasonable. i.e. the generic variant already assumes the presence of 2 I2C peripherals. 