### PR TITLE
Fix includes for assembler files in PlatformIO build

### DIFF
--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -190,7 +190,10 @@ else:
         "-iprefix" + os.path.join(FRAMEWORK_DIR),
         "@%s" % os.path.join(FRAMEWORK_DIR, "lib", "platform_inc.txt")
     ])
-
+    env.Append(ASFLAGS=[
+        "-iprefix" + os.path.join(FRAMEWORK_DIR),
+        "@%s" % os.path.join(FRAMEWORK_DIR, "lib", "platform_inc.txt")
+    ])
 
 def configure_usb_flags(cpp_defines):
     if "USE_TINYUSB" in cpp_defines:


### PR DESCRIPTION
An oversight in the order of updating the ASFLAGS with a copy of the CCFLAGS (see line 110) and then updating the CCFLAGS (without resyncing the ASFLAGS) leads to a fatal compilation error in the [Adafruit PicoDVI](https://github.com/adafruit/PicoDVI) library, in which `tmds_encode.S` fails to find the `pico/config.h` include file. This fix updates the ASFLAGS manually after changing the CCFLAGS so that they're equal again, and the library can be compiled.

Failure reported in https://community.platformio.org/t/anybody-know-how-to-fix-this-this-is-an-error-for-the-picodvi-library-downloaded-from-platfrom/41607.

(This change only affects assembler files which access include files outside of the already added pico-sdk/src/rp2040/hardware_regs and pico-sdk/src/common/pico_binary_info folders.)