### PR TITLE
Add checks for Adafruit TinyUSB to USB libs

### DIFF
--- a/libraries/FatFSUSB/src/FatFSUSB.h
+++ b/libraries/FatFSUSB/src/FatFSUSB.h
@@ -19,6 +19,10 @@
 
 #pragma once
 
+#ifdef USE_TINYUSB
+#error FatFSUSB is not compatible with Adafruit TinyUSB
+#endif
+
 #include <Arduino.h>
 
 class FatFSUSBClass {

--- a/libraries/Joystick/src/Joystick.h
+++ b/libraries/Joystick/src/Joystick.h
@@ -18,11 +18,14 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#ifndef _JOYSTICK_h
-#define _JOYSTICK_h
+#pragma once
+
+#ifdef USE_TINYUSB
+#error Joystick is not compatible with Adafruit TinyUSB
+#endif
 
 #include <HID_Joystick.h>
-#include "class/hid/hid.h"
+#include <class/hid/hid.h>
 
 //======================================================================
 class Joystick_ : public HID_Joystick {
@@ -31,5 +34,3 @@ public:
     virtual void send_now(void) override;
 };
 extern Joystick_ Joystick;
-
-#endif /* _JOYSTICK_h */

--- a/libraries/Keyboard/src/Keyboard.h
+++ b/libraries/Keyboard/src/Keyboard.h
@@ -20,8 +20,11 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#ifndef KEYBOARD_h
-#define KEYBOARD_h
+#pragma once
+
+#ifdef USE_TINYUSB
+#error Keyboard is not compatible with Adafruit TinyUSB
+#endif
 
 #include <HID_Keyboard.h>
 
@@ -34,5 +37,3 @@ public:
     Keyboard_(void);
 };
 extern Keyboard_ Keyboard;
-
-#endif

--- a/libraries/Mouse/src/Mouse.h
+++ b/libraries/Mouse/src/Mouse.h
@@ -19,8 +19,11 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#ifndef MOUSE_h
-#define MOUSE_h
+#pragma once
+
+#ifdef USE_TINYUSB
+#error Mouse is not compatible with Adafruit TinyUSB
+#endif
 
 #include <HID_Mouse.h>
 
@@ -30,5 +33,3 @@ public:
     virtual void move(int x, int y, signed char wheel = 0) override;
 };
 extern Mouse_ Mouse;
-
-#endif

--- a/libraries/MouseAbsolute/src/MouseAbsolute.h
+++ b/libraries/MouseAbsolute/src/MouseAbsolute.h
@@ -1,5 +1,5 @@
 /*
-    Mouse.h
+    MouseAbsolute.h
 
     Copyright (c) 2015, Arduino LLC
     Original code (pre-library): Copyright (c) 2011, Peter Barrett
@@ -19,8 +19,11 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#ifndef MOUSEABSOLUTE_h
-#define MOUSEABSOLUTE_h
+#pragma once
+
+#ifdef USE_TINYUSB
+#error MouseAbsolute is not compatible with Adafruit TinyUSB
+#endif
 
 #include <HID_Mouse.h>
 
@@ -30,5 +33,3 @@ public:
     virtual void move(int x, int y, signed char wheel = 0) override;
 };
 extern MouseAbsolute_ MouseAbsolute;
-
-#endif

--- a/libraries/SingleFileDrive/src/SingleFileDrive.h
+++ b/libraries/SingleFileDrive/src/SingleFileDrive.h
@@ -19,6 +19,10 @@
 
 #pragma once
 
+#ifdef USE_TINYUSB
+#error SingleFileDrive is not compatible with Adafruit TinyUSB
+#endif
+
 #include <Arduino.h>
 
 class SingleFileDrive {


### PR DESCRIPTION
The included USB libraries are not compatible with Adafruit TinyUSB, so add a #error message when they're built with the define set.