### PR TITLE
BTstack: remove superfluous call during setup.

### DIFF
--- a/libraries/BTstackLib/src/BTstackLib.cpp
+++ b/libraries/BTstackLib/src/BTstackLib.cpp
@@ -808,9 +808,6 @@ void BTstackManager::setup(const char * name) {
     hci_add_event_handler(&hci_event_callback_registration);
     l2cap_init();
 
-    // setup central device db
-    le_device_db_init();
-
     sm_init();
 
     att_server_init(att_db_util_get_address(), att_read_callback, att_write_callback);


### PR DESCRIPTION
Hi,

The call to `le_device_db_init()` seems to superfluous as it is called in the subsequent `sm_init()`. It is not present in BTstack examples I've seen, for example:

https://github.com/bluekitchen/btstack/blob/72ef1732c954d938091467961e41f4aa9b976b34/example/le_streamer_client.c

Removing has no apparent effects (good or bad) in my projects.

Best regards,
djpearman