### PR TITLE
Split variant build, combine spell + style checks

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,28 +13,21 @@ env:
 
 jobs:
 
-# Me no spell so good
-  code-spell:
-    name: Check spelling
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-      with:
-        submodules: true
-    - name: Run codespell
-      uses: codespell-project/actions-codespell@master
-      with:
-        skip: ./ArduinoCore-API,./libraries/ESP8266SdFat,./libraries/Adafruit_TinyUSB_Arduino,./libraries/LittleFS/lib,./tools/pyserial,./pico-sdk,./.github,./docs/i2s.rst,./cores/rp2040/api,./libraries/FreeRTOS,./tools/libbearssl/bearssl,./include,./libraries/WiFi/examples/BearSSL_Server,./ota/uzlib,./libraries/http-parser/lib,./libraries/WebServer/examples/HelloServerBearSSL/HelloServerBearSSL.ino,./libraries/HTTPUpdateServer/examples/SecureBearSSLUpdater/SecureBearSSLUpdater.ino,./.git,./libraries/FatFS/lib/fatfs,./libraries/FatFS/src/diskio.h,./libraries/FatFS/src/ff.cpp,./libraries/FatFS/src/ffconf.h,./libraries/FatFS/src/ffsystem.cpp,./libraries/FatFS/src/ff.h,./libraries/lwIP_WINC1500/src/driver,./libraries/lwIP_WINC1500/src/common,./libraries/lwIP_WINC1500/src/bus_wrapper,./libraries/lwIP_WINC1500/src/spi_flash
-        ignore_words_list: ser,dout,shiftIn,acount
-
-# Consistent style
+# Consistent style, spelling
   astyle:
-    name: Style, Boards, Package
+    name: Spelling, Style, Boards, Package
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
       with:
         submodules: false
+    - name: Run codespell
+      uses: codespell-project/actions-codespell@master
+      with:
+        skip: ./ArduinoCore-API,./libraries/ESP8266SdFat,./libraries/Adafruit_TinyUSB_Arduino,./libraries/LittleFS/lib,./tools/pyserial,./pico-sdk,./.github,./docs/i2s.rst,./cores/rp2040/api,./libraries/FreeRTOS,./tools/libbearssl/bearssl,./include,./libraries/WiFi/examples/BearSSL_Server,./ota/uzlib,./libraries/http-parser/lib,./libraries/WebServer/examples/HelloServerBearSSL/HelloServerBearSSL.ino,./libraries/HTTPUpdateServer/examples/SecureBearSSLUpdater/SecureBearSSLUpdater.ino,./.git,./libraries/FatFS/lib/fatfs,./libraries/FatFS/src/diskio.h,./libraries/FatFS/src/ff.cpp,./libraries/FatFS/src/ffconf.h,./libraries/FatFS/src/ffsystem.cpp,./libraries/FatFS/src/ff.h,./libraries/lwIP_WINC1500/src/driver,./libraries/lwIP_WINC1500/src/common,./libraries/lwIP_WINC1500/src/bus_wrapper,./libraries/lwIP_WINC1500/src/spi_flash
+        ignore_words_list: ser,dout,shiftIn,acount
+    - name: Get submodules for following tests
+      run: git submodule update --init
     - name: Check package references
       run: |
         ./tests/ci/pkgrefs_test.sh
@@ -226,8 +219,11 @@ jobs:
 
 # Build every variant using PIO for simplicity
   build-variants:
-    name: Build Every Variant
+    name: Build Every Variant ${{ matrix.chunk }}
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        chunk: [0, 1]
     steps:
     - uses: actions/checkout@v4
       with:
@@ -264,6 +260,11 @@ jobs:
         cp -f /home/runner/work/arduino-pico/arduino-pico/tools/json/*.json /home/runner/.platformio/platforms/raspberrypi/boards/.
     - name: Build Every Variant
       run: |
+        cnt=0
         for b in $(cut -f1 -d. /home/runner/work/arduino-pico/arduino-pico/boards.txt | sed 's/#.*//' | sed 's/^menu$//' | sort -u); do
-          pio ci --board=$b -O "platform_packages=framework-arduinopico@symlink:///home/runner/work/arduino-pico/arduino-pico" libraries/rp2040/examples/Bootsel/Bootsel.ino
+          cnt=$((cnt + 1))
+          rem=$((cnt % 2))
+          if [ $rem == ${{ matrix.chunk }} ]; then
+            pio ci --board=$b -O "platform_packages=framework-arduinopico@symlink:///home/runner/work/arduino-pico/arduino-pico" libraries/rp2040/examples/Bootsel/Bootsel.ino
+          fi
         done

--- a/tests/restyle.sh
+++ b/tests/restyle.sh
@@ -2,7 +2,7 @@
 
 for dir in ./cores/rp2040 ./libraries/EEPROM ./libraries/I2S ./libraries/SingleFileDrive \
            ./libraries/LittleFS/src ./libraries/LittleFS/examples ./libraries/PWMAudio \
-           ./libraries/rp2040 ./libraries/SD ./libraries/ESP8266SdFat ./libraries/ADCInput \
+           ./libraries/rp2040 ./libraries/SD ./libraries/ADCInput \
            ./libraries/Servo ./libraries/SPI ./libraries/Wire ./libraries/PDM \
            ./libraries/WiFi ./libraries/lwIP_Ethernet ./libraries/lwIP_CYW43 \
            ./libraries/FreeRTOS/src ./libraries/LEAmDNS ./libraries/MD5Builder \


### PR DESCRIPTION
Variant builds were taking longer than the actual individual CI jobs, so split it up.

Compile the spelling and style checks, they ran very fast and spent more time in checking out than in running.