### PR TITLE
Factor out cut-n-pasted GAMEPAD16 HID structures

### DIFF
--- a/cores/rp2040/sdkoverride/tusb_gamepad16.h
+++ b/cores/rp2040/sdkoverride/tusb_gamepad16.h
@@ -1,0 +1,75 @@
+/*
+    16-bit axis gamepad definition
+    Copyright (c) 2024 Earle F. Philhower, III <earlephilhower@yahoo.com>
+
+    This library is free software; you can redistribute it and/or
+    modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+    version 2.1 of the License, or (at your option) any later version.
+
+    This library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+    Lesser General Public License for more details.
+
+    You should have received a copy of the GNU Lesser General Public
+    License along with this library; if not, write to the Free Software
+    Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+*/
+
+#pragma once
+
+#include "tusb.h"
+#include "class/hid/hid_device.h"
+
+#define TUD_HID_REPORT_DESC_GAMEPAD16(...) \
+  HID_USAGE_PAGE ( HID_USAGE_PAGE_DESKTOP     )                 ,\
+  HID_USAGE      ( HID_USAGE_DESKTOP_GAMEPAD  )                 ,\
+  HID_COLLECTION ( HID_COLLECTION_APPLICATION )                 ,\
+    /* Report ID if any */\
+    __VA_ARGS__ \
+    /* 16 bit X, Y, Z, Rz, Rx, Ry (min -32767, max 32767 ) */ \
+    HID_USAGE_PAGE     ( HID_USAGE_PAGE_DESKTOP                 ) ,\
+    HID_USAGE          ( HID_USAGE_DESKTOP_X                    ) ,\
+    HID_USAGE          ( HID_USAGE_DESKTOP_Y                    ) ,\
+    HID_USAGE          ( HID_USAGE_DESKTOP_Z                    ) ,\
+    HID_USAGE          ( HID_USAGE_DESKTOP_RZ                   ) ,\
+    HID_USAGE          ( HID_USAGE_DESKTOP_RX                   ) ,\
+    HID_USAGE          ( HID_USAGE_DESKTOP_RY                   ) ,\
+    HID_LOGICAL_MIN_N  ( -32767, 2                              ) ,\
+    HID_LOGICAL_MAX_N  ( 32767, 2                               ) ,\
+    HID_REPORT_COUNT   ( 6                                      ) ,\
+    HID_REPORT_SIZE    ( 16                                     ) ,\
+    HID_INPUT          ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
+    /* 8 bit DPad/Hat Button Map  */ \
+    HID_USAGE_PAGE     ( HID_USAGE_PAGE_DESKTOP                 ) ,\
+    HID_USAGE          ( HID_USAGE_DESKTOP_HAT_SWITCH           ) ,\
+    HID_LOGICAL_MIN    ( 1                                      ) ,\
+    HID_LOGICAL_MAX    ( 8                                      ) ,\
+    HID_PHYSICAL_MIN   ( 0                                      ) ,\
+    HID_PHYSICAL_MAX_N ( 315, 2                                 ) ,\
+    HID_REPORT_COUNT   ( 1                                      ) ,\
+    HID_REPORT_SIZE    ( 8                                      ) ,\
+    HID_INPUT          ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
+    /* 32 bit Button Map */ \
+    HID_USAGE_PAGE     ( HID_USAGE_PAGE_BUTTON                  ) ,\
+    HID_USAGE_MIN      ( 1                                      ) ,\
+    HID_USAGE_MAX      ( 32                                     ) ,\
+    HID_LOGICAL_MIN    ( 0                                      ) ,\
+    HID_LOGICAL_MAX    ( 1                                      ) ,\
+    HID_REPORT_COUNT   ( 32                                     ) ,\
+    HID_REPORT_SIZE    ( 1                                      ) ,\
+    HID_INPUT          ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
+  HID_COLLECTION_END \
+
+// HID Gamepad Protocol Report.
+typedef struct TU_ATTR_PACKED {
+    int16_t x;         ///< Delta x  movement of left analog-stick
+    int16_t y;         ///< Delta y  movement of left analog-stick
+    int16_t z;         ///< Delta z  movement of right analog-joystick
+    int16_t rz;        ///< Delta Rz movement of right analog-joystick
+    int16_t rx;        ///< Delta Rx movement of analog left trigger
+    int16_t ry;        ///< Delta Ry movement of analog right trigger
+    uint8_t hat;       ///< Buttons mask for currently pressed buttons in the DPad/hat
+    uint32_t buttons;  ///< Buttons mask for currently pressed buttons
+} hid_gamepad16_report_t;

