### PR TITLE
Add true 10- and 16-bit joystick modes

### DIFF
--- a/cores/rp2040/RP2040USB.cpp
+++ b/cores/rp2040/RP2040USB.cpp
@@ -155,11 +155,52 @@ static uint8_t *GetDescHIDReport(int *len) {
     return __hid_report;
 }
 
+#define TUD_HID_REPORT_DESC_GAMEPAD16(...) \
+  HID_USAGE_PAGE ( HID_USAGE_PAGE_DESKTOP     )                 ,\
+  HID_USAGE      ( HID_USAGE_DESKTOP_GAMEPAD  )                 ,\
+  HID_COLLECTION ( HID_COLLECTION_APPLICATION )                 ,\
+    /* Report ID if any */\
+    __VA_ARGS__ \
+    /* 16 bit X, Y, Z, Rz, Rx, Ry (min -32767, max 32767 ) */ \
+    HID_USAGE_PAGE     ( HID_USAGE_PAGE_DESKTOP                 ) ,\
+    HID_USAGE          ( HID_USAGE_DESKTOP_X                    ) ,\
+    HID_USAGE          ( HID_USAGE_DESKTOP_Y                    ) ,\
+    HID_USAGE          ( HID_USAGE_DESKTOP_Z                    ) ,\
+    HID_USAGE          ( HID_USAGE_DESKTOP_RZ                   ) ,\
+    HID_USAGE          ( HID_USAGE_DESKTOP_RX                   ) ,\
+    HID_USAGE          ( HID_USAGE_DESKTOP_RY                   ) ,\
+    HID_LOGICAL_MIN_N  ( -32767, 2                              ) ,\
+    HID_LOGICAL_MAX_N  ( 32767, 2                               ) ,\
+    HID_REPORT_COUNT   ( 6                                      ) ,\
+    HID_REPORT_SIZE    ( 16                                     ) ,\
+    HID_INPUT          ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
+    /* 8 bit DPad/Hat Button Map  */ \
+    HID_USAGE_PAGE     ( HID_USAGE_PAGE_DESKTOP                 ) ,\
+    HID_USAGE          ( HID_USAGE_DESKTOP_HAT_SWITCH           ) ,\
+    HID_LOGICAL_MIN    ( 1                                      ) ,\
+    HID_LOGICAL_MAX    ( 8                                      ) ,\
+    HID_PHYSICAL_MIN   ( 0                                      ) ,\
+    HID_PHYSICAL_MAX_N ( 315, 2                                 ) ,\
+    HID_REPORT_COUNT   ( 1                                      ) ,\
+    HID_REPORT_SIZE    ( 8                                      ) ,\
+    HID_INPUT          ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
+    /* 32 bit Button Map */ \
+    HID_USAGE_PAGE     ( HID_USAGE_PAGE_BUTTON                  ) ,\
+    HID_USAGE_MIN      ( 1                                      ) ,\
+    HID_USAGE_MAX      ( 32                                     ) ,\
+    HID_LOGICAL_MIN    ( 0                                      ) ,\
+    HID_LOGICAL_MAX    ( 1                                      ) ,\
+    HID_REPORT_COUNT   ( 32                                     ) ,\
+    HID_REPORT_SIZE    ( 1                                      ) ,\
+    HID_INPUT          ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
+  HID_COLLECTION_END \
+
+
 void __SetupDescHIDReport() {
     //allocate memory for the HID report descriptors. We don't use them, but need the size here.
     uint8_t desc_hid_report_mouse[] = { TUD_HID_REPORT_DESC_MOUSE(HID_REPORT_ID(1)) };
     uint8_t desc_hid_report_absmouse[] = { TUD_HID_REPORT_DESC_ABSMOUSE(HID_REPORT_ID(1)) };
-    uint8_t desc_hid_report_joystick[] = { TUD_HID_REPORT_DESC_GAMEPAD(HID_REPORT_ID(1)) };
+    uint8_t desc_hid_report_joystick[] = { TUD_HID_REPORT_DESC_GAMEPAD16(HID_REPORT_ID(1)) };
     uint8_t desc_hid_report_keyboard[] = { TUD_HID_REPORT_DESC_KEYBOARD(HID_REPORT_ID(1)), TUD_HID_REPORT_DESC_CONSUMER(HID_REPORT_ID(2)) };
     int size = 0;
 
@@ -229,7 +270,7 @@ void __SetupDescHIDReport() {
                 reportid++;
                 offset += sizeof(desc_hid_report_absmouse);
             }
-            uint8_t desc_local[] = { TUD_HID_REPORT_DESC_GAMEPAD(HID_REPORT_ID(reportid)) };
+            uint8_t desc_local[] = { TUD_HID_REPORT_DESC_GAMEPAD16(HID_REPORT_ID(reportid)) };
             memcpy(__hid_report + offset, desc_local, sizeof(desc_local));
         }
     }

--- a/libraries/Joystick/docs/api.md
+++ b/libraries/Joystick/docs/api.md
@@ -156,8 +156,6 @@ Switch axis value range between 10bit and 8bit.
 * Default: 10bit, range for an axis from 0 to 1023
 * 8bit mode: range from -127 to 127.
 
