### PR TITLE
Fix crash on audio end from IRQ, refactor A2DP

### DIFF
--- a/libraries/BluetoothAudio/examples/A2DPSink/A2DPSink.ino
+++ b/libraries/BluetoothAudio/examples/A2DPSink/A2DPSink.ino
@@ -45,7 +45,6 @@ void setup() {
 
 void loop() {
   if (BOOTSEL) {
-    __lockBluetooth();
     if (status == A2DPSink::PAUSED) {
       a2dp.play();
       Serial.printf("Resuming\n");
@@ -53,7 +52,6 @@ void loop() {
       a2dp.pause();
       Serial.printf("Pausing\n");
     }
-    __unlockBluetooth();
     while (BOOTSEL);
   }
 }

--- a/libraries/BluetoothAudio/src/A2DPSink.cpp
+++ b/libraries/BluetoothAudio/src/A2DPSink.cpp
@@ -191,9 +191,10 @@ bool A2DPSink::begin() {
 }
 
 bool A2DPSink::disconnect() {
-    __lockBluetooth();
-    a2dp_sink_disconnect(a2dp_sink_a2dp_connection.a2dp_cid);
-    __unlockBluetooth();
+    BluetoothLock b;
+    if (_connected) {
+        a2dp_sink_disconnect(a2dp_sink_a2dp_connection.a2dp_cid);
+    }
     if (!_running || !_connected) {
         return false;
     }
@@ -202,10 +203,11 @@ bool A2DPSink::disconnect() {
 }
 
 void A2DPSink::clearPairing() {
-    disconnect();
-    __lockBluetooth();
+    BluetoothLock b;
+    if (_connected) {
+        a2dp_sink_disconnect(a2dp_sink_a2dp_connection.a2dp_cid);
+    }
     gap_delete_all_link_keys();
-    __unlockBluetooth();
 }
 
 

--- a/libraries/BluetoothAudio/src/A2DPSink.h
+++ b/libraries/BluetoothAudio/src/A2DPSink.h
@@ -22,6 +22,7 @@
 
 #include <Arduino.h>
 #include "BluetoothHCI.h"
+#include "BluetoothLock.h"
 #include "BluetoothAudioConsumer.h"
 #include "BluetoothMediaConfigurationSBC.h"
 
@@ -120,60 +121,70 @@ public:
     void playback_handler(int16_t * buffer, uint16_t num_audio_frames);
 
     void play() {
+        BluetoothLock b;
         if (_connected) {
             avrcp_controller_play(a2dp_sink_avrcp_connection.avrcp_cid);
         }
     }
 
     void stop() {
+        BluetoothLock b;
         if (_connected) {
             avrcp_controller_stop(a2dp_sink_avrcp_connection.avrcp_cid);
         }
     }
 
     void pause() {
+        BluetoothLock b;
         if (_connected) {
             avrcp_controller_pause(a2dp_sink_avrcp_connection.avrcp_cid);
         }
     }
 
     void fastForward() {
+        BluetoothLock b;
         if (_connected) {
             avrcp_controller_fast_forward(a2dp_sink_avrcp_connection.avrcp_cid);
         }
     }
 
     void rewind() {
+        BluetoothLock b;
         if (_connected) {
             avrcp_controller_rewind(a2dp_sink_avrcp_connection.avrcp_cid);
         }
     }
 
     void forward() {
+        BluetoothLock b;
         if (_connected) {
             avrcp_controller_forward(a2dp_sink_avrcp_connection.avrcp_cid);
         }
     }
 
     void backward() {
+        BluetoothLock b;
         if (_connected) {
             avrcp_controller_backward(a2dp_sink_avrcp_connection.avrcp_cid);
         }
     }
 
     void volumeUp() {
+        BluetoothLock b;
         if (_connected) {
             avrcp_controller_volume_up(a2dp_sink_avrcp_connection.avrcp_cid);
         }
     }
 
     void volumeDown() {
+        BluetoothLock b;
         if (_connected) {
             avrcp_controller_volume_down(a2dp_sink_avrcp_connection.avrcp_cid);
         }
     }
 
     void mute() {
+        BluetoothLock b;
         if (_connected) {
             avrcp_controller_mute(a2dp_sink_avrcp_connection.avrcp_cid);
         }

--- a/libraries/BluetoothAudio/src/A2DPSource.h
+++ b/libraries/BluetoothAudio/src/A2DPSource.h
@@ -22,6 +22,7 @@
 
 #include <Arduino.h>
 #include "BluetoothHCI.h"
+#include "BluetoothLock.h"
 #include "BluetoothMediaConfigurationSBC.h"
 #include <functional>
 #include <list>
@@ -84,13 +85,12 @@ public:
     }
 
     bool getUnderflow() {
+        BluetoothLock b;
         if (!_running) {
             return false;
         }
-        __lockBluetooth();
         auto ret = _underflow;
         _underflow = false;
-        __unlockBluetooth();
         return ret;
     }
 

--- a/libraries/BluetoothAudio/src/BluetoothAudio.h
+++ b/libraries/BluetoothAudio/src/BluetoothAudio.h
@@ -1,3 +1,4 @@
+#include "BluetoothLock.h"
 #include "BluetoothDevice.h"
 #include "BluetoothHCI.h"
 #include "BluetoothMediaConfigurationSBC.h"

--- a/libraries/BluetoothAudio/src/BluetoothLock.h
+++ b/libraries/BluetoothAudio/src/BluetoothLock.h
@@ -1,0 +1,33 @@
+/*
+    Bluetooth lock helper class
+
+    Copyright (c) 2024 Earle F. Philhower, III <earlephilhower@yahoo.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#pragma once
+
+#include <Arduino.h>
+
+class BluetoothLock {
+public:
+    BluetoothLock() {
+        __lockBluetooth();
+    }
+    ~BluetoothLock() {
+        __unlockBluetooth();
+    }
+};


### PR DESCRIPTION
Fixes #2188

We get a call to stop the audio channel from a timer/IRQ context, so can't safely remove the IRQ handler for the AudioBufferManager.  The SDK will panic.

Because the IRQ handler will be a noop if it's not uninstalled, we will instead just leave our shared handler in place and let it do nothing.

Use a common BluetoothLock RAII in BluetoothAudio to clen up the code and automatically lock BT for the AVRCP button methods.