### PR TITLE
Clean up WIFI local variable MAC size

### DIFF
--- a/libraries/WiFi/src/WiFiClass.h
+++ b/libraries/WiFi/src/WiFiClass.h
@@ -154,7 +154,7 @@ public:
     }
 
     String softAPmacAddress(void) {
-        uint8_t mac[8];
+        uint8_t mac[6];
         macAddress(mac);
         char buff[32];
         sprintf(buff, "%02x:%02x:%02x:%02x:%02x:%02x", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);
@@ -240,7 +240,7 @@ public:
     */
     uint8_t* macAddress(uint8_t* mac);
     String macAddress(void) {
-        uint8_t mac[8];
+        uint8_t mac[6];
         macAddress(mac);
         char buff[32];
         sprintf(buff, "%02x:%02x:%02x:%02x:%02x:%02x", mac[0], mac[1], mac[2], mac[3], mac[4], mac[5]);


### PR DESCRIPTION
MACs are 6-bytes long, not 8.  D'oh.