### PR TITLE
Make LittleFS filenames support full size

### DIFF
--- a/libraries/LittleFS/src/LittleFS.h
+++ b/libraries/LittleFS/src/LittleFS.h
@@ -29,7 +29,7 @@
 #include <FS.h>
 #include <FSImpl.h>
 
-#define LFS_NAME_MAX 32
+#define LFS_NAME_MAX 255
 #include "../lib/littlefs/lfs.h"
 
 using namespace fs;

--- a/libraries/LittleFS/src/lfs.c
+++ b/libraries/LittleFS/src/lfs.c
@@ -2,7 +2,7 @@
 // Just have a stub here that redirects to the actual source file
 
 #pragma GCC diagnostic ignored "-Wmissing-field-initializers"
-#define LFS_NAME_MAX 32
+#define LFS_NAME_MAX 255
 #define LFS_NO_DEBUG
 #define LFS_NO_WARN
 #define LFS_NO_ERROR

--- a/libraries/LittleFS/src/lfs_util.c
+++ b/libraries/LittleFS/src/lfs_util.c
@@ -1,4 +1,4 @@
-#define LFS_NAME_MAX 32
+#define LFS_NAME_MAX 255
 #define LFS_NO_DEBUG
 #define LFS_NO_WARN
 #define LFS_NO_ERROR


### PR DESCRIPTION
Support 255 character names, not just 32, in LittleFS filesystems.