### PR TITLE
LwipIntfDev - linkStatus() added

### DIFF
--- a/libraries/lwIP_Ethernet/src/LwipIntfDev.h
+++ b/libraries/lwIP_Ethernet/src/LwipIntfDev.h
@@ -50,6 +50,11 @@
 #define DEFAULT_MTU 1500
 #endif
 
+enum EthernetLinkStatus {
+    Unknown,
+    LinkON,
+    LinkOFF
+};
 
 extern "C" void cyw43_hal_generate_laa_mac(__unused int idx, uint8_t buf[6]);
 
@@ -148,6 +153,9 @@ public:
     // ESP8266WiFi API compatibility
 
     wl_status_t status();
+
+    // Arduino Ethernet compatibility
+    EthernetLinkStatus linkStatus();
 
 protected:
     err_t netif_init();
@@ -440,6 +448,11 @@ void LwipIntfDev<RawDev>::_irq(void *param) {
 template<class RawDev>
 wl_status_t LwipIntfDev<RawDev>::status() {
     return _started ? (connected() ? WL_CONNECTED : WL_DISCONNECTED) : WL_NO_SHIELD;
+}
+
+template<class RawDev>
+EthernetLinkStatus LwipIntfDev<RawDev>::linkStatus() {
+    return RawDev::isLinkDetectable() ? _started && RawDev::isLinked() ? LinkON : LinkOFF : Unknown;
 }
 
 template<class RawDev>


### PR DESCRIPTION
all Ethernet libraries have `linkStatus`. 
https://github.com/JAndrassy/Arduino-Networking-API/blob/main/ArduinoNetAPILibs.md#ethernet-network-interface

all code in this PR copied from esp8266 core without changes.

tested with the [ModernEthernetTest](https://github.com/JAndrassy/NetApiHelpers/blob/master/examples/ModernEthernetTest/ModernEthernetTest.ino)