### PR TITLE
Fix WiFiMulti and ESPhost STA connection w/BSSID

### DIFF
--- a/libraries/lwIP_ESPHost/src/lwIP_ESPHost.cpp
+++ b/libraries/lwIP_ESPHost/src/lwIP_ESPHost.cpp
@@ -54,7 +54,7 @@ void ESPHostLwIP::setBSSID(const uint8_t *bssid) {
     if (bssid == nullptr) {
         ap.bssid[0] = 0;
     } else {
-        memcpy(ap.bssid, bssid, sizeof(ap.bssid));
+        snprintf((char *)ap.bssid, sizeof(ap.bssid), "%02x:%02x:%02x:%02x:%02x:%02x", bssid[0], bssid[1], bssid[2], bssid[3], bssid[4], bssid[5]);
     }
 }
 


### PR DESCRIPTION
WiFiMulti specifies a specific BSSID, in addition to the AP name and password.  In the WiFi core the BSSID is stored as the raw 6-byte MAC address, but the ESPHostedFG firmware expects a formatted C-String (i.e. "ab:cd:ef:01:02:03" instead of {0xab, 0xcd, 0xef, 1, 2, 3})

Convert the raw bytes to the string format expected in the ESP FW.