### PR TITLE
Protect W5500/ENC28J60 isLinked() call from IRQ-mode

### DIFF
--- a/libraries/lwIP_enc28j60/src/utility/enc28j60.cpp
+++ b/libraries/lwIP_enc28j60/src/utility/enc28j60.cpp
@@ -715,8 +715,10 @@ uint16_t ENC28J60::phyread(uint8_t reg) {
 
 bool ENC28J60::isLinked() {
     // ( https://github.com/JAndrassy/EthernetENC/tree/master/src/utility/enc28j60.h )
+    ethernet_arch_lwip_gpio_mask();
     ethernet_arch_lwip_begin();
     auto ret = !!(phyread(MACSTAT2) & 0x400);
     ethernet_arch_lwip_end();
+    ethernet_arch_lwip_gpio_unmask();
     return ret;
 }

--- a/libraries/lwIP_w5500/src/utility/w5500.h
+++ b/libraries/lwIP_w5500/src/utility/w5500.h
@@ -84,9 +84,11 @@ public:
         @return true when physical link is up
     */
     bool isLinked() {
+        ethernet_arch_lwip_gpio_mask();
         ethernet_arch_lwip_begin();
         auto ret = wizphy_getphylink() == PHY_LINK_ON;
         ethernet_arch_lwip_end();
+        ethernet_arch_lwip_gpio_unmask();
         return ret;
     }
 


### PR DESCRIPTION
Fixes #2105