### PR TITLE
Make Python3 re.split() use a r-string

### DIFF
--- a/tools/uf2conv.py
+++ b/tools/uf2conv.py
@@ -261,7 +261,7 @@ def get_drives():
                 print("Unable to build drive list");
                 sys.exit(1)
         for line in to_str(r).split('\n'):
-            words = re.split('\s+', line)
+            words = re.split(r'\s+', line)
             if len(words) >= 3 and words[1] == "2" and words[2] == "FAT":
                 drives.append(words[0])
     else:


### PR DESCRIPTION
Fixes #1983