### PR TITLE
Fix LWIP crash on unexpected ping packets

### DIFF
--- a/libraries/lwIP_Ethernet/src/LwipIntfDev.h
+++ b/libraries/lwIP_Ethernet/src/LwipIntfDev.h
@@ -205,8 +205,8 @@ u8_t LwipIntfDev<RawDev>::_pingCB(void *arg, struct raw_pcb *pcb, struct pbuf *p
     (void) addr;
     LwipIntfDev<RawDev> *w = (LwipIntfDev<RawDev> *)arg;
     struct icmp_echo_hdr *iecho;
-    if (pbuf_header(p, -20) == 0) {
-        iecho = (struct icmp_echo_hdr *)p->payload;
+    if (p->len > 20) {
+        iecho = (struct icmp_echo_hdr *)((uint8_t*)p->payload + 20);
         if ((iecho->id == w->_ping_id) && (iecho->seqno == htons(w->_ping_seq_num))) {
             w->_ping_ttl = pcb->ttl;
             pbuf_free(p);


### PR DESCRIPTION
When a ping is sent from the Pico, a raw_recv callback is added which sees all raw incoming packets to detect the response from the ping target. If while waiting for the target response an external ping packet arrives this incoming ping request packet will be processed by the LwipIntfDev<>::_pingCB which will return "0" not processed and which *should* not change the payload unless it handles the actual packet.

Unfortunately, the 20 byte header was unconditionally stripped off of the packet before checking if this was our response, changing the payload address and causing an assertion in LWIP.

Fix by using absolute offsets inside the raw packet for the ping response checks.

Fixes #2156
Fixes #2149