### PR TITLE
Avoid deadlock BT/LE HID send when disconnected

### DIFF
--- a/libraries/HID_Bluetooth/src/PicoBluetoothBLEHID.h
+++ b/libraries/HID_Bluetooth/src/PicoBluetoothBLEHID.h
@@ -178,11 +178,13 @@ public:
         while (connected() && _needToSend) {
             /* noop busy wait */
         }
-        _needToSend = true;
-        _sendReport = rpt;
-        _sendReportLen = len;
         __lockBluetooth();
-        hids_device_request_can_send_now_event(_con_handle);
+        if (connected()) {
+            _needToSend = true;
+            _sendReport = rpt;
+            _sendReportLen = len;
+            hids_device_request_can_send_now_event(_con_handle);
+        }
         __unlockBluetooth();
         while (connected() && _needToSend) {
             /* noop busy wait */

--- a/libraries/HID_Bluetooth/src/PicoBluetoothHID.h
+++ b/libraries/HID_Bluetooth/src/PicoBluetoothHID.h
@@ -142,12 +142,14 @@ public:
     }
 
     bool send(int id, void *rpt, int len) {
-        _needToSend = true;
-        _sendReportID = id;
-        _sendReport = rpt;
-        _sendReportLen = len;
         __lockBluetooth();
-        hid_device_request_can_send_now_event(getCID());
+        if (connected()) {
+            _needToSend = true;
+            _sendReportID = id;
+            _sendReport = rpt;
+            _sendReportLen = len;
+            hid_device_request_can_send_now_event(getCID());
+        }
         __unlockBluetooth();
         while (connected() && _needToSend) {
             /* noop busy wait */


### PR DESCRIPTION
Fixes #2251

The 2-phase send could get out of whack if transmission was attempted when no device was connected. Clear things up so if things aren't connected, then no data gets set as pending.