### PR TITLE
Low bitrate whine fix (DMA pacing timer)

### DIFF
--- a/libraries/PWMAudio/src/PWMAudio.cpp
+++ b/libraries/PWMAudio/src/PWMAudio.cpp
@@ -32,8 +32,8 @@ PWMAudio::PWMAudio(pin_size_t pin, bool stereo) {
     _buffers = 8;
     _bufferWords = 0;
     _stereo = stereo;
-    _sampleRate=48000;
-    _pacer=-1;
+    _sampleRate = 48000;
+    _pacer = -1;
 }
 
 PWMAudio::~PWMAudio() {
@@ -94,13 +94,14 @@ bool PWMAudio::setPWMFrequency(int newFreq) {
     return true;
 }
 
-bool PWMAudio::setFrequency(int frequency)
-{
-    if(_pacer<0) return false;
+bool PWMAudio::setFrequency(int frequency) {
+    if (_pacer < 0) {
+        return false;
+    }
     uint16_t _pacer_D, _pacer_N;
     /*Flip fraction(N for D, D for N) because we are using it as sys_clk * fraction(mechanic of dma_timer_set_fraction) for smaller than sys_clk values*/
-    find_pacer_fraction(frequency, &_pacer_D, &_pacer_N); 
-    dma_timer_set_fraction(_pacer, _pacer_N, _pacer_D); 
+    find_pacer_fraction(frequency, &_pacer_D, &_pacer_N);
+    dma_timer_set_fraction(_pacer, _pacer_N, _pacer_D);
     return true;
 }
 
@@ -134,12 +135,14 @@ bool PWMAudio::begin() {
     /*Calculate and set the DMA pacer timer. This timer will pull data on a fixed sample rate. So the actual PWM frequency can be higher or lower.*/
     _pacer = dma_claim_unused_timer(false);
     /*When no unused timer is found, return*/
-    if(_pacer<0) return false;
+    if (_pacer < 0) {
+        return false;
+    }
     uint16_t _pacer_D = 0;
     uint16_t _pacer_N = 0;
     /*Flip fraction(N for D, D for N) because we are using it as sys_clk * fraction(mechanic of dma_timer_set_fraction) for smaller than sys_clk values*/
-    find_pacer_fraction(_sampleRate, &_pacer_D, &_pacer_N); 
-    dma_timer_set_fraction(_pacer, _pacer_N, _pacer_D); 
+    find_pacer_fraction(_sampleRate, &_pacer_D, &_pacer_N);
+    dma_timer_set_fraction(_pacer, _pacer_N, _pacer_D);
     int _pacer_dreq = dma_get_timer_dreq(_pacer);
 
     uint32_t ccAddr = PWM_BASE + PWM_CH0_CC_OFFSET + pwm_gpio_to_slice_num(_pin) * 20;
@@ -254,8 +257,7 @@ void PWMAudio::find_pacer_fraction(int target, uint16_t *numerator, uint16_t *de
     static uint16_t bestNum;
     static uint16_t bestDenom;
     /*Check if we can load the previous values*/
-    if(target==last_target)
-    {
+    if (target == last_target) {
         *numerator = bestNum;
         *denominator = bestDenom;
         return;
@@ -263,11 +265,11 @@ void PWMAudio::find_pacer_fraction(int target, uint16_t *numerator, uint16_t *de
 
     float targetRatio = (float)F_CPU / target;
     float lowestError = HUGE_VALF;
-    
+
     for (uint16_t denom = 1; denom < max; denom++) {
         uint16_t num = (int)((targetRatio * denom) + 0.5f); /*Calculate numerator, rounding to nearest integer*/
-        
-        /*Check if numerator is within bounds*/ 
+
+        /*Check if numerator is within bounds*/
         if (num > 0 && num < max) {
             float actualRatio = (float)num / denom;
             float error = fabsf(actualRatio - targetRatio);
@@ -276,12 +278,14 @@ void PWMAudio::find_pacer_fraction(int target, uint16_t *numerator, uint16_t *de
                 bestNum = num;
                 bestDenom = denom;
                 lowestError = error;
-                if(error==0) break;
+                if (error == 0) {
+                    break;
+                }
             }
         }
     }
 
-    last_target=target;
+    last_target = target;
     *numerator = bestNum;
     *denominator = bestDenom;
 }

--- a/libraries/PWMAudio/src/PWMAudio.cpp
+++ b/libraries/PWMAudio/src/PWMAudio.cpp
@@ -168,6 +168,7 @@ void PWMAudio::end() {
         _arb = nullptr;
 
         dma_timer_unclaim(_pacer);
+        _pacer = -1;
     }
 }
 

--- a/libraries/PWMAudio/src/PWMAudio.cpp
+++ b/libraries/PWMAudio/src/PWMAudio.cpp
@@ -32,6 +32,8 @@ PWMAudio::PWMAudio(pin_size_t pin, bool stereo) {
     _buffers = 8;
     _bufferWords = 0;
     _stereo = stereo;
+    _sampleRate=48000;
+    _pacer=-1;
 }
 
 PWMAudio::~PWMAudio() {
@@ -63,7 +65,7 @@ bool PWMAudio::setStereo(bool stereo) {
     return true;
 }
 
-bool PWMAudio::setFrequency(int newFreq) {
+bool PWMAudio::setPWMFrequency(int newFreq) {
     _freq = newFreq;
 
     // Figure out the scale factor for PWM values
@@ -92,6 +94,16 @@ bool PWMAudio::setFrequency(int newFreq) {
     return true;
 }
 
+bool PWMAudio::setFrequency(int frequency)
+{
+    if(_pacer<0) return false;
+    uint16_t _pacer_D, _pacer_N;
+    /*Flip fraction(N for D, D for N) because we are using it as sys_clk * fraction(mechanic of dma_timer_set_fraction) for smaller than sys_clk values*/
+    find_pacer_fraction(frequency, &_pacer_D, &_pacer_N); 
+    dma_timer_set_fraction(_pacer, _pacer_N, _pacer_D); 
+    return true;
+}
+
 void PWMAudio::onTransmit(void(*fn)(void)) {
     _cb = fn;
     if (_running) {
@@ -117,12 +129,23 @@ bool PWMAudio::begin() {
         _bufferWords = 16;
     }
 
-    setFrequency(_freq);
+    setPWMFrequency(_freq);
+
+    /*Calculate and set the DMA pacer timer. This timer will pull data on a fixed sample rate. So the actual PWM frequency can be higher or lower.*/
+    _pacer = dma_claim_unused_timer(false);
+    /*When no unused timer is found, return*/
+    if(_pacer<0) return false;
+    uint16_t _pacer_D = 0;
+    uint16_t _pacer_N = 0;
+    /*Flip fraction(N for D, D for N) because we are using it as sys_clk * fraction(mechanic of dma_timer_set_fraction) for smaller than sys_clk values*/
+    find_pacer_fraction(_sampleRate, &_pacer_D, &_pacer_N); 
+    dma_timer_set_fraction(_pacer, _pacer_N, _pacer_D); 
+    int _pacer_dreq = dma_get_timer_dreq(_pacer);
 
     uint32_t ccAddr = PWM_BASE + PWM_CH0_CC_OFFSET + pwm_gpio_to_slice_num(_pin) * 20;
 
     _arb = new AudioBufferManager(_buffers, _bufferWords, 0x80008000, OUTPUT, DMA_SIZE_32);
-    if (!_arb->begin(pwm_get_dreq(pwm_gpio_to_slice_num(_pin)), (volatile void*)ccAddr)) {
+    if (!_arb->begin(_pacer_dreq, (volatile void*)ccAddr)) {
         _running = false;
         delete _arb;
         _arb = nullptr;
@@ -143,6 +166,8 @@ void PWMAudio::end() {
         }
         delete _arb;
         _arb = nullptr;
+
+        dma_timer_unclaim(_pacer);
     }
 }
 
@@ -218,4 +243,34 @@ size_t PWMAudio::write(const uint8_t *buffer, size_t size) {
         }
     }
     return writtenSize;
+}
+
+void PWMAudio::find_pacer_fraction(int target, uint16_t *numerator, uint16_t *denominator) {
+    const uint16_t max = 0xFFFF;
+
+    float targetRatio = (float)F_CPU / target;
+    float lowestError = HUGE_VALF;
+    uint16_t bestNum = 1;
+    uint16_t bestDenom = 1;
+    
+    for (uint16_t denom = 1; denom < max; denom++) {
+        Serial.println(denom);
+        uint16_t num = (int)((targetRatio * denom) + 0.5f); // Calculate numerator, rounding to nearest integer
+        
+        // Check if numerator is within bounds
+        if (num > 0 && num < max) {
+            float actualRatio = (float)num / denom;
+            float error = fabsf(actualRatio - targetRatio);
+
+            if (error < lowestError) {
+                bestNum = num;
+                bestDenom = denom;
+                lowestError = error;
+                if(error==0) break;
+            }
+        }
+    }
+
+    *numerator = bestNum;
+    *denominator = bestDenom;
 }

--- a/libraries/PWMAudio/src/PWMAudio.cpp
+++ b/libraries/PWMAudio/src/PWMAudio.cpp
@@ -249,16 +249,25 @@ size_t PWMAudio::write(const uint8_t *buffer, size_t size) {
 void PWMAudio::find_pacer_fraction(int target, uint16_t *numerator, uint16_t *denominator) {
     const uint16_t max = 0xFFFF;
 
+    /*Cache last results so we dont have to recalculate*/
+    static int last_target;
+    static uint16_t bestNum;
+    static uint16_t bestDenom;
+    /*Check if we can load the previous values*/
+    if(target==last_target)
+    {
+        *numerator = bestNum;
+        *denominator = bestDenom;
+        return;
+    }
+
     float targetRatio = (float)F_CPU / target;
     float lowestError = HUGE_VALF;
-    uint16_t bestNum = 1;
-    uint16_t bestDenom = 1;
     
     for (uint16_t denom = 1; denom < max; denom++) {
-        Serial.println(denom);
-        uint16_t num = (int)((targetRatio * denom) + 0.5f); // Calculate numerator, rounding to nearest integer
+        uint16_t num = (int)((targetRatio * denom) + 0.5f); /*Calculate numerator, rounding to nearest integer*/
         
-        // Check if numerator is within bounds
+        /*Check if numerator is within bounds*/ 
         if (num > 0 && num < max) {
             float actualRatio = (float)num / denom;
             float error = fabsf(actualRatio - targetRatio);
@@ -272,6 +281,7 @@ void PWMAudio::find_pacer_fraction(int target, uint16_t *numerator, uint16_t *de
         }
     }
 
+    last_target=target;
     *numerator = bestNum;
     *denominator = bestDenom;
 }

--- a/libraries/PWMAudio/src/PWMAudio.h
+++ b/libraries/PWMAudio/src/PWMAudio.h
@@ -37,13 +37,13 @@ public:
     bool setStereo(bool stereo = true);
 
     bool begin(long sampleRate) {
-        _sampleRate=sampleRate;
+        _sampleRate = sampleRate;
         return begin();
     }
 
     bool begin(long sampleRate, long PWMfrequency) {
         setPWMFrequency(PWMfrequency);
-        _sampleRate=sampleRate;
+        _sampleRate = sampleRate;
         return begin();
     }
 

--- a/libraries/PWMAudio/src/PWMAudio.h
+++ b/libraries/PWMAudio/src/PWMAudio.h
@@ -29,12 +29,21 @@ public:
     virtual ~PWMAudio();
 
     bool setBuffers(size_t buffers, size_t bufferWords);
-    bool setFrequency(int newFreq);
+    /*Sets the frequency of the PWM in hz*/
+    bool setPWMFrequency(int newFreq);
+    /*Sets the sample rate frequency in hz*/
+    bool setFrequency(int frequency);
     bool setPin(pin_size_t pin);
     bool setStereo(bool stereo = true);
 
     bool begin(long sampleRate) {
-        setFrequency(sampleRate);
+        _sampleRate=sampleRate;
+        return begin();
+    }
+
+    bool begin(long sampleRate, long PWMfrequency) {
+        setPWMFrequency(PWMfrequency);
+        _sampleRate=sampleRate;
         return begin();
     }
 
@@ -70,6 +79,9 @@ private:
     bool _stereo;
 
     int _freq;
+    int _sampleRate;
+
+    int _pacer;
 
     size_t _buffers;
     size_t _bufferWords;
@@ -84,4 +96,7 @@ private:
     void (*_cb)();
 
     AudioBufferManager *_arb;
+
+    /*An accurate but brute force method to find 16bit numerator and denominator.*/
+    void find_pacer_fraction(int target, uint16_t *numerator, uint16_t *denominator);
 };


### PR DESCRIPTION
When using low bitrates like 8000hz or 11025hz as example, PWMAudio will produce a high pitched whine(same as sample rate hz), that sometimes can overwhelm the audio.
This is because the DMA transfers (sample rate) are synced to the PWM wave generation (pwm frequency).

In the RP2040 datasheet under DMA 2.5.5.1, there is a section about pacing timers.
This is a timer that triggers the DREQ every n clock_sys ticks.
Now this is replacing the PWM synced method, which allows the PWM wave generation to have a different frequency than the sample rate.

There is one downside;
The begin() function CAN take quite a few milliseconds worst case to find the perfect fraction for the pacing timer. As the pacer has to be configured with a numerator and a denominator.
It has to find the right fraction based on CPU frequency and bitrate target.

For backwards compatibility and to prevent confusion, I kept the old functions.
setFrequency is still bit rate and setPWMFrequency is to set the PWM.
Now begin has an override so you can select either the usual begin(bitrate) OR begin(bitrate, pwmfreq).

If there is anything to be changed, let me know. (This is my first contribution too!)

Thanks!