### PR TITLE
Fix minor LWIP wrapper errors

### DIFF
--- a/cores/rp2040/lwip_wrap.cpp
+++ b/cores/rp2040/lwip_wrap.cpp
@@ -247,19 +247,19 @@ extern "C" {
     extern void __real_tcp_setprio(struct tcp_pcb *pcb, u8_t prio);
     void __wrap_tcp_setprio(struct tcp_pcb *pcb, u8_t prio) {
         LWIPMutex m;
-        return __real_tcp_setprio(pcb, prio);
+        __real_tcp_setprio(pcb, prio);
     }
 
     extern void __real_tcp_backlog_delayed(struct tcp_pcb* pcb);
     void __wrap_tcp_backlog_delayed(struct tcp_pcb* pcb) {
         LWIPMutex m;
-        return __real_tcp_backlog_delayed(pcb);
+        __real_tcp_backlog_delayed(pcb);
     }
 
     extern void __real_tcp_backlog_accepted(struct tcp_pcb* pcb);
     void __wrap_tcp_backlog_accepted(struct tcp_pcb* pcb) {
         LWIPMutex m;
-        return __real_tcp_backlog_accepted(pcb);
+        __real_tcp_backlog_accepted(pcb);
     }
     extern struct udp_pcb *__real_udp_new(void);
     struct udp_pcb *__wrap_udp_new(void) {

--- a/lib/platform_wrap.txt
+++ b/lib/platform_wrap.txt
@@ -166,6 +166,7 @@
 
 -Wl,--wrap=tcp_arg
 -Wl,--wrap=tcp_new
+-Wl,--wrap=tcp_bind
 -Wl,--wrap=tcp_listen
 -Wl,--wrap=tcp_listen_with_backlog
 -Wl,--wrap=tcp_accept


### PR DESCRIPTION
Somehow returning the results of a `void` function from another `void` wrapper didn't trigger any warnings.  Also missed tcp_bind actual GCC wrapping.