### PR TITLE
Add undervolting/overvolting according to CPU frequency

### DIFF
--- a/cores/rp2040/main.cpp
+++ b/cores/rp2040/main.cpp
@@ -22,6 +22,7 @@
 #include "RP2040USB.h"
 #include <pico/stdlib.h>
 #include <pico/multicore.h>
+#include <hardware/vreg.h>
 #include <reent.h>
 
 RP2040 rp2040;

--- a/cores/rp2040/main.cpp
+++ b/cores/rp2040/main.cpp
@@ -80,7 +80,36 @@ static struct _reent *_impure_ptr1 = nullptr;
 
 extern "C" int main() {
 #if F_CPU != 125000000
-    set_sys_clock_khz(F_CPU / 1000, true);
+
+    // Optimal core frequency (under and overvolting) based on
+    // https://forums.raspberrypi.com/viewtopic.php?p=1820686&sid=a1bc42fab114da743f958a5dbf160925#p1820686
+    uint32_t frequency_khz = F_CPU / 1000;
+    if (frequency_khz <= 120000) {
+        vreg_set_voltage(VREG_VOLTAGE_0_85);
+    } else if (frequency_khz <= 150000) {
+        vreg_set_voltage(VREG_VOLTAGE_0_90);
+    } else if (frequency_khz <= 180000) {
+        vreg_set_voltage(VREG_VOLTAGE_0_95);
+    } else if (frequency_khz <= 210000) {
+        vreg_set_voltage(VREG_VOLTAGE_1_00);
+    } else if (frequency_khz <= 240000) {
+        vreg_set_voltage(VREG_VOLTAGE_1_05);
+    } else if (frequency_khz <= 270000) {
+        vreg_set_voltage(VREG_VOLTAGE_1_10);
+    } else if (frequency_khz <= 300000) {
+        vreg_set_voltage(VREG_VOLTAGE_1_15);
+    } else if (frequency_khz <= 330000) {
+        vreg_set_voltage(VREG_VOLTAGE_1_20);
+    } else if (frequency_khz <= 360000) {
+        vreg_set_voltage(VREG_VOLTAGE_1_25);
+    } else if (frequency_khz <= 402000) {
+        vreg_set_voltage(VREG_VOLTAGE_1_30);
+    } else {
+        // If the frequency is out of the safe range, set to the highest safe voltage
+        vreg_set_voltage(VREG_VOLTAGE_1_30);
+    }
+    sleep_ms(1); // Allow time for voltage change
+    set_sys_clock_khz(frequency_khz, true); // Set the system clock frequency
 #endif
 
     // Let rest of core know if we're using FreeRTOS

--- a/tools/makeboards.py
+++ b/tools/makeboards.py
@@ -34,9 +34,10 @@ def BuildDebugLevel(name):
         print("%s.menu.dbglvl.%s.build.debug_level=%s" % (name, l[0], l[1]))
 
 def BuildFreq(name):
-    for f in [ 133,  50, 100, 120, 125, 128, 150, 175, 200, 225, 240, 250, 275, 300]:
+    for f in [ 133,  50, 100, 120, 125, 128, 150, 175, 200, 225, 240, 250, 275, 300, 402, 436]:
         warn = ""
         if f > 133: warn = " (Overclock)"
+        if f > 300: warn = " (Experimental, not all chips supported.)"
         print("%s.menu.freq.%s=%s MHz%s" % (name, f, f, warn))
         print("%s.menu.freq.%s.build.f_cpu=%dL" % (name, f, f * 1000000))
 


### PR DESCRIPTION
This adds adjustment of the core voltage according to the results from
https://forums.raspberrypi.com/viewtopic.php?p=1820686&sid=a1bc42fab114da743f958a5dbf160925#p1820686

This way the CPU cores will run at the VCORE for the corresponding frequencies.
This allows for operation above 400MHz.