### PR TITLE
Fix PWMAudio::write(buffer, len)

### DIFF
--- a/libraries/PWMAudio/src/PWMAudio.cpp
+++ b/libraries/PWMAudio/src/PWMAudio.cpp
@@ -242,8 +242,8 @@ size_t PWMAudio::write(const uint8_t *buffer, size_t size) {
             return writtenSize;
         } else {
             p++;
-            size -= 4;
-            writtenSize += 4;
+            size -= 2;
+            writtenSize += 2;
         }
     }
     return writtenSize;


### PR DESCRIPTION
PWMAudio was only ever writing one half the buffer passed in because of an off-by-2 error.  Fixes the sine output in KeyboardPiano.