-__Note:__ due to the gamepad descriptor of tinyUSB, the maximum range is -127/127. 10bit mode enables mapping, not a higher resolution.
-
 
 #### Syntax 
 
@@ -215,6 +213,11 @@ void loop() {
 * [Joystick.sliderLeft()](#joysticksliderleft)
 * [Joystick.sliderRight()](#joysticksliderright)
 
+
+### `Joystick.use10bit()`
+### `Joystick.use16bit()`
+
+Set axis value range to 10-bit (0...1024) or 16-bit (-32767...32767).
 
 ### `Joystick.useManualSend()`
 

--- a/libraries/Joystick/examples/Joystick-AllFunctions/Joystick-AllFunctions.ino
+++ b/libraries/Joystick/examples/Joystick-AllFunctions/Joystick-AllFunctions.ino
@@ -33,8 +33,8 @@ void loop() {
     }
     Joystick.useManualSend(false);
 
+    Joystick.use10bit();
     // Iterate all joystick axis
-    // Note: although you can use 0-1023 here (10bit), internally 8bits are used (-127 to 127)
     Serial.println("Joystick X");
     for (uint16_t i = 0; i < 1023; i++) {
       Joystick.X(i);
@@ -74,7 +74,7 @@ void loop() {
     // Use int8 mode for the axis.
     // Note: hat is not used differently.
     Serial.println("Now all axis in 8bit mode, -127 to 127");
-    Joystick.use8bit(true);
+    Joystick.use8bit();
     Serial.println("Joystick X");
     for (int16_t i = -127; i < 128; i++) {
       Joystick.X(i);
@@ -105,6 +105,6 @@ void loop() {
       Joystick.sliderRight(i);
       delay(2);
     } Joystick.sliderRight(0);
-    Joystick.use8bit(false);
+    Joystick.use10bit();
   }
 }

--- a/libraries/Joystick/examples/Joystick16Bit/Joystick16Bits.ino
+++ b/libraries/Joystick/examples/Joystick16Bit/Joystick16Bits.ino
@@ -1,0 +1,22 @@
+#include <Joystick.h>
+
+// Set 1KHz polling frequency (1000/second)
+int usb_hid_poll_interval = 1;
+
+void setup() {
+  Joystick.use16bit();
+  Joystick.begin();
+}
+
+void loop() {
+  static int16_t delta = 1;
+  static int16_t p = 0;
+  if (p == 32767) {
+    delta = -1;
+  } else if (p == -32767) {
+    delta = 1;
+  }
+  p += delta;
+  Joystick.X(p);
+  Joystick.Y(-p);
+}

--- a/libraries/JoystickBLE/src/JoystickBLE.cpp
+++ b/libraries/JoystickBLE/src/JoystickBLE.cpp
@@ -65,7 +65,7 @@ void JoystickBLE_::setBattery(int lvl) {
 
 void JoystickBLE_::send_now() {
     //insert report ID; not part of the hid_gamepad_report_t
-    uint8_t *report = (uint8_t *)malloc(sizeof(hid_gamepad_report_t) +1);
+    uint8_t *report = (uint8_t *)malloc(sizeof(hid_gamepad16_report_t) + 1);
     if (report) {
         report[0] = __BLEGetJoystickReportID();
         memcpy(&report[1], (uint8_t*)&data, sizeof(data));

--- a/libraries/KeyboardBLE/src/KeyboardBLE.cpp
+++ b/libraries/KeyboardBLE/src/KeyboardBLE.cpp
@@ -68,10 +68,10 @@ void KeyboardBLE_::sendReport(KeyReport* keys) {
     memcpy(data.keycode, keys->keys, sizeof(data.keycode));
 
     //stitch in report id
-    static uint8_t report[sizeof(hid_keyboard_report_t) +1];
+    static uint8_t report[sizeof(hid_keyboard_report_t) + 1];
     report[0] = __BLEGetKeyboardReportID();
     memcpy(&report[1], (uint8_t*)&data, sizeof(hid_keyboard_report_t));
-    PicoBluetoothBLEHID.send(&report, sizeof(hid_keyboard_report_t) +1);
+    PicoBluetoothBLEHID.send(&report, sizeof(hid_keyboard_report_t) + 1);
 }
 
 void KeyboardBLE_::sendConsumerReport(uint16_t key) {

--- a/libraries/MouseBLE/src/MouseBLE.cpp
+++ b/libraries/MouseBLE/src/MouseBLE.cpp
@@ -68,7 +68,7 @@ void MouseBLE_::setAbsolute(bool absolute) {
 }
 
 void MouseBLE_::move(int x, int y, signed char wheel) {
-    static uint8_t report[sizeof(hid_abs_mouse_report_t) +1];
+    static uint8_t report[sizeof(hid_abs_mouse_report_t) + 1];
 
     if (!_absolute) {
         hid_mouse_report_t data;


### PR DESCRIPTION
Fixes #2275

Adds `Joystick.use10bit` and `Joystick.use16bit` methods.  10-bit is unsigned from 0...1023 while 16-bit is signed -32767..32767. Defines a new HID descriptor to support the increased resolution.