### PR TITLE
Protect againt calling LWIP_Ethernet::begin twice

### DIFF
--- a/cores/rp2040/lwip_wrap.cpp
+++ b/cores/rp2040/lwip_wrap.cpp
@@ -358,4 +358,16 @@ extern "C" {
         __real_raw_remove(pcb);
     }
 
+    extern struct netif *__real_netif_add(struct netif *netif, const ip4_addr_t *ipaddr, const ip4_addr_t *netmask, const ip4_addr_t *gw, void *state, netif_init_fn init, netif_input_fn input);
+    struct netif *__wrap_netif_add(struct netif *netif, const ip4_addr_t *ipaddr, const ip4_addr_t *netmask, const ip4_addr_t *gw, void *state, netif_init_fn init, netif_input_fn input) {
+        LWIPMutex m;
+        return __real_netif_add(netif, ipaddr, netmask, gw, state, init, input);
+    }
+
+    extern void __real_netif_remove(struct netif *netif);
+    void __wrap_netif_remove(struct netif *netif) {
+        LWIPMutex m;
+        __real_netif_remove(netif);
+    }
+
 }; // extern "C"

--- a/lib/platform_wrap.txt
+++ b/lib/platform_wrap.txt
@@ -203,6 +203,9 @@
 -Wl,--wrap=raw_sendto
 -Wl,--wrap=raw_remove
 
+-Wl,--wrap=netif_add
+-Wl,--wrap=netif_remove
+
 -Wl,--wrap=cyw43_cb_process_ethernet
 -Wl,--wrap=cyw43_cb_tcpip_set_link_up
 -Wl,--wrap=cyw43_cb_tcpip_set_link_down

--- a/libraries/lwIP_Ethernet/src/LwipIntfDev.h
+++ b/libraries/lwIP_Ethernet/src/LwipIntfDev.h
@@ -310,6 +310,11 @@ bool LwipIntfDev<RawDev>::config(IPAddress local_ip, IPAddress dns) {
 extern char wifi_station_hostname[];
 template<class RawDev>
 bool LwipIntfDev<RawDev>::begin(const uint8_t* macAddress, const uint16_t mtu) {
+    if (_started) {
+        // ERROR - Need to ::end before calling ::begin again
+        return false;
+    }
+
     lwip_init();
     __startEthernetContext();
 


### PR DESCRIPTION
As seen in debug of #2149, if the LwipIntfDev is already _started, return false for a ::begin() call.

Also, protect netif_add/_remove on the very small possibilty of being called by LwipIntfDev devices while the CYW43 driver is doing work.