### PR TITLE
Fix crash on SD.end() without initial SD.begin()

### DIFF
--- a/libraries/SD/src/SD.h
+++ b/libraries/SD/src/SD.h
@@ -43,8 +43,9 @@ public:
 
     void end(bool endSPI = true) {
         SDFS.end();
-        if (endSPI) {
+        if (endSPI && _spi) {
             _spi->end();
+            _spi = nullptr;
         }
     }
 
@@ -205,7 +206,7 @@ private:
         return time(nullptr);
     }
 
-    HardwareSPI *_spi;
+    HardwareSPI *_spi = nullptr;
 };
 
 


### PR DESCRIPTION
Fixes #2220