### PR TITLE
Make W5100 example run on Wiznet w/no changes

### DIFF
--- a/libraries/lwIP_w5100/examples/WiFiClient-W5100/WiFiClient-W5100.ino
+++ b/libraries/lwIP_w5100/examples/WiFiClient-W5100/WiFiClient-W5100.ino
@@ -8,16 +8,21 @@
 const char* host = "djxmmx.net";
 const uint16_t port = 17;
 
-Wiznet5100lwIP eth(1 /* chip select */);
+#ifdef ARDUINO_WIZNET_5100S_EVB_PICO
 // To use Interrupt-driven mode, pass in an SPI object and an IRQ pin like so:
-// Wiznet5100lwIP eth(17, SPI, 21);
+Wiznet5100lwIP eth(17, SPI, 21);
+#else
+Wiznet5100lwIP eth(1 /* chip select */);
+#endif
 
 void setup() {
+#ifndef ARDUINO_WIZNET_5100S_EVB_PICO
   // Set up SPI pinout to match your HW
   SPI.setRX(0);
   SPI.setCS(1);
   SPI.setSCK(2);
   SPI.setTX(3);
+#endif
 
   Serial.begin(115200);
   delay(5000);


### PR DESCRIPTION
Use the #define board name to identify when building for the WIZnet W5100s-EVB-Pico and assign the proper pins and IRQs.