### PR TITLE
lwIP_nodriver - end() compilation error fix

### DIFF
--- a/libraries/WiFi/src/utility/lwIP_nodriver.h
+++ b/libraries/WiFi/src/utility/lwIP_nodriver.h
@@ -37,8 +37,7 @@ public:
         (void) timeout;
     }
 
-    void end(bool apMode) {
-        (void) apMode;
+    void end() {
     }
 
     bool connected() {


### PR DESCRIPTION
fixes https://github.com/earlephilhower/arduino-pico/issues/1965
the error is from my "prepare for alternative drivers" PR and it affects compilation for wired Ethernet with boards other than Pico W