### PR TITLE
lwIP_enc28j60 - add missing end() method

### DIFF
--- a/libraries/lwIP_enc28j60/src/utility/enc28j60.cpp
+++ b/libraries/lwIP_enc28j60/src/utility/enc28j60.cpp
@@ -516,6 +516,12 @@ bool ENC28J60::begin(const uint8_t* address, netif *net) {
 
 /*---------------------------------------------------------------------------*/
 
+void ENC28J60::end() {
+
+}
+
+/*---------------------------------------------------------------------------*/
+
 uint16_t ENC28J60::sendFrame(const uint8_t* data, uint16_t datalen) {
     uint16_t dataend;
 

--- a/libraries/lwIP_enc28j60/src/utility/enc28j60.h
+++ b/libraries/lwIP_enc28j60/src/utility/enc28j60.h
@@ -62,6 +62,11 @@ public:
     bool begin(const uint8_t* address, netif *net);
 
     /**
+        Shut down the Ethernet controlled
+    */
+    void end();
+
+    /**
         Send an Ethernet frame
         @param data a pointer to the data to send
         @param datalen the length of the data in the packet


### PR DESCRIPTION
RawDev::end() is used in LwipIntfDev::end().