### PR TITLE
lwIP_ESPHost - using interrupt

### DIFF
--- a/libraries/lwIP_ESPHost/src/ESPHost.cpp
+++ b/libraries/lwIP_ESPHost/src/ESPHost.cpp
@@ -19,7 +19,8 @@
 */
 
 #include "ESPHost.h"
-#include "CEspControl.h"
+#include <CEspControl.h>
+#include <LwipEthernet.h>
 
 ESPHost::ESPHost(int8_t cs, arduino::SPIClass &spi, int8_t intrpin) {
     (void) cs;
@@ -42,8 +43,10 @@ void ESPHost::end() {
 }
 
 uint16_t ESPHost::sendFrame(const uint8_t *data, uint16_t datalen) {
+    ethernet_arch_lwip_gpio_mask();
     int res = CEspControl::getInstance().sendBuffer(apMode ? ESP_AP_IF : ESP_STA_IF, 0, (uint8_t*) data, datalen);
     CEspControl::getInstance().communicateWithEsp();
+    ethernet_arch_lwip_gpio_unmask();
     return (res == ESP_CONTROL_OK) ? datalen : 0;
 }
 

--- a/libraries/lwIP_ESPHost/src/ESPHost.h
+++ b/libraries/lwIP_ESPHost/src/ESPHost.h
@@ -44,7 +44,7 @@ public:
     }
 
     bool interruptIsPossible() {
-        return false;
+        return true;
     }
 
     PinStatus interruptMode() {

--- a/libraries/lwIP_ESPHost/src/lwIP_ESPHost.h
+++ b/libraries/lwIP_ESPHost/src/lwIP_ESPHost.h
@@ -27,6 +27,8 @@
 class ESPHostLwIP : public LwipIntfDev<ESPHost> {
 public:
 
+    ESPHostLwIP();
+
     void setSTA();
     void setAP();
 


### PR DESCRIPTION
I attempt to make the ESPHost work with interrupt. There are two problems.

First problem is small. The DATA_READY pin is active HGH with esp_hosted. So we need a way to return from RawDev the state for interrupt.

Second problem is big. The semaphores don't work. It is a problem without the interrupt too, but with the interrupt version `handlePackets` doesn't run in async_context so there is no locking.
`ethernet_arch_lwip_begin/end` only guards code executed within async_context so using it elsewhere doesn't stop the code executing. It only blocks handlePackets if executed from the timer worker.