### PR TITLE
BTstackLib: added function to set scan respone data.

### DIFF
--- a/libraries/BTstackLib/src/BTstackLib.cpp
+++ b/libraries/BTstackLib/src/BTstackLib.cpp
@@ -889,6 +889,9 @@ uint16_t BTstackManager::addGATTCharacteristicDynamic(UUID * uuid, uint16_t flag
 void BTstackManager::setAdvData(uint16_t adv_data_len, const uint8_t * adv_data) {
     gap_advertisements_set_data(adv_data_len, (uint8_t*) adv_data);
 }
+void BTstackManager::setScanData(uint16_t scan_data_len, const uint8_t * scan_data) {
+    gap_scan_response_set_data(scan_data_len, (uint8_t*) scan_data);
+}
 void BTstackManager::startAdvertising() {
     gap_advertisements_enable(1);
 }

--- a/libraries/BTstackLib/src/BTstackLib.h
+++ b/libraries/BTstackLib/src/BTstackLib.h
@@ -143,6 +143,7 @@ extern "C" {
         void enableDebugLogger();
 
         void setAdvData(uint16_t size, const uint8_t * data);
+        void setScanData(uint16_t size, const uint8_t * data);
         void iBeaconConfigure(UUID * uuid, uint16_t major_id, uint16_t minor_id, uint8_t measured_power = 0xc6);
         void startAdvertising();
         void stopAdvertising();


### PR DESCRIPTION
Hi,

I added a function to set the BLE scan response data via BTstackManager - essentially just a wrapper around the underlying BTstack function. The passed data must be structured in the same manner as advertising data.

Best regards,
djpearman