### PR TITLE
Fix leak in HTTPSClient

### DIFF
--- a/libraries/HTTPClient/src/HTTPClient.h
+++ b/libraries/HTTPClient/src/HTTPClient.h
@@ -179,7 +179,11 @@ typedef std::vector<Cookie> CookieJar;
 class HTTPClient {
 public:
     HTTPClient() = default;
-    ~HTTPClient() = default;
+    ~HTTPClient() {
+        if (_clientMade) {
+            delete _clientMade;
+        }
+    }
     HTTPClient(HTTPClient&&) = default;
     HTTPClient& operator=(HTTPClient&&) = default;
 

--- a/libraries/WiFi/src/WiFiClientSecureBearSSL.cpp
+++ b/libraries/WiFi/src/WiFiClientSecureBearSSL.cpp
@@ -123,6 +123,10 @@ WiFiClientSecureCtx::~WiFiClientSecureCtx() {
         _client->unref();
         _client = nullptr;
     }
+    if (_esp32_ta) {
+        delete _esp32_ta;
+    }
+
     _cipher_list = nullptr; // std::shared will free if last reference
     _freeSSL();
     stack_thunk_del_ref();


### PR DESCRIPTION
Fixes #2254

The faked certificate was allocated but not deleted in certain cases.  Make sure to clean up in the destructor.