### PR TITLE
Add W5100, W5500, and ECN28J60 interrupt-driven mode

### DIFF
--- a/docs/ethernet.rst
+++ b/docs/ethernet.rst
@@ -86,6 +86,19 @@ Pico may not have enough time to service the Ethernet port before the timer fire
 leading to a lock up and hang.
 
 
+Using Interrupt-Driven Handling
+-------------------------------
+
+The WizNet devices support generating an interrupt when a packet is received, removing the
+need for polling and decreasing latency.  Simply specify the SPI object to use and the
+interrupt pin whwn instantiating the Ethernet object:
+
+.. code:: cpp
+
+    #include <W5100lwIP.h>
+    Wiznet5100lwIP eth(SS /* Chip Select*/, SPI /* SPI interface */, 17 /* Interrupt GPIO */ );
+
+
 Adjusting SPI Speed
 -------------------
 

--- a/docs/ethernet.rst
+++ b/docs/ethernet.rst
@@ -89,9 +89,9 @@ leading to a lock up and hang.
 Using Interrupt-Driven Handling
 -------------------------------
 
-The WizNet devices support generating an interrupt when a packet is received, removing the
-need for polling and decreasing latency.  Simply specify the SPI object to use and the
-interrupt pin whwn instantiating the Ethernet object:
+The WizNet and ENC28J60 devices support generating an interrupt when a packet is received,
+removing the need for polling and decreasing latency.  Simply specify the SPI object to use and the
+interrupt pin when instantiating the Ethernet object:
 
 .. code:: cpp
 

--- a/docs/ethernet.rst
+++ b/docs/ethernet.rst
@@ -127,12 +127,12 @@ For example, to set the W5500 to use a 30MHZ clock:
 Using the WIZnet W5100S-EVB-Pico
 --------------------------------
 
-You can use the onboard Ethernet chip with these drivers by utilizing the following options:
+You can use the onboard Ethernet chip with these drivers, in interrupt mode, by utilizing the following options:
 
 .. code:: cpp
 
     #include <W5100lwIP.h>
