### PR TITLE
BREAKING: Remove FS::info64, make FS::info 64-bit

### DIFF
--- a/cores/rp2040/FS.cpp
+++ b/cores/rp2040/FS.cpp
@@ -366,13 +366,6 @@ bool FS::info(FSInfo& info) {
     return _impl->info(info);
 }
 
-bool FS::info64(FSInfo64& info) {
-    if (!_impl) {
-        return false;
-    }
-    return _impl->info64(info);
-}
-
 File FS::open(const String& path, const char* mode) {
     return open(path.c_str(), mode);
 }

--- a/cores/rp2040/FS.h
+++ b/cores/rp2040/FS.h
@@ -152,18 +152,8 @@ protected:
     time_t (*_timeCallback)(void) = nullptr;
 };
 
-// Backwards compatible, <4GB filesystem usage
-struct FSInfo {
-    size_t totalBytes;
-    size_t usedBytes;
-    size_t blockSize;
-    size_t pageSize;
-    size_t maxOpenFiles;
-    size_t maxPathLength;
-};
-
 // Support > 4GB filesystems (SD, etc.)
-struct FSInfo64 {
+struct FSInfo {
     uint64_t totalBytes;
     uint64_t usedBytes;
     size_t blockSize;
@@ -171,7 +161,6 @@ struct FSInfo64 {
     size_t maxOpenFiles;
     size_t maxPathLength;
 };
-
 
 class FSConfig {
 public:
@@ -201,7 +190,6 @@ public:
 
     bool format();
     bool info(FSInfo& info);
-    bool info64(FSInfo64& info);
 
     File open(const char* path, const char* mode);
     File open(const String& path, const char* mode);

--- a/cores/rp2040/FSImpl.h
+++ b/cores/rp2040/FSImpl.h
@@ -119,7 +119,6 @@ public:
     virtual void end() = 0;
     virtual bool format() = 0;
     virtual bool info(FSInfo& info) = 0;
-    virtual bool info64(FSInfo64& info) = 0;
     virtual FileImplPtr open(const char* path, OpenMode openMode, AccessMode accessMode) = 0;
     virtual bool exists(const char* path) = 0;
     virtual DirImplPtr openDir(const char* path) = 0;

--- a/libraries/FatFS/src/FatFS.h
+++ b/libraries/FatFS/src/FatFS.h
@@ -88,7 +88,7 @@ public:
         return _mounted ? (FR_OK == f_rename(pathFrom, pathTo)) : false;
     }
 
-    bool info64(FSInfo64& info) override {
+    bool info(FSInfo& info) override {
         if (!_mounted) {
             DEBUGV("FatFS::info: FS not mounted\n");
             return false;
@@ -102,20 +102,6 @@ public:
         info.maxPathLength = 255; // TODO ?
         info.totalBytes = (uint64_t)(fs->n_fatent - 2) * (uint64_t)fs->csize * 512;
         info.usedBytes = info.totalBytes - (uint64_t)fre_clust * fs->csize * 512;
-        return true;
-    }
-
-    bool info(FSInfo& info) override {
-        FSInfo64 i;
-        if (!info64(i)) {
-            return false;
-        }
-        info.blockSize     = i.blockSize;
-        info.pageSize      = i.pageSize;
-        info.maxOpenFiles  = i.maxOpenFiles;
-        info.maxPathLength = i.maxPathLength;
-        info.totalBytes    = (size_t)i.totalBytes;
-        info.usedBytes     = (size_t)i.usedBytes;
         return true;
     }
 

--- a/libraries/HTTPUpdateServer/src/HTTPUpdateServer-impl.h
+++ b/libraries/HTTPUpdateServer/src/HTTPUpdateServer-impl.h
@@ -139,9 +139,9 @@ void HTTPUpdateServerTemplate<ServerType, ServerPort>::setup(WebServerTemplate<S
                     }
                 }
             } else {
-                FSInfo64 i;
+                FSInfo i;
                 LittleFS.begin();
-                LittleFS.info64(i);
+                LittleFS.info(i);
                 uint32_t maxSketchSpace = i.totalBytes - i.usedBytes;
                 if (!Update.begin(maxSketchSpace, U_FLASH)) { //start with max available size
                     _setUpdaterError();

--- a/libraries/LittleFS/src/LittleFS.h
+++ b/libraries/LittleFS/src/LittleFS.h
@@ -115,20 +115,6 @@ public:
         return true;
     }
 
-    virtual bool info64(FSInfo64& info64) {
-        FSInfo i;
-        if (!info(i)) {
-            return false;
-        }
-        info64.blockSize     = i.blockSize;
-        info64.pageSize      = i.pageSize;
-        info64.maxOpenFiles  = i.maxOpenFiles;
-        info64.maxPathLength = i.maxPathLength;
-        info64.totalBytes    = i.totalBytes;
-        info64.usedBytes     = i.usedBytes;
-        return true;
-    }
-
     bool remove(const char* path) override {
         if (!_mounted || !path || !path[0]) {
             return false;

--- a/libraries/SDFS/src/SDFS.h
+++ b/libraries/SDFS/src/SDFS.h
@@ -92,7 +92,7 @@ public:
         return _mounted ? _fs.rename(pathFrom, pathTo) : false;
     }
 
-    bool info64(FSInfo64& info) override {
+    bool info(FSInfo& info) override {
         if (!_mounted) {
             DEBUGV("SDFS::info: FS not mounted\n");
             return false;
@@ -103,26 +103,6 @@ public:
         info.maxPathLength = 255; // TODO ?
         info.totalBytes = (uint64_t)_fs.vol()->clusterCount() * (uint64_t)info.blockSize;
         info.usedBytes = info.totalBytes - ((uint64_t)_fs.vol()->freeClusterCount() * (uint64_t)_fs.vol()->bytesPerCluster());
-        return true;
-    }
-
-    bool info(FSInfo& info) override {
-        FSInfo64 i;
-        if (!info64(i)) {
-            return false;
-        }
-        info.blockSize     = i.blockSize;
-        info.pageSize      = i.pageSize;
-        info.maxOpenFiles  = i.maxOpenFiles;
-        info.maxPathLength = i.maxPathLength;
-#ifdef DEBUG_RP2040_PORT
-        if (i.totalBytes > std::numeric_limits<uint32_t>::max()) {
-            // This catches both total and used cases, since used must always be < total.
-            DEBUG_RP2040_PORT.printf_P(PSTR("WARNING: SD card size overflow (%lld >= 4GB).  Please update source to use info64().\n"), (long long)i.totalBytes);
-        }
-#endif
-        info.totalBytes    = (size_t)i.totalBytes;
-        info.usedBytes     = (size_t)i.usedBytes;
         return true;
     }
 

--- a/libraries/WebServer/examples/FSBrowser/FSBrowser.ino
+++ b/libraries/WebServer/examples/FSBrowser/FSBrowser.ino
@@ -154,9 +154,12 @@ void handleStatus() {
   if (fsOK) {
     fileSystem->info(fs_info);
     json += F("\"true\", \"totalBytes\":\"");
-    json += fs_info.totalBytes;
+    char b64[32];
+    sprintf(b64, "%llu", fs_info.totalBytes);
+    json += b64;
     json += F("\", \"usedBytes\":\"");
-    json += fs_info.usedBytes;
+    sprintf(b64, "%llu", fs_info.usedBytes);
+    json += b64;
     json += "\"";
   } else {
     json += "\"false\"";

--- a/libraries/WebServer/examples/WebUpdate/WebUpdate.ino
+++ b/libraries/WebServer/examples/WebUpdate/WebUpdate.ino
@@ -43,9 +43,9 @@ void setup(void) {
       if (upload.status == UPLOAD_FILE_START) {
         WiFiUDP::stopAll();
         Serial.printf("Update: %s\n", upload.filename.c_str());
-        FSInfo64 i;
+        FSInfo i;
         LittleFS.begin();
-        LittleFS.info64(i);
+        LittleFS.info(i);
         uint32_t maxSketchSpace = i.totalBytes - i.usedBytes;
         if (!Update.begin(maxSketchSpace)) {  // start with max available size
           Update.printError(Serial);


### PR DESCRIPTION
Removed FS::info64, and updates FS::info with the 64-bit version since in 2024 it's almost impossible to get a SD card smaller than 4GB.

Most code can simply replace info64 with info and continue operation, if they were updated to be 64-bit in the first place.