### PR TITLE
Add RP2040.memcpyDMA for DMA-managed memory copies

### DIFF
--- a/docs/rp2040.rst
+++ b/docs/rp2040.rst
@@ -99,3 +99,13 @@ bootloader.
 void rp2040.rebootToBootloader()
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Will reboot the RP2040 into USB UF2 upload mode.
+
+DMA-based MEMCPY
+----------------
+The onboard DMA engines can copy 4-byte aligned quantities faster than the CPU.
+
+void \*rp2040.memcpyDMA(void \*dest, const void \*src, size_t count);
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Uses a DMA engine to transfer data from src to dest in 4-byte chunks without CPU
+intervention.  If any arguments are not 4-byte aligned, or if the count is not a
+multiple of 4, then it will fall back to CPU-managed memcpy.

--- a/libraries/rp2040/examples/DMAMemcpy/DMAMemcpy.ino
+++ b/libraries/rp2040/examples/DMAMemcpy/DMAMemcpy.ino
@@ -1,0 +1,51 @@
+// Simple speed and functionality test for DMA memcpy
+// Released to the public domain by Earle F. Philhower, III, 2024
+
+
+uint32_t src[1024];
+uint32_t dest[1024];
+
+void setup() {
+  // Set up a simple test pattern in src, verify after each pass
+  srand(0xc0de);
+  for (int i = 0; i < 1024; i++) {
+    src[i] = ((~i) & 1024) | ((i) << 22);
+  }
+}
+
+void verify(const char *name, uint32_t *src) {
+  for (int i = 0; i < 1024; i++) {
+    uint32_t expected = ((~i) & 1024) | ((i) << 22);
+    if (expected != src[i]) {
+      Serial.printf("ERROR, mismatch @ %d on %s memcpy\n", i, name);
+      while (true) {
+        // Idle forever, this is fatal!
+      }
+    }
+  }
+}
+
+void loop() {
+  uint64_t start, stop;
+
+  start = rp2040.getCycleCount();
+  for (int i = 0; i < 1000; i++) {
+    memcpy(dest, src, 4 * 1024);
+    memcpy(src, dest, 4 * 1024);
+  }
+  stop = rp2040.getCycleCount();
+  verify("CPU", src);
+  verify("CPU", dest);
+  Serial.printf("CPU: %lld clock cycles for 4K\n", (stop - start) / 1000);
+
+  start = rp2040.getCycleCount();
+  for (int i = 0; i < 1000; i++) {
+    rp2040.memcpyDMA(dest, src, 4 * 1024);
+    rp2040.memcpyDMA(src, dest, 4 * 1024);
+  }
+  stop = rp2040.getCycleCount();
+  verify("DMA", src);
+  verify("DMA", dest);
+  Serial.printf("DMA: %lld clock cycles for 4K\n\n\n", (stop - start) / 1000);
+  delay(1000);
+}


### PR DESCRIPTION
RP2040::memcpyDMA implements a DMA-controlled memory copy call identical in function to standard memcpy, but using an onboard DMA engine.  For large memory transfers this can be significantly faster than using the CPU-based memcpy.  Only 4-byte aligned source, destination, and counts are allowed. If any inputs are not 4-byte aligned, then standard memcpy will occur so it will behave correctly for any inputs.