--- a/libraries/HID_Bluetooth/src/HID_Bluetooth.cpp
+++ b/libraries/HID_Bluetooth/src/HID_Bluetooth.cpp
@@ -1,46 +1,5 @@
 #include "HID_Bluetooth.h"
-
-#define TUD_HID_REPORT_DESC_GAMEPAD16(...) \
-  HID_USAGE_PAGE ( HID_USAGE_PAGE_DESKTOP     )                 ,\
-  HID_USAGE      ( HID_USAGE_DESKTOP_GAMEPAD  )                 ,\
-  HID_COLLECTION ( HID_COLLECTION_APPLICATION )                 ,\
-    /* Report ID if any */\
-    __VA_ARGS__ \
-    /* 16 bit X, Y, Z, Rz, Rx, Ry (min -32767, max 32767 ) */ \
-    HID_USAGE_PAGE     ( HID_USAGE_PAGE_DESKTOP                 ) ,\
-    HID_USAGE          ( HID_USAGE_DESKTOP_X                    ) ,\
-    HID_USAGE          ( HID_USAGE_DESKTOP_Y                    ) ,\
-    HID_USAGE          ( HID_USAGE_DESKTOP_Z                    ) ,\
-    HID_USAGE          ( HID_USAGE_DESKTOP_RZ                   ) ,\
-    HID_USAGE          ( HID_USAGE_DESKTOP_RX                   ) ,\
-    HID_USAGE          ( HID_USAGE_DESKTOP_RY                   ) ,\
-    HID_LOGICAL_MIN_N  ( -32767, 2                              ) ,\
-    HID_LOGICAL_MAX_N  ( 32767, 2                               ) ,\
-    HID_REPORT_COUNT   ( 6                                      ) ,\
-    HID_REPORT_SIZE    ( 16                                     ) ,\
-    HID_INPUT          ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
-    /* 8 bit DPad/Hat Button Map  */ \
-    HID_USAGE_PAGE     ( HID_USAGE_PAGE_DESKTOP                 ) ,\
-    HID_USAGE          ( HID_USAGE_DESKTOP_HAT_SWITCH           ) ,\
-    HID_LOGICAL_MIN    ( 1                                      ) ,\
-    HID_LOGICAL_MAX    ( 8                                      ) ,\
-    HID_PHYSICAL_MIN   ( 0                                      ) ,\
-    HID_PHYSICAL_MAX_N ( 315, 2                                 ) ,\
-    HID_REPORT_COUNT   ( 1                                      ) ,\
-    HID_REPORT_SIZE    ( 8                                      ) ,\
-    HID_INPUT          ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
-    /* 32 bit Button Map */ \
-    HID_USAGE_PAGE     ( HID_USAGE_PAGE_BUTTON                  ) ,\
-    HID_USAGE_MIN      ( 1                                      ) ,\
-    HID_USAGE_MAX      ( 32                                     ) ,\
-    HID_LOGICAL_MIN    ( 0                                      ) ,\
-    HID_LOGICAL_MAX    ( 1                                      ) ,\
-    HID_REPORT_COUNT   ( 32                                     ) ,\
-    HID_REPORT_SIZE    ( 1                                      ) ,\
-    HID_INPUT          ( HID_DATA | HID_VARIABLE | HID_ABSOLUTE ) ,\
-  HID_COLLECTION_END \
-
-
+#include <sdkoverride/tusb_gamepad16.h>
 
 //setup the report map.
 //more generic function to be used with BLE & BT Classis


### PR DESCRIPTION
Create a single spot with the gamepad16's HID report descriptor and report structure.  Avoids cut-n-pasted code.