### PR TITLE
Replace most remaining ESP_ debug macros

### DIFF
--- a/libraries/ArduinoOTA/src/ArduinoOTA.cpp
+++ b/libraries/ArduinoOTA/src/ArduinoOTA.cpp
@@ -22,23 +22,22 @@
 #include <functional>
 #include <WiFiUdp.h>
 #include "ArduinoOTA.h"
-#include "MD5Builder.h"
+#include <MD5Builder.h>
 #include <PicoOTA.h>
 #include <StreamString.h>
 
-#include "lwip/udp.h"
-#include "include/UdpContext.h"
+#include <lwip/udp.h>
+#include <include/UdpContext.h>
 
 #if !defined(NO_GLOBAL_INSTANCES) && !defined(NO_GLOBAL_MDNS)
 #include <LEAmDNS.h>
 #endif
 
-//#ifdef DEBUG_ESP_OTA
-//#ifdef DEBUG_ESP_PORT
-//#define OTA_DEBUG DEBUG_ESP_PORT
-//#endif
-//#endif
-#define OTA_DEBUG Serial
+#ifdef DEBUG_RP2040_CORE
+#ifdef DEBUG_RP2040_PORT
+#define OTA_DEBUG DEBUG_RP2040_PORT
+#endif
+#endif
 
 ArduinoOTAClass::ArduinoOTAClass() {
 }

--- a/libraries/DNSServer/src/DNSServer.cpp
+++ b/libraries/DNSServer/src/DNSServer.cpp
@@ -24,8 +24,8 @@
 #include <lwip/def.h>
 #include <Arduino.h>
 
-#ifdef DEBUG_ESP_PORT
-#define CONSOLE DEBUG_ESP_PORT
+#ifdef DEBUG_RP2040_PORT
+#define CONSOLE DEBUG_RP2040_PORT
 #else
 #define CONSOLE Serial
 #endif

--- a/libraries/HTTPUpdate/src/HTTPUpdate.h
+++ b/libraries/HTTPUpdate/src/HTTPUpdate.h
@@ -31,9 +31,9 @@
 #include <WiFiUdp.h>
 #include <HTTPClient.h>
 
-#ifdef DEBUG_ESP_HTTP_UPDATE
-#ifdef DEBUG_ESP_PORT
-#define DEBUG_HTTP_UPDATE(fmt, ...) DEBUG_ESP_PORT.printf_P( (PGM_P)PSTR(fmt), ## __VA_ARGS__ )
+#ifdef DEBUG_RP2040_CORE
+#ifdef DEBUG_RP2040_PORT
+#define DEBUG_HTTP_UPDATE(fmt, ...) DEBUG_RP2040_PORT.printf_P( (PGM_P)PSTR(fmt), ## __VA_ARGS__ )
 #endif
 #endif
 

