### PR TITLE
Add asynchronous SPI transactions

### DIFF
--- a/docs/spi.rst
+++ b/docs/spi.rst
@@ -39,7 +39,39 @@ in order to consunme the received data and provide data to transmit.
 * The callbacks operate at IRQ time and may be called very frequently at high SPI frequencies.  So, make then small, fast, and with no memory allocations or locking.
 
 
-Examples
-~~~~~~~~
+Asynchronous Operation
+======================
 
-See the SPItoMyself example for a complete Master and Slave application.
+Applications can use asynchronous SPI calls to allow for processing while long-running SPI transfers are
+being performed.  For example, a game could send a full screen update out over SPI and immediately start
+processing the next frame without waiting for the first one to be sent.  DMA is used to handle
+the transfer to/from the hardware freeing the CPU from bit-banging or busy waiting.
+
+Note that asynchronous operations can not be intersped with normal, synchronous ones.  ``transferAsync``
+should still occur after a ``beginTransaction()`` and when ``finishedAsync()`` returns ``true`` then
+``endTransaction()`` should also be called.
+
+All buffers need to be valid throughout the entire operation.  Read data cannot be accessed until
+the transaction is completed and can't be "peeked" at while the operation is ongoing.
+
+bool transferAsync(const void \*send, void \*recv, size_t bytes)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Begins an SPI asynchronous transaction.  Either ``send`` or ``recv`` can be ``nullptr`` if data only needs
+to be transferred in one direction.
+Check ``finishedAsync()`` to determine when the operation completes and conclude the transaction.
+This operation needs to allocate a buffer from heap equal to ``bytes`` in size if ``LSBMODE`` is used.
+
+bool finishedAsync()
+~~~~~~~~~~~~~~~~~~~~
+Call to check if the asynchronous operations is completed and the buffer passed in can be either read or
+reused.  Frees the allocated memory and completes the asynchronous transaction.
+
+void abortAsync()
+~~~~~~~~~~~~~~~~~
+Cancels the outstanding asynchronous transaction and frees any allocated memory.
+
+
+Examples
+========
+
+See the SPItoMyself and SPItoMyselfAsync examples for a complete Master and Slave application.

--- a/libraries/SPI/examples/SPItoMyselfAsync/SPItoMyselfAsync.ino
+++ b/libraries/SPI/examples/SPItoMyselfAsync/SPItoMyselfAsync.ino
@@ -1,0 +1,93 @@
+// Shows how to use SPISlave on a single device in asynchronous mode
+// Core0 runs as an SPI master and initiates a transmission to the slave
+// Core1 runs the SPI Slave mode and provides a unique reply to messages from the master
+//
+// Released to the public domain 2024 by Earle F. Philhower, III <earlephilhower@yahoo.com>
+
+#include <SPI.h>
+#include <SPISlave.h>
+
+// Wiring:
+// Master RX  GP0 <-> GP11  Slave TX
+// Master CS  GP1 <-> GP9   Slave CS
+// Master CK  GP2 <-> GP10  Slave CK
+// Master TX  GP3 <-> GP8   Slave RX
+
+SPISettings spisettings(1000000, MSBFIRST, SPI_MODE0);
+
+// Core 0 will be SPI master
+void setup() {
+  SPI.setRX(0);
+  SPI.setCS(1);
+  SPI.setSCK(2);
+  SPI.setTX(3);
+  SPI.begin(true);
+
+  delay(5000);
+}
+
+int transmits = 0;
+void loop() {
+  char msg[42];
+  int loops = 0;
+  memset(msg, 0, sizeof(msg));
+  sprintf(msg, "What's up? This is transmission %d", transmits);
+  Serial.printf("\n\nM-SEND: '%s'\n", msg);
+  SPI.beginTransaction(spisettings);
+  SPI.transferAsync(msg, msg, sizeof(msg));
+  while (!SPI.finishedAsync()) {
+    loops++;
+  }
+  SPI.endTransaction();
+  Serial.printf("M-RECV: '%s', idle loops %d\n", msg, loops);
+  transmits++;
+  delay(5000);
+}
+
+// Core 1 will be SPI slave
+
+volatile bool recvBuffReady = false;
+char recvBuff[42] = "";
+int recvIdx = 0;
+void recvCallback(uint8_t *data, size_t len) {
+  memcpy(recvBuff + recvIdx, data, len);
+  recvIdx += len;
+  if (recvIdx == sizeof(recvBuff)) {
+    recvBuffReady = true;
+    recvIdx = 0;
+  }
+}
+
+int sendcbs = 0;
+// Note that the buffer needs to be long lived, the SPISlave doesn't copy it.  So no local stack variables, only globals or heap(malloc/new) allocations.
+char sendBuff[42];
+void sentCallback() {
+  memset(sendBuff, 0, sizeof(sendBuff));
+  sprintf(sendBuff, "Slave to Master Xmission %d", sendcbs++);
+  SPISlave1.setData((uint8_t*)sendBuff, sizeof(sendBuff));
+}
+
+// Note that we use SPISlave1 here **not** because we're running on
+// Core 1, but because SPI0 is being used already.  You can use
+// SPISlave or SPISlave1 on any core.
+void setup1() {
+  SPISlave1.setRX(8);
+  SPISlave1.setCS(9);
+  SPISlave1.setSCK(10);
+  SPISlave1.setTX(11);
+  // Ensure we start with something to send...
+  sentCallback();
+  // Hook our callbacks into the slave
+  SPISlave1.onDataRecv(recvCallback);
+  SPISlave1.onDataSent(sentCallback);
+  SPISlave1.begin(spisettings);
+  delay(3000);
+  Serial.println("S-INFO: SPISlave started");
+}
+
+void loop1() {
+  if (recvBuffReady) {
+    Serial.printf("S-RECV: '%s'\n", recvBuff);
+    recvBuffReady = false;
+  }
+}

--- a/libraries/SPI/keywords.txt
+++ b/libraries/SPI/keywords.txt
@@ -26,6 +26,9 @@ setRX	KEYWORD2
 setTX	KEYWORD2
 setSCK	KEYWORD2
 setCS	KEYWORD2
+transferAsync	KEYWORD2
+finishedAsync	KEYWORD2
+abortAsync	KEYWORD2
 
 #######################################
 # Constants (LITERAL1)


### PR DESCRIPTION
Fixes #1192

Uses DMA operations to avoid the need to bit-bang or busy wait for SPI operations that might be very slow. Optional, adds new API calls to enable. Simple example included.