### PR TITLE
Use block writes for BT audio consumers

### DIFF
--- a/libraries/BluetoothAudio/src/BluetoothAudioConsumerI2S.cpp
+++ b/libraries/BluetoothAudio/src/BluetoothAudioConsumerI2S.cpp
@@ -75,10 +75,8 @@ void BluetoothAudioConsumerI2S::fill() {
         _a2dpSink->playback_handler((int16_t *) buff, 32);
         num_samples -= 64;
         for (int i = 0; i < 64; i++) {
-            int32_t tmp = buff[i];
-            tmp *= _gain;
-            tmp >>= 8;
-            _i2s->write((int16_t)tmp);
+            buff[i] = (((int32_t)buff[i]) * _gain) >> 8;
         }
+        _i2s->write((uint8_t *)buff, 64 * 2);
     }
 }

--- a/libraries/BluetoothAudio/src/BluetoothAudioConsumerPWM.cpp
+++ b/libraries/BluetoothAudio/src/BluetoothAudioConsumerPWM.cpp
@@ -76,10 +76,8 @@ void BluetoothAudioConsumerPWM::fill() {
         _a2dpSink->playback_handler((int16_t *) buff, 32);
         num_samples -= 64;
         for (int i = 0; i < 64; i++) {
-            int32_t tmp = buff[i];
-            tmp *= _gain;
-            tmp >>= 8;
-            _pwm->write((int16_t)tmp);
+            buff[i] = (((int32_t)buff[i]) * _gain) >> 8;
         }
+        _pwm->write((uint8_t *)buff, 64 * 2);
     }
 }


### PR DESCRIPTION
Around 2x the performance, and every bit is needed w/BT SBC compression and decompression.