--- a/libraries/SD/src/SD.h
+++ b/libraries/SD/src/SD.h
@@ -1,5 +1,5 @@
 /*
-    SD.h - A thin shim for Arduino ESP8266 Filesystems
+    SD.h - A thin shim for Arduino RP2040 Filesystems
     Copyright (c) 2019 Earle F. Philhower, III.  All rights reserved.
 
     This library is free software; you can redistribute it and/or
@@ -139,9 +139,9 @@ public:
 
     size_t size() {
         uint64_t sz = size64();
-#ifdef DEBUG_ESP_PORT
+#ifdef DEBUG_RP2040_PORT
         if (sz > std::numeric_limits<uint32_t>::max()) {
-            DEBUG_ESP_PORT.printf_P(PSTR("WARNING: SD card size overflow (%lld >= 4GB).  Please update source to use size64().\n"), (long long)sz);
+            DEBUG_RP2040_PORT.printf_P(PSTR("WARNING: SD card size overflow (%lld >= 4GB).  Please update source to use size64().\n"), (long long)sz);
         }
 #endif
         return (size_t)sz;

--- a/libraries/SDFS/src/SDFS.h
+++ b/libraries/SDFS/src/SDFS.h
@@ -115,10 +115,10 @@ public:
         info.pageSize      = i.pageSize;
         info.maxOpenFiles  = i.maxOpenFiles;
         info.maxPathLength = i.maxPathLength;
-#ifdef DEBUG_ESP_PORT
+#ifdef DEBUG_RP2040_PORT
         if (i.totalBytes > std::numeric_limits<uint32_t>::max()) {
             // This catches both total and used cases, since used must always be < total.
-            DEBUG_ESP_PORT.printf_P(PSTR("WARNING: SD card size overflow (%lld >= 4GB).  Please update source to use info64().\n"), (long long)i.totalBytes);
+            DEBUG_RP2040_PORT.printf_P(PSTR("WARNING: SD card size overflow (%lld >= 4GB).  Please update source to use info64().\n"), (long long)i.totalBytes);
         }
 #endif
         info.totalBytes    = (size_t)i.totalBytes;

--- a/libraries/WiFi/src/CertStoreBearSSL.cpp
+++ b/libraries/WiFi/src/CertStoreBearSSL.cpp
@@ -21,8 +21,8 @@
 #include <memory>
 
 
-#if defined(DEBUG_ESP_SSL) && defined(DEBUG_ESP_PORT)
-#define DEBUG_BSSL(fmt, ...)  DEBUG_ESP_PORT.printf_P((PGM_P)PSTR( "BSSL:" fmt), ## __VA_ARGS__)
+#if defined(DEBUG_RP2040_CORE) && defined(DEBUG_RP2040_PORT)
+#define DEBUG_BSSL(fmt, ...)  DEBUG_RP2040_PORT.printf_P((PGM_P)PSTR( "BSSL:" fmt), ## __VA_ARGS__)
 #else
 #define DEBUG_BSSL(...)
 #endif

--- a/libraries/WiFi/src/WiFiClientSecureBearSSL.cpp
+++ b/libraries/WiFi/src/WiFiClientSecureBearSSL.cpp
@@ -29,18 +29,14 @@
 #include "WiFiClientSecureBearSSL.h"
 #include "WiFiNTP.h"
 #include "StackThunk.h"
-#include "lwip/opt.h"
-#include "lwip/ip.h"
-#include "lwip/tcp.h"
-#include "lwip/inet.h"
-#include "lwip/netif.h"
+#include <lwip/opt.h>
+#include <lwip/ip.h>
+#include <lwip/tcp.h>
+#include <lwip/inet.h>
+#include <lwip/netif.h>
 #include <include/ClientContext.h>
-//#include "c_types.h"
-//#include <mmu_iram.h>
-//#include <umm_malloc/umm_malloc.h>
-//#include <umm_malloc/umm_heap_select.h>
-#if 1
-#if !CORE_MOCK
+
+#if !defined(CORE_MOCK)
 
 // The BearSSL thunks in use for now
 #define br_ssl_engine_recvapp_ack thunk_br_ssl_engine_recvapp_ack
@@ -53,10 +49,9 @@
 #define br_ssl_engine_sendrec_buf thunk_br_ssl_engine_sendrec_buf
 
 #endif
-#endif
 
-#if defined(DEBUG_ESP_SSL) && defined(DEBUG_ESP_PORT)
-#define DEBUG_BSSL(fmt, ...)  DEBUG_ESP_PORT.printf_P((PGM_P)PSTR( "BSSL:" fmt), ## __VA_ARGS__)
+#if defined(DEBUG_RP2040_CORE) && defined(DEBUG_RP2040_PORT)
+#define DEBUG_BSSL(fmt, ...)  DEBUG_RP2040_PORT.printf_P((PGM_P)PSTR( "BSSL:" fmt), ## __VA_ARGS__)
 #else
 #define DEBUG_BSSL(...)
 #endif
@@ -721,12 +716,12 @@ extern "C" {
         if (!xc->done_cert) {
             br_sha1_update(&xc->sha1_cert, buf, len);
             br_x509_decoder_push(&xc->ctx, (const void*)buf, len);
-#if defined(DEBUG_ESP_SSL) && defined(DEBUG_ESP_PORT)
+#if defined(DEBUG_RP2040_CORE) && defined(DEBUG_RP2040_PORT)
             DEBUG_BSSL("CERT: ");
             for (size_t i = 0; i < len; i++) {
-                DEBUG_ESP_PORT.printf_P(PSTR("%02x "), buf[i] & 0xff);
+                DEBUG_RP2040_PORT.printf_P(PSTR("%02x "), buf[i] & 0xff);
             }
-            DEBUG_ESP_PORT.printf_P(PSTR("\n"));
+            DEBUG_RP2040_PORT.printf_P(PSTR("\n"));
 #endif
         }
     }
@@ -750,7 +745,7 @@ extern "C" {
         char res[20];
         br_sha1_out(&xc->sha1_cert, res);
         if (xc->match_fingerprint && memcmp(res, xc->match_fingerprint, sizeof(res))) {
-#ifdef DEBUG_ESP_SSL
+#if defined(DEBUG_RP2040_CORE) && defined(DEBUG_RP2040_PORT)
             DEBUG_BSSL("insecure_end_chain: Received cert FP doesn't match\n");
             char buff[3 * sizeof(res) + 1]; // 3 chars per byte XX_, and null
             buff[0] = 0;
@@ -1143,7 +1138,7 @@ bool WiFiClientSecureCtx::_connectSSL(const char* hostName) {
         }
     }
 
-#ifdef DEBUG_ESP_SSL
+#if defined(DEBUG_RP2040_CORE) && defined(DEBUG_RP2040_PORT)
     // BearSSL will reject all connections unless an authentication option is set, warn in DEBUG builds
     if (!_use_insecure && !_use_fingerprint && !_use_self_signed && !_knownkey && !_certStore && !_ta) {
         DEBUG_BSSL("Connection *will* fail, no authentication method is setup\n");
@@ -1213,7 +1208,7 @@ bool WiFiClientSecureCtx::_connectSSL(const char* hostName) {
     }
 
     auto ret = _wait_for_handshake();
-#ifdef DEBUG_ESP_SSL
+#if defined(DEBUG_RP2040_CORE) && defined(DEBUG_RP2040_PORT)
     if (!ret) {
         char err[256];
         getLastSSLError(err, sizeof(err));

--- a/libraries/WiFi/src/include/UdpContext.h
+++ b/libraries/WiFi/src/include/UdpContext.h
@@ -171,7 +171,7 @@ public:
         _on_rx = handler;
     }
 
-#ifdef DEBUG_ESP_CORE
+#ifdef DEBUG_RP2040_CORE
     // this helper is ready to be used when debugging UDP
     void printChain(const pbuf* pb, const char* msg, size_t n) const {
         // printf the pb pbuf chain, buffered and all at once

--- a/libraries/lwIP_Ethernet/src/LwipIntfCB.cpp
+++ b/libraries/lwIP_Ethernet/src/LwipIntfCB.cpp
@@ -39,7 +39,7 @@ extern "C" void netif_status_changed(struct netif* netif) {
 
 bool LwipIntf::stateChangeSysCB(LwipIntf::CBType&& cb) {
     if (netifStatusChangeListLength >= NETIF_STATUS_CB_SIZE) {
-#if defined(DEBUG_ESP_CORE)
+#if defined(DEBUG_RP2040_CORE)
         DEBUGV("NETIF_STATUS_CB_SIZE is too low\n");
 #endif
         return false;


### PR DESCRIPTION
In ported libraries there were still some remaining DEBUG_ESP_PORT references.  Moved to their RP2040 equivalents.