-    Wiznet5100lwIP eth(17);  // Note chip select is **17**
+    Wiznet5100lwIP eth(17, SPI, 21);  // Note chip select is **17**
 
     void setup() {
         // Set SPI to the onboard Wiznet chip

--- a/libraries/lwIP_Ethernet/src/LwipEthernet.cpp
+++ b/libraries/lwIP_Ethernet/src/LwipEthernet.cpp
@@ -72,14 +72,15 @@ void __removeEthernetPacketHandler(int id) {
     ethernet_arch_lwip_end();
 }
 
-
+static uint32_t gpioMaskStack[4][4];
 static uint32_t gpioMask[4] = {0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff};
-static uint32_t gpioUnmask[4] = {0, 0, 0, 0};
 
 void ethernet_arch_lwip_gpio_mask() {
     noInterrupts();
+    memmove(gpioMaskStack[1], gpioMaskStack[0], 4 * sizeof(uint32_t) * 3); // Push down the stack
     io_irq_ctrl_hw_t *irq_ctrl_base = get_core_num() ? &iobank0_hw->proc1_irq_ctrl : &iobank0_hw->proc0_irq_ctrl;
     for (int i = 0; i < 4; i++) {
+        gpioMaskStack[0][i] = irq_ctrl_base->inte[i];
         irq_ctrl_base->inte[i] = irq_ctrl_base->inte[i] & gpioMask[i];
     }
     interrupts();
@@ -89,8 +90,9 @@ void ethernet_arch_lwip_gpio_unmask() {
     noInterrupts();
     io_irq_ctrl_hw_t *irq_ctrl_base = get_core_num() ? &iobank0_hw->proc1_irq_ctrl : &iobank0_hw->proc0_irq_ctrl;
     for (int i = 0; i < 4; i++) {
-        irq_ctrl_base->inte[i] = irq_ctrl_base->inte[i] | gpioUnmask[i];
+        irq_ctrl_base->inte[i] = gpioMaskStack[0][i];
     }
+    memmove(gpioMaskStack[0], gpioMaskStack[1],  4 * sizeof(uint32_t) * 3); // Pop up the stack
     interrupts();
 }
 
@@ -100,14 +102,12 @@ void __addEthernetGPIO(int pin) {
     int idx = pin / 8;
     int off = (pin % 8) * 4;
     gpioMask[idx] &= ~(0xf << off);
-    gpioUnmask[idx] |= irq_ctrl_base->inte[idx] & (0xf << off);
 }
 
 void __removeEthernetGPIO(int pin) {
     int idx = pin / 8;
     int off = (pin % 8) * 4;
     gpioMask[idx] |= 0xf << off;
-    gpioUnmask[idx] &= 0xffffffff ^ (0xf << off);
 }
 
 
@@ -173,6 +173,7 @@ static uint32_t _pollingPeriod = 20;
 static void ethernet_timeout_reached(__unused async_context_t *context, __unused async_at_time_worker_t *worker) {
     assert(worker == &ethernet_timeout_worker);
     __ethernet_timeout_reached_calls++;
+    ethernet_arch_lwip_gpio_mask(); // Ensure non-polled devices won't interrupt us
     for (auto handlePacket : _handlePacketList) {
         handlePacket.second();
     }
@@ -183,6 +184,7 @@ static void ethernet_timeout_reached(__unused async_context_t *context, __unused
 #else
     sys_check_timeouts();
 #endif
+    ethernet_arch_lwip_gpio_unmask();
 }
 
 static void update_next_timeout(async_context_t *context, async_when_pending_worker_t *worker) {

--- a/libraries/lwIP_Ethernet/src/LwipEthernet.cpp
+++ b/libraries/lwIP_Ethernet/src/LwipEthernet.cpp
@@ -98,7 +98,6 @@ void ethernet_arch_lwip_gpio_unmask() {
 
 // To be called after IRQ is set, so we can just rad from the IOREG instead of duplicating the calculation
 void __addEthernetGPIO(int pin) {
-    io_irq_ctrl_hw_t *irq_ctrl_base = get_core_num() ? &iobank0_hw->proc1_irq_ctrl : &iobank0_hw->proc0_irq_ctrl;
     int idx = pin / 8;
     int off = (pin % 8) * 4;
     gpioMask[idx] &= ~(0xf << off);

--- a/libraries/lwIP_Ethernet/src/LwipEthernet.cpp
+++ b/libraries/lwIP_Ethernet/src/LwipEthernet.cpp
@@ -72,12 +72,13 @@ void __removeEthernetPacketHandler(int id) {
     ethernet_arch_lwip_end();
 }
 
-static uint32_t gpioMaskStack[4][4];
+#define GPIOSTACKSIZE 8
+static uint32_t gpioMaskStack[GPIOSTACKSIZE][4];
 static uint32_t gpioMask[4] = {0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff};
 
 void ethernet_arch_lwip_gpio_mask() {
     noInterrupts();
-    memmove(gpioMaskStack[1], gpioMaskStack[0], 4 * sizeof(uint32_t) * 3); // Push down the stack
+    memmove(gpioMaskStack[1], gpioMaskStack[0], 4 * sizeof(uint32_t) * (GPIOSTACKSIZE - 1)); // Push down the stack
     io_irq_ctrl_hw_t *irq_ctrl_base = get_core_num() ? &iobank0_hw->proc1_irq_ctrl : &iobank0_hw->proc0_irq_ctrl;
     for (int i = 0; i < 4; i++) {
         gpioMaskStack[0][i] = irq_ctrl_base->inte[i];
@@ -92,7 +93,7 @@ void ethernet_arch_lwip_gpio_unmask() {
     for (int i = 0; i < 4; i++) {
         irq_ctrl_base->inte[i] = gpioMaskStack[0][i];
     }
-    memmove(gpioMaskStack[0], gpioMaskStack[1],  4 * sizeof(uint32_t) * 3); // Pop up the stack
+    memmove(gpioMaskStack[0], gpioMaskStack[1],  4 * sizeof(uint32_t) * (GPIOSTACKSIZE - 1)); // Pop up the stack
     interrupts();
 }
 

--- a/libraries/lwIP_Ethernet/src/LwipEthernet.h
+++ b/libraries/lwIP_Ethernet/src/LwipEthernet.h
@@ -27,6 +27,11 @@
 
 void ethernet_arch_lwip_begin() __attribute__((weak));
 void ethernet_arch_lwip_end() __attribute__((weak));
+void ethernet_arch_lwip_gpio_mask() __attribute__((weak));
+void ethernet_arch_lwip_gpio_unmask() __attribute__((weak));
+
+void __addEthernetGPIO(int pin);
+void __removeEthernetGPIO(int pin);
 
 // Internal Ethernet helper functions
 void __startEthernetContext();

--- a/libraries/lwIP_Ethernet/src/LwipIntfDev.h
+++ b/libraries/lwIP_Ethernet/src/LwipIntfDev.h
@@ -398,6 +398,7 @@ bool LwipIntfDev<RawDev>::begin(const uint8_t* macAddress, const uint16_t mtu) {
     if (_intrPin >= 0) {
         if (RawDev::interruptIsPossible()) {
             noInterrupts(); // Ensure this is atomically set up
+            pinMode(_intrPin, INPUT);
             attachInterruptParam(_intrPin, _irq, LOW, (void*)this);
             __addEthernetGPIO(_intrPin);
             interrupts();

--- a/libraries/lwIP_Ethernet/src/LwipIntfDev.h
+++ b/libraries/lwIP_Ethernet/src/LwipIntfDev.h
@@ -144,6 +144,7 @@ public:
         return _packetsSent;
     }
 
+
     // ESP8266WiFi API compatibility
 
     wl_status_t status();
@@ -156,6 +157,7 @@ protected:
     static err_t netif_init_s(netif* netif);
     static err_t linkoutput_s(netif* netif, struct pbuf* p);
     static void  netif_status_callback_s(netif* netif);
+    static void _irq(void *param);
 public:
     // called on a regular basis or on interrupt
     err_t handlePackets();
@@ -358,7 +360,9 @@ bool LwipIntfDev<RawDev>::begin(const uint8_t* macAddress, const uint16_t mtu) {
         return false;
     }
 
-    _phID = __addEthernetPacketHandler([this] { this->handlePackets(); });
+    if (_intrPin < 0) {
+        _phID = __addEthernetPacketHandler([this] { this->handlePackets(); });
+    }
 
     if (localIP().v4() == 0) {
         // IP not set, starting DHCP
@@ -393,7 +397,10 @@ bool LwipIntfDev<RawDev>::begin(const uint8_t* macAddress, const uint16_t mtu) {
 
     if (_intrPin >= 0) {
         if (RawDev::interruptIsPossible()) {
-            // attachInterrupt(_intrPin, [&]() { this->handlePackets(); }, FALLING);
+            noInterrupts(); // Ensure this is atomically set up
+            attachInterruptParam(_intrPin, _irq, LOW, (void*)this);
+            __addEthernetGPIO(_intrPin);
+            interrupts();
         } else {
             ::printf((PGM_P)F(
                          "lwIP_Intf: Interrupt not implemented yet, enabling transparent polling\r\n"));
@@ -406,7 +413,12 @@ bool LwipIntfDev<RawDev>::begin(const uint8_t* macAddress, const uint16_t mtu) {
 
 template<class RawDev>
 void LwipIntfDev<RawDev>::end() {
-    __removeEthernetPacketHandler(_phID);
+    if (_intrPin < 0) {
+        __removeEthernetPacketHandler(_phID);
+    } else {
+        detachInterrupt(_intrPin);
+        __removeEthernetGPIO(_intrPin);
+    }
 
     RawDev::end();
 
@@ -415,6 +427,13 @@ void LwipIntfDev<RawDev>::end() {
     _started = false;
 }
 
+template<class RawDev>
+void LwipIntfDev<RawDev>::_irq(void *param) {
+    LwipIntfDev *d = static_cast<LwipIntfDev*>(param);
+    ethernet_arch_lwip_begin();
+    d->handlePackets();
+    ethernet_arch_lwip_end();
+}
 
 template<class RawDev>
 wl_status_t LwipIntfDev<RawDev>::status() {

--- a/libraries/lwIP_Ethernet/src/LwipIntfDev.h
+++ b/libraries/lwIP_Ethernet/src/LwipIntfDev.h
@@ -432,6 +432,7 @@ void LwipIntfDev<RawDev>::_irq(void *param) {
     LwipIntfDev *d = static_cast<LwipIntfDev*>(param);
     ethernet_arch_lwip_begin();
     d->handlePackets();
+    sys_check_timeouts();
     ethernet_arch_lwip_end();
 }
 

--- a/libraries/lwIP_enc28j60/src/utility/enc28j60.cpp
+++ b/libraries/lwIP_enc28j60/src/utility/enc28j60.cpp
@@ -69,6 +69,9 @@
 #define ECON2_AUTOINC 0x80
 #define ECON2_PKTDEC 0x40
 
+#define EIE_PKTIE 0x40
+#define EIE_INTIE 0x80
+
 #define EIR_TXIF 0x08
 
 #define ERXTX_BANK 0x00
@@ -153,8 +156,7 @@
 // The ENC28J60 SPI Interface supports clock speeds up to 20 MHz
 static const SPISettings spiSettings(20000000, MSBFIRST, SPI_MODE0);
 
-ENC28J60::ENC28J60(int8_t cs, SPIClass& spi, int8_t intr) : _bank(ERXTX_BANK), _cs(cs), _spi(spi) {
-    (void)intr;
+ENC28J60::ENC28J60(int8_t cs, SPIClass& spi, int8_t intr) : _bank(ERXTX_BANK), _cs(cs), _intr(intr), _spi(spi) {
 }
 
 void ENC28J60::enc28j60_arch_spi_select(void) {
@@ -488,6 +490,12 @@ bool ENC28J60::reset(void) {
     /* Turn on autoincrement for buffer access */
     setregbitfield(ECON2, ECON2_AUTOINC);
 
+    /* Enable interrupt on packet receive if desired */
+    if (_intr >= 0) {
+        setregbitfield(EIE, EIE_PKTIE);
+        setregbitfield(EIE, EIE_INTIE);
+    }
+
     /* Turn on reception */
     writereg(ECON1, ECON1_RXEN);
 
@@ -510,6 +518,8 @@ bool ENC28J60::begin(const uint8_t* address, netif *net) {
 
 uint16_t ENC28J60::sendFrame(const uint8_t* data, uint16_t datalen) {
     uint16_t dataend;
+
+    ethernet_arch_lwip_gpio_mask(); // So we don't fire an IRQ and interrupt the send w/a receive!
 
     /*
         1. Appropriately program the ETXST pointer to point to an unused
@@ -581,6 +591,8 @@ uint16_t ENC28J60::sendFrame(const uint8_t* data, uint16_t datalen) {
                0xff & data[1], 0xff & data[2], 0xff & data[3], 0xff & data[4], 0xff & data[5]);
     }
 #endif
+
+    ethernet_arch_lwip_gpio_unmask();
 
     // sent_packets++;
     // PRINTF("enc28j60: sent_packets %d\n", sent_packets);

--- a/libraries/lwIP_enc28j60/src/utility/enc28j60.h
+++ b/libraries/lwIP_enc28j60/src/utility/enc28j60.h
@@ -99,7 +99,7 @@ public:
     netif *_netif;
 protected:
     static constexpr bool interruptIsPossible() {
-        return false;
+        return true;
     }
 
     /**
@@ -154,6 +154,7 @@ private:
 
     uint8_t   _bank;
     int8_t    _cs;
+    int8_t    _intr;
     SPIClass& _spi;
 
     const uint8_t* _localMac;

--- a/libraries/lwIP_w5100/examples/WiFiClient-W5100/WiFiClient-W5100.ino
+++ b/libraries/lwIP_w5100/examples/WiFiClient-W5100/WiFiClient-W5100.ino
@@ -9,6 +9,8 @@ const char* host = "djxmmx.net";
 const uint16_t port = 17;
 
 Wiznet5100lwIP eth(1 /* chip select */);
+// To use Interrupt-driven mode, pass in an SPI object and an IRQ pin like so:
+// Wiznet5100lwIP eth(17, SPI, 21);
 
 void setup() {
   // Set up SPI pinout to match your HW

--- a/libraries/lwIP_w5100/src/utility/w5100.cpp
+++ b/libraries/lwIP_w5100/src/utility/w5100.cpp
@@ -209,7 +209,6 @@ bool Wiznet5100::begin(const uint8_t* mac_address, netif *net) {
     if (_intr >= 0) {
         setSn_IR(0xff); // Clear everything
         setIMR(IM_IR0);
-        pinMode(_intr, INPUT);
     }
 
     // Success

--- a/libraries/lwIP_w5100/src/utility/w5100.h
+++ b/libraries/lwIP_w5100/src/utility/w5100.h
@@ -101,7 +101,7 @@ public:
     netif *_netif;
 protected:
     static constexpr bool interruptIsPossible() {
-        return false;
+        return true;
     }
 
     /**
@@ -144,6 +144,7 @@ private:
 
     SPIClass& _spi;
     int8_t    _cs;
+    int8_t    _intr;
     uint8_t   _mac_address[6];
 
     /**
@@ -308,6 +309,17 @@ private:
         MR_IND = 0x01,  ///< Indirect Bus Interface mode
     };
 
+    /** Interrupt Mask register values */
+    enum {
+        IM_IR0 = 0x01,  ///< Occurrence of Socket 0 Socket Interrupt Enable
+        IM_IR1 = 0x02,  ///< Occurrence of Socket 1 Socket Interrupt Enable
+        IM_IR2 = 0x04,  ///< Occurrence of Socket 2 Socket Interrupt Enable
+        IM_IR3 = 0x08,  ///< Occurrence of Socket 3 Socket Interrupt Enable
+        IM_IR5 = 0x20,  ///< PPPoE Close Enable
+        IM_IR6 = 0x40,  ///< Destination unreachable Enable
+        IM_IR7 = 0x80,  ///< IP Conflict Enable
+    };
+
     /** Socket Mode Register values @ref Sn_MR */
     enum {
         Sn_MR_CLOSE  = 0x00,  ///< Unused socket
@@ -373,6 +385,24 @@ private:
     */
     inline uint8_t getMR() {
         return wizchip_read(MR);
+    }
+
+    /**
+        Set Interrupt Mask Register
+        @param (uint8_t)mr The value to be set.
+        @sa geIMR()
+    */
+    inline void setIMR(uint8_t mode) {
+        wizchip_write(IMR, mode);
+    }
+
+    /**
+        Get Mode Register
+        @return uint8_t. The value of Mode register.
+        @sa setIMR()
+    */
+    inline uint8_t getIMR() {
+        return wizchip_read(IMR);
     }
 
     /**

--- a/libraries/lwIP_w5500/src/utility/w5500.cpp
+++ b/libraries/lwIP_w5500/src/utility/w5500.cpp
@@ -34,6 +34,7 @@
 
 #include <SPI.h>
 #include "w5500.h"
+#include <LwipEthernet.h>
 
 uint8_t Wiznet5500::wizchip_read(uint8_t block, uint16_t address) {
     uint8_t ret;
@@ -238,8 +239,7 @@ int8_t Wiznet5500::wizphy_setphypmode(uint8_t pmode) {
     return -1;
 }
 
-Wiznet5500::Wiznet5500(int8_t cs, SPIClass& spi, int8_t intr) : _spi(spi), _cs(cs) {
-    (void)intr;
+Wiznet5500::Wiznet5500(int8_t cs, SPIClass& spi, int8_t intr) : _spi(spi), _cs(cs), _intr(intr) {
 }
 
 bool Wiznet5500::begin(const uint8_t* mac_address, netif *net) {
@@ -248,13 +248,6 @@ bool Wiznet5500::begin(const uint8_t* mac_address, netif *net) {
 
     pinMode(_cs, OUTPUT);
     wizchip_cs_deselect();
-
-#if 0
-    _spi.begin();
-    _spi.setClockDivider(SPI_CLOCK_DIV4); // 4 MHz?
-    _spi.setBitOrder(MSBFIRST);
-    _spi.setDataMode(SPI_MODE0);
-#endif
 
     wizchip_sw_reset();
 
@@ -271,6 +264,12 @@ bool Wiznet5500::begin(const uint8_t* mac_address, netif *net) {
     if (getSn_SR() != SOCK_MACRAW) {
         // Failed to put socket 0 into MACRaw mode
         return false;
+    }
+
+    if (_intr >= 0) {
+        setSn_IR(0xff); // Clear everything
+        setSIMR(1);
+        pinMode(_intr, INPUT);
     }
 
     // Success
@@ -305,6 +304,8 @@ uint16_t Wiznet5500::readFrame(uint8_t* buffer, uint16_t bufsize) {
 }
 
 uint16_t Wiznet5500::readFrameSize() {
+    setSn_IR(Sn_IR_RECV);
+
     uint16_t len = getSn_RX_RSR();
 
     if (len == 0) {
@@ -333,26 +334,18 @@ uint16_t Wiznet5500::readFrameData(uint8_t* buffer, uint16_t framesize) {
     wizchip_recv_data(buffer, framesize);
     setSn_CR(Sn_CR_RECV);
 
-#if 1
     // let lwIP deal with mac address filtering
     return framesize;
-#else
-    // Had problems with W5500 MAC address filtering (the Sn_MR_MFEN option)
-    // Do it in software instead:
-    if ((buffer[0] & 0x01) || memcmp(&buffer[0], _mac_address, 6) == 0) {
-        // Addressed to an Ethernet multicast address or our unicast address
-        return framesize;
-    } else {
-        return 0;
-    }
-#endif
 }
 
 uint16_t Wiznet5500::sendFrame(const uint8_t* buf, uint16_t len) {
+    ethernet_arch_lwip_gpio_mask(); // So we don't fire an IRQ and interrupt the send w/a receive!
+
     // Wait for space in the transmit buffer
     while (1) {
         uint16_t freesize = getSn_TX_FSR();
         if (getSn_SR() == SOCK_CLOSED) {
+            ethernet_arch_lwip_gpio_unmask();
             return -1;
         }
         if (len <= freesize) {
@@ -372,9 +365,11 @@ uint16_t Wiznet5500::sendFrame(const uint8_t* buf, uint16_t len) {
         } else if (tmp & Sn_IR_TIMEOUT) {
             setSn_IR(Sn_IR_TIMEOUT);
             // There was a timeout
+            ethernet_arch_lwip_gpio_unmask();
             return -1;
         }
     }
 
+    ethernet_arch_lwip_gpio_unmask();
     return len;
 }

--- a/libraries/lwIP_w5500/src/utility/w5500.cpp
+++ b/libraries/lwIP_w5500/src/utility/w5500.cpp
@@ -269,7 +269,6 @@ bool Wiznet5500::begin(const uint8_t* mac_address, netif *net) {
     if (_intr >= 0) {
         setSn_IR(0xff); // Clear everything
         setSIMR(1);
-        pinMode(_intr, INPUT);
     }
 
     // Success

--- a/libraries/lwIP_w5500/src/utility/w5500.h
+++ b/libraries/lwIP_w5500/src/utility/w5500.h
@@ -104,7 +104,7 @@ public:
 
 protected:
     static constexpr bool interruptIsPossible() {
-        return false;
+        return true;
     }
 
     /**
@@ -152,6 +152,7 @@ private:
 
     SPIClass& _spi;
     int8_t    _cs;
+    int8_t    _intr;
     uint8_t   _mac_address[6];
 
     /**
@@ -319,7 +320,7 @@ private:
         IR       = 0x0015,  ///< Interrupt Register (R/W)
         _IMR_    = 0x0016,  ///< Interrupt mask register (R/W)
         SIR      = 0x0017,  ///< Socket Interrupt Register (R/W)
-        SIMR     = 0x0018,  ///< Socket Interrupt Mask Register (R/W)
+        _SIMR_   = 0x0018,  ///< Socket Interrupt Mask Register (R/W)
         _RTR_    = 0x0019,  ///< Timeout register address (1 is 100us) (R/W)
         _RCR_    = 0x001B,  ///< Retry count register (R/W)
         UIPR     = 0x0028,  ///< Unreachable IP register address in UDP mode (R)
@@ -521,6 +522,24 @@ private:
     }
 
     /**
+        Set @ref SIR register
+        @param (uint8_t)ir Value to set @ref SIR register.
+        @sa getSIR()
+    */
+    inline void setSIR(uint8_t ir) {
+        wizchip_write(BlockSelectCReg, SIR, ir);
+    }
+
+    /**
+        Get @ref SIR register
+        @return uint8_t. Value of @ref SIR register.
+        @sa setSIR()
+    */
+    inline uint8_t getSIR() {
+        return wizchip_read(BlockSelectCReg, SIR);
+    }
+
+    /**
         Set @ref _IMR_ register
         @param (uint8_t)imr Value to set @ref _IMR_ register.
         @sa getIMR()
@@ -536,6 +555,24 @@ private:
     */
     inline uint8_t getIMR() {
         return wizchip_read(BlockSelectCReg, _IMR_);
+    }
+
+    /**
+        Set @ref _SIMR_ register
+        @param (uint8_t)imr Value to set @ref _SIMR_ register.
+        @sa getIMR()
+    */
+    inline void setSIMR(uint8_t imr) {
+        wizchip_write(BlockSelectCReg, _SIMR_, imr);
+    }
+
+    /**
+        Get @ref _SIMR_ register
+        @return uint8_t. Value of @ref _SIMR_ register.
+        @sa setSIMR()
+    */
+    inline uint8_t getSIMR() {
+        return wizchip_read(BlockSelectCReg, _SIMR_);
     }
 
     /**


### PR DESCRIPTION
No polling needed and should reduce latency by using the GPIO interrupt to signal the Pico to read a received packet.