### PR TITLE
Ensure makeboards.py writes UNIX newlines

### DIFF
--- a/tools/makeboards.py
+++ b/tools/makeboards.py
@@ -356,14 +356,14 @@ def MakeBoardJSON(name, vendor_name, product_name, vid, pid, pwr, boarddefine, f
 .replace('USBPWR', str(pwr))\
 .replace(' EXTRA_INFO', m_extra.rstrip())
     jsondir = os.path.abspath(os.path.dirname(__file__)) + "/json"
-    f = open(jsondir + "/" + name + ".json", "w")
+    f = open(jsondir + "/" + name + ".json", "w", newline='\n')
     f.write(json)
     f.close()
 
 pkgjson = json.load(open(os.path.abspath(os.path.dirname(__file__)) + '/../package/package_pico_index.template.json'))
 pkgjson['packages'][0]['platforms'][0]['boards'] = []
 
-sys.stdout = open(os.path.abspath(os.path.dirname(__file__)) + "/../boards.txt", "w")
+sys.stdout = open(os.path.abspath(os.path.dirname(__file__)) + "/../boards.txt", "w", newline='\n')
 WriteWarning()
 BuildGlobalMenuList()
 
@@ -530,5 +530,5 @@ MakeBoard("wiznet_5500_evb_pico", "WIZnet", "W5500-EVB-Pico", "0x2e8a", "0x1029"
 MakeBoard("generic", "Generic", "RP2040", "0x2e8a", "0xf00a", 250, "GENERIC_RP2040", 16, "boot2_generic_03h_4_padded_checksum")
 
 sys.stdout.close()
-with open(os.path.abspath(os.path.dirname(__file__)) + '/../package/package_pico_index.template.json', 'w') as f:
+with open(os.path.abspath(os.path.dirname(__file__)) + '/../package/package_pico_index.template.json', 'w', newline='\n') as f:
     f.write(json.dumps(pkgjson, indent=3))


### PR DESCRIPTION
The repo and development use only '\n' (UNIX) EOLs.  When a user runs makeboards on a Windows system they end up changing every line in boards.txt and the JSON files to Windows '\r\n' format.

Explicitly set the newline character when opening the output files to avoid this.