### PR TITLE
W6100 implementation based on W5500 driver

### DIFF
--- a/libraries/lwIP_w6100/src/W6100lwIP.h
+++ b/libraries/lwIP_w6100/src/W6100lwIP.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <LwipIntfDev.h>
+#include <utility/w6100.h>
+#include <LwipEthernet.h>
+#include <WiFi.h>
+
+using Wiznet6100lwIP = LwipIntfDev<Wiznet6100>;

--- a/libraries/lwIP_w6100/src/utility/w6100.cpp
+++ b/libraries/lwIP_w6100/src/utility/w6100.cpp
@@ -192,7 +192,7 @@ void Wiznet6100::wizchip_recv_ignore(uint16_t len) {
 }
 
 bool Wiznet6100::wizchip_sw_reset() {
-    setChipLOCK(W6100_CHPLCKR_UNLOCK);
+    setChipLOCK(CHPLCKR_UNLOCK);
     uint16_t count = 0;
     do
     { // Wait Unlock Complete
@@ -200,7 +200,7 @@ bool Wiznet6100::wizchip_sw_reset() {
         {             // Check retry count
             return false; // Over Limit retry count
         }
-    } while ((getStatus() & W6100_SYSR_CHPL_LOCK) ^ W6100_SYSR_CHPL_ULOCK); // Exit Wait Unlock Complete
+    } while ((getStatus() & SYSR_CHPL_LOCK) ^ SYSR_CHPL_ULOCK); // Exit Wait Unlock Complete
 
     setCommand0(0x0); // Software Reset
 
@@ -211,7 +211,7 @@ bool Wiznet6100::wizchip_sw_reset() {
             return false; // Over Limit retry count
         }
 
-    } while ((getStatus() & W6100_SYSR_CHPL_LOCK) ^ W6100_SYSR_CHPL_LOCK); // Exit Wait Lock Complete
+    } while ((getStatus() & SYSR_CHPL_LOCK) ^ SYSR_CHPL_LOCK); // Exit Wait Lock Complete
 
     return true;
 }
@@ -286,9 +286,9 @@ bool Wiznet6100::begin(const uint8_t* mac_address, netif *net) {
     wizchip_sw_reset();
 
     // Unlock
-    setChipLOCK(W6100_CHPLCKR_UNLOCK);
-    setNetLOCK(W6100_NETLCKR_UNLOCK);
-    setPHYLOCK(W6100_PHYLCKR_UNLOCK);
+    setChipLOCK(CHPLCKR_UNLOCK);
+    setNetLOCK(NETLCKR_UNLOCK);
+    setPHYLOCK(PHYLCKR_UNLOCK);
 
     // W6100 CIDR0
     // Version 97(dec) 0x61(hex)
@@ -324,16 +324,16 @@ bool Wiznet6100::begin(const uint8_t* mac_address, netif *net) {
         
 
         // Configure socket 0 interrupts
-        setSn_IMR(W6100_Sn_IMR_RECV); // we're not interested in W6100_Sn_IMR_SENDOK atm
+        setSn_IMR(Sn_IMR_RECV); // we're not interested in Sn_IMR_SENDOK atm
 
         // Enable socket 0 interrupts
-        setSIMR(W6100_SIMR_S0_INT);
+        setSIMR(SIMR_S0_INT);
 
         // Disable unused interrupts
         setIMR(0);
 
         // Enable interrupt pin
-        setCommand1(W6100_SYCR1_IEN);
+        setCommand1(SYCR1_IEN);
         
     }
 
@@ -390,7 +390,7 @@ uint16_t Wiznet6100::readFrameSize() {
     data_len -= 2;
 
     // Clear interrupt flags
-    setICLR(W6100_Sn_IRCLR_RECV);
+    setICLR(Sn_IRCLR_RECV);
 
     return data_len;
 }

--- a/libraries/lwIP_w6100/src/utility/w6100.cpp
+++ b/libraries/lwIP_w6100/src/utility/w6100.cpp
@@ -1,0 +1,445 @@
+/*
+    Copyright (c) 2013, WIZnet Co., Ltd.
+    Copyright (c) 2016, Nicholas Humfrey
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+    1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+    HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+    STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+    OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+// original sources: https://github.com/njh/W5500MacRaw
+
+#include <SPI.h>
+#include "w6100.h"
+#include <LwipEthernet.h>
+
+/**
+    Check physical link
+    @return true when physical link is up
+*/
+bool Wiznet6100::isLinked()
+{
+    ethernet_arch_lwip_gpio_mask();
+    ethernet_arch_lwip_begin();
+    auto ret = wizphy_getphylink() == PHY_LINK_ON;
+    ethernet_arch_lwip_end();
+    ethernet_arch_lwip_gpio_unmask();
+    return ret;
+}
+
+
+uint8_t Wiznet6100::wizchip_read(uint8_t block, uint16_t address) {
+    uint8_t ret;
+
+    wizchip_cs_select();
+
+    block |= AccessModeRead;
+
+    wizchip_spi_write_byte((address & 0xFF00) >> 8);
+    wizchip_spi_write_byte((address & 0x00FF) >> 0);
+    wizchip_spi_write_byte(block);
+
+    ret = wizchip_spi_read_byte();
+
+    wizchip_cs_deselect();
+    return ret;
+}
+
+uint16_t Wiznet6100::wizchip_read_word(uint8_t block, uint16_t address) {
+    return ((uint16_t)wizchip_read(block, address) << 8) + wizchip_read(block, address + 1);
+}
+
+void Wiznet6100::wizchip_read_buf(uint8_t block, uint16_t address, uint8_t* pBuf, uint16_t len) {
+    uint16_t i;
+
+    wizchip_cs_select();
+
+    block |= AccessModeRead;
+
+    wizchip_spi_write_byte((address & 0xFF00) >> 8);
+    wizchip_spi_write_byte((address & 0x00FF) >> 0);
+    wizchip_spi_write_byte(block);
+    for (i = 0; i < len; i++) {
+        pBuf[i] = wizchip_spi_read_byte();
+    }
+
+    wizchip_cs_deselect();
+}
+
+void Wiznet6100::wizchip_write(uint8_t block, uint16_t address, uint8_t wb) {
+    wizchip_cs_select();
+
+    block |= AccessModeWrite | FixedDataMode1;
+
+    wizchip_spi_write_byte((address & 0xFF00) >> 8);
+    wizchip_spi_write_byte((address & 0x00FF) >> 0);
+    wizchip_spi_write_byte(block);
+    wizchip_spi_write_byte(wb);
+
+    wizchip_cs_deselect();
+}
+
+void Wiznet6100::wizchip_write_word(uint8_t block, uint16_t address, uint16_t word) {
+    wizchip_write(block, address, (uint8_t)(word >> 8));
+    wizchip_write(block, address + 1, (uint8_t)word);
+}
+
+void Wiznet6100::wizchip_write_buf(uint8_t block, uint16_t address, const uint8_t* pBuf,
+                                   uint16_t len) {
+    uint16_t i;
+
+    wizchip_cs_select();
+
+    block |= AccessModeWrite;
+
+    wizchip_spi_write_byte((address & 0xFF00) >> 8);
+    wizchip_spi_write_byte((address & 0x00FF) >> 0);
+    wizchip_spi_write_byte(block);
+    for (i = 0; i < len; i++) {
+        wizchip_spi_write_byte(pBuf[i]);
+    }
+
+    wizchip_cs_deselect();
+}
+
+void Wiznet6100::setSn_CR(uint8_t cr) {
+    // Write the command to the Command Register
+    wizchip_write(BlockSelectSReg, Sn_CR, cr);
+
+    // Now wait for the command to complete
+    while (wizchip_read(BlockSelectSReg, Sn_CR))
+        ;
+}
+
+uint16_t Wiznet6100::getSn_TX_FSR() {
+    uint16_t val = 0, val1 = 0;
+    do {
+        val1 = wizchip_read_word(BlockSelectSReg, Sn_TX_FSR);
+        if (val1 != 0) {
+            val = wizchip_read_word(BlockSelectSReg, Sn_TX_FSR);
+        }
+    } while (val != val1);
+    return val;
+}
+
+uint16_t Wiznet6100::getSn_RX_RSR() {
+    uint16_t val = 0, val1 = 0;
+    do {
+        val1 = wizchip_read_word(BlockSelectSReg, Sn_RX_RSR);
+        if (val1 != 0) {
+            val = wizchip_read_word(BlockSelectSReg, Sn_RX_RSR);
+        }
+    } while (val != val1);
+    return val;
+}
+
+void Wiznet6100::wizchip_send_data(const uint8_t* wizdata, uint16_t len) {
+    uint16_t ptr = 0;
+
+    if (len == 0) {
+        return;
+    }
+    ptr = getSn_TX_WR();
+    wizchip_write_buf(BlockSelectTxBuf, ptr, wizdata, len);
+
+    ptr += len;
+
+    setSn_TX_WR(ptr);
+}
+
+void Wiznet6100::wizchip_recv_data(uint8_t* wizdata, uint16_t len) {
+    uint16_t ptr;
+
+    if (len == 0) {
+        return;
+    }
+    ptr = getSn_RX_RD();
+    wizchip_read_buf(BlockSelectRxBuf, ptr, wizdata, len);
+    ptr += len;
+
+    setSn_RX_RD(ptr);
+}
+
+void Wiznet6100::wizchip_recv_ignore(uint16_t len) {
+    uint16_t ptr;
+
+    ptr = getSn_RX_RD();
+    ptr += len;
+    setSn_RX_RD(ptr);
+}
+
+bool Wiznet6100::wizchip_sw_reset() {
+    setChipLOCK(W6100_CHPLCKR_UNLOCK);
+    uint16_t count = 0;
+    do
+    { // Wait Unlock Complete
+        if (++count > 20)
+        {             // Check retry count
+            return false; // Over Limit retry count
+        }
+    } while ((getStatus() & W6100_SYSR_CHPL_LOCK) ^ W6100_SYSR_CHPL_ULOCK); // Exit Wait Unlock Complete
+
+    setCommand0(0x0); // Software Reset
+
+    do
+    { // Wait Lock Complete
+        if (++count > 20)
+        {             // Check retry count
+            return false; // Over Limit retry count
+        }
+
+    } while ((getStatus() & W6100_SYSR_CHPL_LOCK) ^ W6100_SYSR_CHPL_LOCK); // Exit Wait Lock Complete
+
+    return true;
+}
+
+int8_t Wiznet6100::wizphy_getphylink() {
+    int8_t tmp;
+    if (getPHYCFGR() & PHYCFGR_LNK_ON) {
+        tmp = PHY_LINK_ON;
+    } else {
+        tmp = PHY_LINK_OFF;
+    }
+    return tmp;
+}
+
+int8_t Wiznet6100::wizphy_getphypmode() {
+    int8_t tmp = 0;
+    if (getPHYCFGR() & PHYCFGR_OPMDC_PDOWN) {
+        tmp = PHY_POWER_DOWN;
+    } else {
+        tmp = PHY_POWER_NORM;
+    }
+    return tmp;
+}
+
+void Wiznet6100::wizphy_reset() {
+    uint8_t tmp = getPHYCFGR();
+    tmp &= PHYCFGR_RST;
+    setPHYCFGR(tmp);
+    tmp = getPHYCFGR();
+    tmp |= ~PHYCFGR_RST;
+    setPHYCFGR(tmp);
+}
+
+int8_t Wiznet6100::wizphy_setphypmode(uint8_t pmode) {
+    uint8_t tmp = 0;
+    tmp         = getPHYCFGR();
+    if ((tmp & PHYCFGR_OPMD) == 0) {
+        return -1;
+    }
+    tmp &= ~PHYCFGR_OPMDC_ALLA;
+    if (pmode == PHY_POWER_DOWN) {
+        tmp |= PHYCFGR_OPMDC_PDOWN;
+    } else {
+        tmp |= PHYCFGR_OPMDC_ALLA;
+    }
+    setPHYCFGR(tmp);
+    wizphy_reset();
+    tmp = getPHYCFGR();
+    if (pmode == PHY_POWER_DOWN) {
+        if (tmp & PHYCFGR_OPMDC_PDOWN) {
+            return 0;
+        }
+    } else {
+        if (tmp & PHYCFGR_OPMDC_ALLA) {
+            return 0;
+        }
+    }
+    return -1;
+}
+
+Wiznet6100::Wiznet6100(int8_t cs, SPIClass &spi, int8_t intr) : _spi(spi), _cs(cs), _intr(intr)
+{
+}
+
+bool Wiznet6100::begin(const uint8_t* mac_address, netif *net) {
+    _netif = net;
+    memcpy(_mac_address, mac_address, 6);
+
+    pinMode(_cs, OUTPUT);
+    wizchip_cs_deselect();
+
+    wizchip_sw_reset();
+
+    // Unlock
+    setChipLOCK(W6100_CHPLCKR_UNLOCK);
+    setNetLOCK(W6100_NETLCKR_UNLOCK);
+    setPHYLOCK(W6100_PHYLCKR_UNLOCK);
+
+    // W6100 CIDR0
+    // Version 97(dec) 0x61(hex)
+    int ver = getVERSIONR();
+
+    Serial.print("version = 0x");
+    Serial.println(ver, HEX);
+
+    if (ver != 0x61) {
+        return false;
+    }
+
+    // Use the full 16Kb of RAM for Socket 0
+    setSn_RXBUF_SIZE(16);
+    setSn_TXBUF_SIZE(16);
+
+    // Set our local MAC address
+    setSHAR(_mac_address);
+
+    // Open Socket 0 in MACRaw mode
+    setSn_MR(Sn_MR_MACRAW);
+    setSn_CR(Sn_CR_OPEN);
+    if (getSn_SR() != SOCK_MACRAW) {
+        // Failed to put socket 0 into MACRaw mode
+        return false;
+    }
+
+    Serial.println("MAC RAW mode!");
+
+    if (_intr >= 0) {
+        
+        setSn_IR(0xff); // Clear everything
+        
+
+        // Configure socket 0 interrupts
+        setSn_IMR(W6100_Sn_IMR_RECV); // we're not interested in W6100_Sn_IMR_SENDOK atm
+
+        // Enable socket 0 interrupts
+        setSIMR(W6100_SIMR_S0_INT);
+
+        // Disable unused interrupts
+        setIMR(0);
+
+        // Enable interrupt pin
+        setCommand1(W6100_SYCR1_IEN);
+        
+    }
+
+    // Success
+    return true;
+}
+
+void Wiznet6100::end() {
+    setSn_CR(Sn_CR_CLOSE);
+
+    // clear all interrupt of the socket
+    setSn_IR(0xFF);
+
+    // Wait for socket to change to closed
+    while (getSn_SR() != SOCK_CLOSED)
+        ;
+}
+
+/*
+uint16_t Wiznet6100::readFrame(uint8_t* buffer, uint16_t bufsize) {
+    uint16_t data_len = readFrameSize();
+
+    if (data_len == 0) {
+        return 0;
+    }
+
+    if (data_len > bufsize) {
+        // Packet is bigger than buffer - drop the packet
+        discardFrame(data_len);
+        return 0;
+    }
+
+    return readFrameData(buffer, data_len);
+}
+*/
+
+uint16_t Wiznet6100::readFrameSize() {
+    setSn_IR(Sn_IR_RECV);
+
+    uint16_t len = getSn_RX_RSR();
+
+    if (len == 0) {
+        return 0;
+    }
+
+    uint8_t  head[2];
+    uint16_t data_len = 0;
+
+    wizchip_recv_data(head, 2);
+    setSn_CR(Sn_CR_RECV);
+
+    data_len = head[0];
+    data_len = (data_len << 8) + head[1];
+    data_len -= 2;
+
+    // Clear interrupt flags
+    setICLR(W6100_Sn_IRCLR_RECV);
+
+    return data_len;
+}
+
+void Wiznet6100::discardFrame(uint16_t framesize) {
+    wizchip_recv_ignore(framesize);
+    setSn_CR(Sn_CR_RECV);
+}
+
+uint16_t Wiznet6100::readFrameData(uint8_t* buffer, uint16_t framesize) {
+    wizchip_recv_data(buffer, framesize);
+    setSn_CR(Sn_CR_RECV);
+
+    // let lwIP deal with mac address filtering
+    return framesize;
+}
+
+uint16_t Wiznet6100::sendFrame(const uint8_t* buf, uint16_t len) {
+    ethernet_arch_lwip_gpio_mask(); // So we don't fire an IRQ and interrupt the send w/a receive!
+
+    // Wait for space in the transmit buffer
+    while (1) {
+        uint16_t freesize = getSn_TX_FSR();
+        if (getSn_SR() == SOCK_CLOSED) {
+            ethernet_arch_lwip_gpio_unmask();
+            return -1;
+        }
+        if (len <= freesize) {
+            break;
+        }
+    };
+
+    wizchip_send_data(buf, len);
+    setSn_CR(Sn_CR_SEND);
+
+    while (1) {
+        uint8_t tmp = getSn_IR();
+        if (tmp & Sn_IR_SENDOK) {
+            setSn_IR(Sn_IR_SENDOK);
+            // Packet sent ok
+            break;
+        } else if (tmp & Sn_IR_TIMEOUT) {
+            setSn_IR(Sn_IR_TIMEOUT);
+            // There was a timeout
+            ethernet_arch_lwip_gpio_unmask();
+            return -1;
+        }
+    }
+
+    ethernet_arch_lwip_gpio_unmask();
+    return len;
+}

--- a/libraries/lwIP_w6100/src/utility/w6100.h
+++ b/libraries/lwIP_w6100/src/utility/w6100.h
@@ -1,0 +1,877 @@
+/*
+    Copyright (c) 2013, WIZnet Co., Ltd.
+    Copyright (c) 2016, Nicholas Humfrey
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+    1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+    ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+    COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+    HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+    STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+    ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+    OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+// original sources: https://github.com/njh/W5500MacRaw
+
+#ifndef W6100_H
+#define W6100_H
+
+#include <stdint.h>
+#include <Arduino.h>
+#include <SPI.h>
+#include <LwipEthernet.h>
+
+#define W6100_CHPLCKR_UNLOCK 0xCE
+#define W6100_NETLCKR_UNLOCK 0x3A
+#define W6100_PHYLCKR_UNLOCK 0x53
+
+#define W6100_SYSR_CHPL_LOCK (1 << 7)
+#define W6100_SYSR_CHPL_ULOCK (0 << 7)
+
+#define W6100_SYCR1_IEN 0x80
+
+// Socket Interrupt Mask register
+#define W6100_SIMR_S7_INT 0x80
+#define W6100_SIMR_S6_INT 0x40
+#define W6100_SIMR_S5_INT 0x20
+#define W6100_SIMR_S4_INT 0x10
+#define W6100_SIMR_S3_INT 0x08
+#define W6100_SIMR_S2_INT 0x04
+#define W6100_SIMR_S1_INT 0x02
+#define W6100_SIMR_S0_INT 0x01
+
+// Sn_IR Clear register
+#define W6100_Sn_IRCLR_SENDOK 0x10
+#define W6100_Sn_IRCLR_TIMEOUT 0x08
+#define W6100_Sn_IRCLR_RECV 0x04
+#define W6100_Sn_IRCLR_DISCON 0x02
+#define W6100_Sn_IRCLR_CON 0x01
+
+// Socket n Interrupt Mask register
+#define W6100_Sn_IMR_SENDOK 0x10
+#define W6100_Sn_IMR_TIMEOUT 0x08
+#define W6100_Sn_IMR_RECV 0x04
+#define W6100_Sn_IMR_DISCON 0x02
+#define W6100_Sn_IMR_CON 0x01
+
+class Wiznet6100 {
+public:
+    /**
+        Constructor that uses the default hardware SPI pins
+        @param cs the Arduino Chip Select / Slave Select pin (default 10)
+    */
+    Wiznet6100(int8_t cs = SS, SPIClass &spi = SPI, int8_t intr = -1);
+
+    /**
+        Initialise the Ethernet controller
+        Must be called before sending or receiving Ethernet frames
+
+        @param address the local MAC address for the Ethernet interface
+        @return Returns true if setting up the Ethernet interface was successful
+    */
+    bool begin(const uint8_t* address, netif *net);
+
+    /**
+        Shut down the Ethernet controlled
+    */
+    void end();
+
+    /**
+        Send an Ethernet frame
+        @param data a pointer to the data to send
+        @param datalen the length of the data in the packet
+        @return the number of bytes transmitted
+    */
+    uint16_t sendFrame(const uint8_t* data, uint16_t datalen);
+
+    /**
+        Read an Ethernet frame
+        @param buffer a pointer to a buffer to write the packet to
+        @param bufsize the available space in the buffer
+        @return the length of the received packet
+               or 0 if no packet was received
+    */
+    uint16_t readFrame(uint8_t* buffer, uint16_t bufsize);
+
+    bool isLinked();
+
+    /**
+        Report whether ::isLinked() API is implemented
+        @return true when ::isLinked() API is implemented
+    */
+    constexpr bool isLinkDetectable() const
+    {
+        return true;
+    }
+
+    constexpr bool needsSPI() const {
+        return true;
+    }
+
+protected:
+    static constexpr bool interruptIsPossible() {
+        return true;
+    }
+
+    static constexpr PinStatus interruptMode() {
+        return LOW;
+    }
+
+    /**
+        Read an Ethernet frame size
+        @return the length of data do receive
+               or 0 if no frame was received
+    */
+    uint16_t readFrameSize();
+
+    /**
+        discard an Ethernet frame
+        @param framesize readFrameSize()'s result
+    */
+    void discardFrame(uint16_t framesize);
+
+    /**
+        Read an Ethernet frame data
+           readFrameSize() must be called first,
+           its result must be passed into framesize parameter
+        @param buffer a pointer to a buffer to write the frame to
+        @param framesize readFrameSize()'s result
+        @return the length of the received frame
+               or 0 if a problem occurred
+    */
+    uint16_t readFrameData(uint8_t* frame, uint16_t framesize);
+
+private:
+    //< SPI interface Read operation in Control Phase
+    static const uint8_t AccessModeRead = (0x00 << 2);
+
+    //< SPI interface Read operation in Control Phase
+    static const uint8_t AccessModeWrite = (0x01 << 2);
+
+    //< Common register block in Control Phase
+    static const uint8_t BlockSelectCReg = (0x00 << 3);
+
+    //< Socket 0 register block in Control Phase
+    static const uint8_t BlockSelectSReg = (0x01 << 3);
+
+    //< Socket 0 Tx buffer address block
+    static const uint8_t BlockSelectTxBuf = (0x02 << 3);
+
+    //< Socket 0 Rx buffer address block
+    static const uint8_t BlockSelectRxBuf = (0x03 << 3);
+
+    //< SPI Fixed Data Mode Length
+    static const uint8_t FixedDataMode1 = 1;
+    static const uint8_t FixedDataMode2 = 2;
+    static const uint8_t FixedDataMode4 = 3;
+
+    SPIClass& _spi;
+    int8_t    _cs;
+    int8_t    _intr;
+    uint8_t   _mac_address[6];
+
+    /**
+        Default function to select chip.
+        @note This function help not to access wrong address. If you do not describe this function
+        or register any functions, null function is called.
+    */
+    inline void wizchip_cs_select() {
+        digitalWrite(_cs, LOW);
+    }
+
+    /**
+        Default function to deselect chip.
+        @note This function help not to access wrong address. If you do not describe this function
+        or register any functions, null function is called.
+    */
+    inline void wizchip_cs_deselect() {
+        digitalWrite(_cs, HIGH);
+    }
+
+    /**
+        Default function to read in SPI interface.
+        @note This function help not to access wrong address. If you do not describe this function
+        or register any functions, null function is called.
+    */
+    inline uint8_t wizchip_spi_read_byte() {
+        return _spi.transfer(0);
+    }
+
+    /**
+        Default function to write in SPI interface.
+        @note This function help not to access wrong address. If you do not describe this function
+        or register any functions, null function is called.
+    */
+    inline void wizchip_spi_write_byte(uint8_t wb) {
+        _spi.transfer(wb);
+    }
+
+    /**
+        Read a 1 byte value from a register.
+        @param address Register address
+        @return The value of register
+    */
+    uint8_t wizchip_read(uint8_t block, uint16_t address);
+
+    /**
+        Reads a 2 byte value from a register.
+        @param address Register address
+        @return The value of register
+    */
+    uint16_t wizchip_read_word(uint8_t block, uint16_t address);
+
+    /**
+        It reads sequence data from registers.
+        @param address Register address
+        @param pBuf Pointer buffer to read data
+        @param len Data length
+    */
+    void wizchip_read_buf(uint8_t block, uint16_t address, uint8_t* pBuf, uint16_t len);
+
+    /**
+        Write a 1 byte value to a register.
+        @param address Register address
+        @param wb Write data
+        @return void
+    */
+    void wizchip_write(uint8_t block, uint16_t address, uint8_t wb);
+
+    /**
+        Write a 2 byte value to a register.
+        @param address Register address
+        @param wb Write data
+        @return void
+    */
+    void wizchip_write_word(uint8_t block, uint16_t address, uint16_t word);
+
+    /**
+        It writes sequence data to registers.
+        @param address Register address
+        @param pBuf Pointer buffer to write data
+        @param len Data length
+    */
+    void wizchip_write_buf(uint8_t block, uint16_t address, const uint8_t* pBuf, uint16_t len);
+
+    /**
+        Get @ref Sn_TX_FSR register
+        @return uint16_t. Value of @ref Sn_TX_FSR.
+    */
+    uint16_t getSn_TX_FSR();
+
+    /**
+        Get @ref Sn_RX_RSR register
+        @return uint16_t. Value of @ref Sn_RX_RSR.
+    */
+    uint16_t getSn_RX_RSR();
+
+    /**
+        Reset WIZCHIP by softly.
+    */
+    bool wizchip_sw_reset();
+
+    /**
+        Get the link status of phy in WIZCHIP
+    */
+    int8_t wizphy_getphylink();
+
+    /**
+        Get the power mode of PHY in WIZCHIP
+    */
+    int8_t wizphy_getphypmode();
+
+    /**
+        Reset Phy
+    */
+    void wizphy_reset();
+
+    /**
+        set the power mode of phy inside WIZCHIP. Refer to @ref PHYCFGR in W5500, @ref PHYSTATUS in
+        W5200
+        @param pmode Setting value of power down mode.
+    */
+    int8_t wizphy_setphypmode(uint8_t pmode);
+
+    /**
+        It copies data to internal TX memory
+
+        @details This function reads the Tx write pointer register and after that,
+        it copies the <i>wizdata(pointer buffer)</i> of the length of <i>len(variable)</i> bytes to
+        internal TX memory and updates the Tx write pointer register. This function is being called
+        by send() and sendto() function also.
+
+        @param wizdata Pointer buffer to write data
+        @param len Data length
+        @sa wizchip_recv_data()
+    */
+    void wizchip_send_data(const uint8_t* wizdata, uint16_t len);
+
+    /**
+        It copies data to your buffer from internal RX memory
+
+        @details This function read the Rx read pointer register and after that,
+        it copies the received data from internal RX memory
+        to <i>wizdata(pointer variable)</i> of the length of <i>len(variable)</i> bytes.
+        This function is being called by recv() also.
+
+        @param wizdata Pointer buffer to read data
+        @param len Data length
+        @sa wizchip_send_data()
+    */
+    void wizchip_recv_data(uint8_t* wizdata, uint16_t len);
+
+    /**
+        It discard the received data in RX memory.
+        @details It discards the data of the length of <i>len(variable)</i> bytes in internal RX
+        memory.
+        @param len Data length
+    */
+    void wizchip_recv_ignore(uint16_t len);
+
+    /** Common registers */
+    enum {
+        MR       = 0x4000,  ///< Mode Register address (R/W)
+        SHAR     = 0x4120,  ///< Source MAC Register address (R/W)
+        INTLEVEL = 0x0013,  ///< Set Interrupt low level timer register address (R/W)
+        IR       = 0x2100,  ///< Interrupt Register (R/W)
+        _IMR_    = 0x2104,  ///< Interrupt mask register (R/W)
+        SIR      = 0x2101,  ///< Socket Interrupt Register (R/W)
+        _SIMR_   = 0x2114,  ///< Socket Interrupt Mask Register (R/W)
+        _RTR_    = 0x2101,  ///< Timeout register address (1 is 100us) (R/W)
+        _RCR_    = 0x4200,  ///< Retry count register (R/W)
+        UIPR     = 0x0000,  ///< Unreachable IP register address in UDP mode (R)
+        UPORTR   = 0x0000,  ///< Unreachable Port register address in UDP mode (R)
+        PHYCFGR  = 0x3000,  ///< PHY Status Register (R/W)
+        VERSIONR = 0x0000,  ///< Chip version register address (R)
+        NETLCKR  = 0x41F5,  ///< Network lock register
+        CHPLCKR  = 0x41F4,  ///< Chip lock register
+        PHYLCKR  = 0x41F6,  ///< PHY lock register
+        SYSR     = 0x2000,  ///< System status register
+        SYCR0    = 0x2004,  ///< System command register 0
+        SYCR1    = 0x2005,  ///< System command register 1
+    };
+
+    /** Socket registers */
+    enum {
+        Sn_MR         = 0x0000,  ///< Socket Mode register (R/W)
+        Sn_CR         = 0x0010,  ///< Socket command register (R/W)
+        Sn_IR         = 0x0020,  ///< Socket interrupt register (R)
+        Sn_ICLR       = 0x0028,  ///< Socket Interrupt clear register (W)
+        Sn_SR         = 0x0030,  ///< Socket status register (R)
+        Sn_PORT       = 0x0114,  ///< Source port register (R/W)
+        Sn_DHAR       = 0x0118,  ///< Peer MAC register address (R/W)
+        Sn_DIPR       = 0x0120,  ///< Peer IP register address (R/W)
+        Sn_DPORT      = 0x0140,  ///< Peer port register address (R/W)
+        Sn_MSSR       = 0x0110,  ///< Maximum Segment Size(Sn_MSSR0) register address (R/W)
+        Sn_TOS        = 0x0104,  ///< IP Type of Service(TOS) Register (R/W)
+        Sn_TTL        = 0x0108,  ///< IP Time to live(TTL) Register (R/W)
+        Sn_RXBUF_SIZE = 0x0220,  ///< Receive memory size register (R/W)
+        Sn_TXBUF_SIZE = 0x0200,  ///< Transmit memory size register (R/W)
+        Sn_TX_FSR     = 0x0204,  ///< Transmit free memory size register (R)
+        Sn_TX_RD      = 0x0208,  ///< Transmit memory read pointer register address (R)
+        Sn_TX_WR      = 0x020C,  ///< Transmit memory write pointer register address (R/W)
+        Sn_RX_RSR     = 0x0224,  ///< Received data size register (R)
+        Sn_RX_RD      = 0x0228,  ///< Read point of Receive memory (R/W)
+        Sn_RX_WR      = 0x022C,  ///< Write point of Receive memory (R)
+        Sn_IMR        = 0x0024,  ///< Socket interrupt mask register (R)
+        Sn_FRAG       = 0x002D,  ///< Fragment field value in IP header register (R/W)
+        Sn_KPALVTR    = 0x002F,  ///< Keep Alive Timer register (R/W)
+    };
+
+    /** Mode register values */
+    enum {
+        MR_RST   = 0x80,  ///< Reset
+        MR_WOL   = 0x20,  ///< Wake on LAN
+        MR_PB    = 0x10,  ///< Ping block
+        MR_PPPOE = 0x08,  ///< Enable PPPoE
+        MR_FARP  = 0x02,  ///< Enable UDP_FORCE_ARP CHECK
+    };
+
+    /* Interrupt Register values */
+    enum {
+        IR_CONFLICT = 0x80,  ///< Check IP conflict
+        IR_UNREACH  = 0x40,  ///< Get the destination unreachable message in UDP sending
+        IR_PPPoE    = 0x20,  ///< Get the PPPoE close message
+        IR_MP       = 0x10,  ///< Get the magic packet interrupt
+    };
+
+    /* Interrupt Mask Register values */
+    enum {
+        IM_IR7 = 0x80,  ///< IP Conflict Interrupt Mask
+        IM_IR6 = 0x40,  ///< Destination unreachable Interrupt Mask
+        IM_IR5 = 0x20,  ///< PPPoE Close Interrupt Mask
+        IM_IR4 = 0x10,  ///< Magic Packet Interrupt Mask
+    };
+
+    /** Socket Mode Register values @ref Sn_MR */
+    enum {
+        Sn_MR_CLOSE  = 0x00,  ///< Unused socket
+        Sn_MR_TCP    = 0x01,  ///< TCP
+        Sn_MR_UDP    = 0x02,  ///< UDP
+        Sn_MR_MACRAW = 0x07,  ///< MAC LAYER RAW SOCK
+        Sn_MR_UCASTB = 0x10,  ///< Unicast Block in UDP Multicasting
+        Sn_MR_ND     = 0x20,  ///< No Delayed Ack(TCP), Multicast flag
+        Sn_MR_BCASTB = 0x40,  ///< Broadcast block in UDP Multicasting
+        Sn_MR_MULTI  = 0x80,  ///< Support UDP Multicasting
+        Sn_MR_MIP6B  = 0x10,  ///< IPv6 packet Blocking in @ref Sn_MR_MACRAW mode
+        Sn_MR_MMB    = 0x20,  ///< Multicast Blocking in @ref Sn_MR_MACRAW mode
+        Sn_MR_MFEN   = 0x80,  ///< MAC filter enable in @ref Sn_MR_MACRAW mode
+    };
+
+    /** Socket Command Register values */
+    enum {
+        Sn_CR_OPEN      = 0x01,  ///< Initialise or open socket
+        Sn_CR_LISTEN    = 0x02,  ///< Wait connection request in TCP mode (Server mode)
+        Sn_CR_CONNECT   = 0x04,  ///< Send connection request in TCP mode (Client mode)
+        Sn_CR_DISCON    = 0x08,  ///< Send closing request in TCP mode
+        Sn_CR_CLOSE     = 0x10,  ///< Close socket
+        Sn_CR_SEND      = 0x20,  ///< Update TX buffer pointer and send data
+        Sn_CR_SEND_MAC  = 0x21,  ///< Send data with MAC address, so without ARP process
+        Sn_CR_SEND_KEEP = 0x22,  ///< Send keep alive message
+        Sn_CR_RECV      = 0x40,  ///< Update RX buffer pointer and receive data
+    };
+
+    /** Socket Interrupt register values */
+    enum {
+        Sn_IR_CON     = 0x01,  ///< CON Interrupt
+        Sn_IR_DISCON  = 0x02,  ///< DISCON Interrupt
+        Sn_IR_RECV    = 0x04,  ///< RECV Interrupt
+        Sn_IR_TIMEOUT = 0x08,  ///< TIMEOUT Interrupt
+        Sn_IR_SENDOK  = 0x10,  ///< SEND_OK Interrupt
+    };
+
+    /** Socket Status Register values */
+    enum {
+        SOCK_CLOSED      = 0x00,  ///< Closed
+        SOCK_INIT        = 0x13,  ///< Initiate state
+        SOCK_LISTEN      = 0x14,  ///< Listen state
+        SOCK_SYNSENT     = 0x15,  ///< Connection state
+        SOCK_SYNRECV     = 0x16,  ///< Connection state
+        SOCK_ESTABLISHED = 0x17,  ///< Success to connect
+        SOCK_FIN_WAIT    = 0x18,  ///< Closing state
+        SOCK_CLOSING     = 0x1A,  ///< Closing state
+        SOCK_TIME_WAIT   = 0x1B,  ///< Closing state
+        SOCK_CLOSE_WAIT  = 0x1C,  ///< Closing state
+        SOCK_LAST_ACK    = 0x1D,  ///< Closing state
+        SOCK_UDP         = 0x22,  ///< UDP socket
+        SOCK_MACRAW      = 0x42,  ///< MAC raw mode socket
+    };
+
+    /* PHYCFGR register value */
+    enum {
+        PHYCFGR_RST         = ~(1 << 7),  //< For PHY reset, must operate AND mask.
+        PHYCFGR_OPMD        = (1 << 6),   // Configure PHY with OPMDC value
+        PHYCFGR_OPMDC_ALLA  = (7 << 3),
+        PHYCFGR_OPMDC_PDOWN = (6 << 3),
+        PHYCFGR_OPMDC_NA    = (5 << 3),
+        PHYCFGR_OPMDC_100FA = (4 << 3),
+        PHYCFGR_OPMDC_100F  = (3 << 3),
+        PHYCFGR_OPMDC_100H  = (2 << 3),
+        PHYCFGR_OPMDC_10F   = (1 << 3),
+        PHYCFGR_OPMDC_10H   = (0 << 3),
+        PHYCFGR_DPX_FULL    = (1 << 2),
+        PHYCFGR_DPX_HALF    = (0 << 2),
+        PHYCFGR_SPD_100     = (1 << 1),
+        PHYCFGR_SPD_10      = (0 << 1),
+        PHYCFGR_LNK_ON      = (1 << 0),
+        PHYCFGR_LNK_OFF     = (0 << 0),
+    };
+
+    enum {
+        PHY_SPEED_10    = 0,  ///< Link Speed 10
+        PHY_SPEED_100   = 1,  ///< Link Speed 100
+        PHY_DUPLEX_HALF = 0,  ///< Link Half-Duplex
+        PHY_DUPLEX_FULL = 1,  ///< Link Full-Duplex
+        PHY_LINK_OFF    = 0,  ///< Link Off
+        PHY_LINK_ON     = 1,  ///< Link On
+        PHY_POWER_NORM  = 0,  ///< PHY power normal mode
+        PHY_POWER_DOWN  = 1,  ///< PHY power down mode
+    };
+
+    /**
+        Set Mode Register
+        @param (uint8_t)mr The value to be set.
+        @sa getMR()
+    */
+    inline void setMR(uint8_t mode) {
+        wizchip_write(BlockSelectCReg, MR, mode);
+    }
+
+    /**
+        Get Mode Register
+        @return uint8_t. The value of Mode register.
+        @sa setMR()
+    */
+    inline uint8_t getMR() {
+        return wizchip_read(BlockSelectCReg, MR);
+    }
+
+    /**
+     * Reads the W6100 system status register
+     * @return uint8_t 
+     */
+    inline uint8_t getStatus() {
+        return wizchip_read(BlockSelectCReg, SYSR);
+    }
+
+    /**
+     * Writes a W6100 command
+     */
+    inline void setCommand0(uint8_t cmd) {
+        wizchip_write(BlockSelectCReg, SYCR0, cmd);
+    }
+
+    /**
+     * Writes a W6100 command
+     */
+    inline void setCommand1(uint8_t cmd)
+    {
+        wizchip_write(BlockSelectCReg, SYCR1, cmd);
+    }
+
+    /**
+        Set local MAC address
+        @param (uint8_t*)shar Pointer variable to set local MAC address. It should be allocated 6
+        bytes.
+        @sa getSHAR()
+    */
+    inline void setSHAR(const uint8_t* macaddr) {
+        wizchip_write_buf(BlockSelectCReg, SHAR, macaddr, 6);
+    }
+
+    /**
+        Get local MAC address
+        @param (uint8_t*)shar Pointer variable to get local MAC address. It should be allocated 6
+        bytes.
+        @sa setSHAR()
+    */
+    inline void getSHAR(uint8_t* macaddr) {
+        wizchip_read_buf(BlockSelectCReg, SHAR, macaddr, 6);
+    }
+
+    /**
+        Set @ref IR register
+        @param (uint8_t)ir Value to set @ref IR register.
+        @sa getIR()
+    */
+    inline void setIR(uint8_t ir) {
+        wizchip_write(BlockSelectCReg, IR, (ir & 0xF0));
+    }
+
+    /**
+        Get @ref IR register
+        @return uint8_t. Value of @ref IR register.
+        @sa setIR()
+    */
+    inline uint8_t getIR() {
+        return wizchip_read(BlockSelectCReg, IR) & 0xF0;
+    }
+
+    /**
+        Set @ref SIR register
+        @param (uint8_t)ir Value to set @ref SIR register.
+        @sa getSIR()
+    */
+    inline void setSIR(uint8_t ir) {
+        wizchip_write(BlockSelectCReg, SIR, ir);
+    }
+
+    /**
+        Get @ref SIR register
+        @return uint8_t. Value of @ref SIR register.
+        @sa setSIR()
+    */
+    inline uint8_t getSIR() {
+        return wizchip_read(BlockSelectCReg, SIR);
+    }
+
+    /**
+        Set @ref _IMR_ register
+        @param (uint8_t)imr Value to set @ref _IMR_ register.
+        @sa getIMR()
+    */
+    inline void setIMR(uint8_t imr) {
+        wizchip_write(BlockSelectCReg, _IMR_, imr);
+    }
+
+    /**
+        Get @ref _IMR_ register
+        @return uint8_t. Value of @ref _IMR_ register.
+        @sa setIMR()
+    */
+    inline uint8_t getIMR() {
+        return wizchip_read(BlockSelectCReg, _IMR_);
+    }
+
+    /**
+        Set @ref _SIMR_ register
+        @param (uint8_t)imr Value to set @ref _SIMR_ register.
+        @sa getIMR()
+    */
+    inline void setSIMR(uint8_t imr) {
+        wizchip_write(BlockSelectCReg, _SIMR_, imr);
+    }
+
+    /**
+     Set @ref _SIMR_ register
+     @param (uint8_t)imr Value to set @ref _SIMR_ register.
+     @sa getIMR()
+ */
+    inline void setICLR(uint8_t imr)
+    {
+        wizchip_write(BlockSelectSReg, Sn_ICLR, imr);
+    }
+
+    /**
+        Get @ref _SIMR_ register
+        @return uint8_t. Value of @ref _SIMR_ register.
+        @sa setSIMR()
+    */
+    inline uint8_t getSIMR() {
+        return wizchip_read(BlockSelectCReg, _SIMR_);
+    }
+
+    /**
+        Set @ref PHYCFGR register
+        @param (uint8_t)phycfgr Value to set @ref PHYCFGR register.
+        @sa getPHYCFGR()
+    */
+    inline void setPHYCFGR(uint8_t phycfgr) {
+        wizchip_write(BlockSelectCReg, PHYCFGR, phycfgr);
+    }
+
+    /**
+        Get @ref PHYCFGR register
+        @return uint8_t. Value of @ref PHYCFGR register.
+        @sa setPHYCFGR()
+    */
+    inline uint8_t getPHYCFGR() {
+        return wizchip_read(BlockSelectCReg, PHYCFGR);
+    }
+
+    /**
+     * Sets the chip lock to
+     * @param state 
+     */
+    inline void setChipLOCK(uint8_t state) {
+        wizchip_write(BlockSelectCReg, CHPLCKR, state);
+    }
+
+    /**
+     * Sets the PHY lock to
+     * @param state
+     */
+    inline void setPHYLOCK(uint8_t state)
+    {
+        wizchip_write(BlockSelectCReg, PHYLCKR, state);
+    }
+    /**
+     * Sets the network lock to
+     * @param state
+     */
+    inline void setNetLOCK(uint8_t state)
+    {
+        wizchip_write(BlockSelectCReg, NETLCKR, state);
+    }
+
+    /**
+        Get @ref VERSIONR register
+        @return uint8_t. Value of @ref VERSIONR register.
+    */
+    inline uint8_t getVERSIONR() {
+        return wizchip_read(BlockSelectCReg, VERSIONR);
+    }
+
+    /**
+        Set @ref Sn_MR register
+        @param (uint8_t)mr Value to set @ref Sn_MR
+        @sa getSn_MR()
+    */
+    inline void setSn_MR(uint8_t mr) {
+        wizchip_write(BlockSelectSReg, Sn_MR, mr);
+    }
+
+    /**
+        Get @ref Sn_MR register
+        @return uint8_t. Value of @ref Sn_MR.
+        @sa setSn_MR()
+    */
+    inline uint8_t getSn_MR() {
+        return wizchip_read(BlockSelectSReg, Sn_MR);
+    }
+
+    /**
+        Set @ref Sn_CR register, then wait for the command to execute
+        @param (uint8_t)cr Value to set @ref Sn_CR
+        @sa getSn_CR()
+    */
+    void setSn_CR(uint8_t cr);
+
+    /**
+        Get @ref Sn_CR register
+        @return uint8_t. Value of @ref Sn_CR.
+        @sa setSn_CR()
+    */
+    inline uint8_t getSn_CR() {
+        return wizchip_read(BlockSelectSReg, Sn_CR);
+    }
+
+    /**
+        Set @ref Sn_IR register
+        @param (uint8_t)ir Value to set @ref Sn_IR
+        @sa getSn_IR()
+    */
+    inline void setSn_IR(uint8_t ir) {
+        wizchip_write(BlockSelectSReg, Sn_IR, (ir & 0x1F));
+    }
+
+    /**
+        Get @ref Sn_IR register
+        @return uint8_t. Value of @ref Sn_IR.
+        @sa setSn_IR()
+    */
+    inline uint8_t getSn_IR() {
+        return (wizchip_read(BlockSelectSReg, Sn_IR) & 0x1F);
+    }
+
+    /**
+        Set @ref Sn_IMR register
+        @param (uint8_t)imr Value to set @ref Sn_IMR
+        @sa getSn_IMR()
+    */
+    inline void setSn_IMR(uint8_t imr) {
+        wizchip_write(BlockSelectSReg, Sn_IMR, (imr & 0x1F));
+    }
+
+    /**
+        Get @ref Sn_IMR register
+        @return uint8_t. Value of @ref Sn_IMR.
+        @sa setSn_IMR()
+    */
+    inline uint8_t getSn_IMR() {
+        return (wizchip_read(BlockSelectSReg, Sn_IMR) & 0x1F);
+    }
+
+    /**
+        Get @ref Sn_SR register
+        @return uint8_t. Value of @ref Sn_SR.
+    */
+    inline uint8_t getSn_SR() {
+        return wizchip_read(BlockSelectSReg, Sn_SR);
+    }
+
+    /**
+        Set @ref Sn_RXBUF_SIZE register
+        @param (uint8_t)rxbufsize Value to set @ref Sn_RXBUF_SIZE
+        @sa getSn_RXBUF_SIZE()
+    */
+    inline void setSn_RXBUF_SIZE(uint8_t rxbufsize) {
+        // W6100 DEBUG: rxbufsize = 16
+        // W6100 DEBUG: original code:
+        /*   static inline uint8_t writeSn(SOCKET s=0, uint16_t addr, uint8_t data=16) {
+    return write(CH_BASE() + s * CH_SIZE + addr, data);
+        */
+        wizchip_write(BlockSelectSReg, Sn_RXBUF_SIZE, rxbufsize);
+    }
+
+    /**
+        Get @ref Sn_RXBUF_SIZE register
+        @return uint8_t. Value of @ref Sn_RXBUF_SIZE.
+        @sa setSn_RXBUF_SIZE()
+    */
+    inline uint8_t getSn_RXBUF_SIZE() {
+        return wizchip_read(BlockSelectSReg, Sn_RXBUF_SIZE);
+    }
+
+    /**
+        Set @ref Sn_TXBUF_SIZE register
+        @param (uint8_t)txbufsize Value to set @ref Sn_TXBUF_SIZE
+        @sa getSn_TXBUF_SIZE()
+    */
+    inline void setSn_TXBUF_SIZE(uint8_t txbufsize) {
+        wizchip_write(BlockSelectSReg, Sn_TXBUF_SIZE, txbufsize);
+    }
+
+    /**
+        Get @ref Sn_TXBUF_SIZE register
+        @return uint8_t. Value of @ref Sn_TXBUF_SIZE.
+        @sa setSn_TXBUF_SIZE()
+    */
+    inline uint8_t getSn_TXBUF_SIZE() {
+        return wizchip_read(BlockSelectSReg, Sn_TXBUF_SIZE);
+    }
+
+    /**
+        Get @ref Sn_TX_RD register
+        @return uint16_t. Value of @ref Sn_TX_RD.
+    */
+    inline uint16_t getSn_TX_RD() {
+        return wizchip_read_word(BlockSelectSReg, Sn_TX_RD);
+    }
+
+    /**
+        Set @ref Sn_TX_WR register
+        @param (uint16_t)txwr Value to set @ref Sn_TX_WR
+        @sa GetSn_TX_WR()
+    */
+    inline void setSn_TX_WR(uint16_t txwr) {
+        wizchip_write_word(BlockSelectSReg, Sn_TX_WR, txwr);
+    }
+
+    /**
+        Get @ref Sn_TX_WR register
+        @return uint16_t. Value of @ref Sn_TX_WR.
+        @sa setSn_TX_WR()
+    */
+    inline uint16_t getSn_TX_WR() {
+        return wizchip_read_word(BlockSelectSReg, Sn_TX_WR);
+    }
+
+    /**
+        Set @ref Sn_RX_RD register
+        @param (uint16_t)rxrd Value to set @ref Sn_RX_RD
+        @sa getSn_RX_RD()
+    */
+    inline void setSn_RX_RD(uint16_t rxrd) {
+        wizchip_write_word(BlockSelectSReg, Sn_RX_RD, rxrd);
+    }
+
+    /**
+        Get @ref Sn_RX_RD register
+        @return uint16_t. Value of @ref Sn_RX_RD.
+        @sa setSn_RX_RD()
+    */
+    inline uint16_t getSn_RX_RD() {
+        return wizchip_read_word(BlockSelectSReg, Sn_RX_RD);
+    }
+
+    /**
+        Get @ref Sn_RX_WR register
+        @return uint16_t. Value of @ref Sn_RX_WR.
+    */
+    inline uint16_t getSn_RX_WR() {
+        return wizchip_read_word(BlockSelectSReg, Sn_RX_WR);
+    }
+
+    netif *_netif;
+};
+
+#endif  // W6100_H

--- a/libraries/lwIP_w6100/src/utility/w6100.h
+++ b/libraries/lwIP_w6100/src/utility/w6100.h
@@ -40,39 +40,6 @@
 #include <SPI.h>
 #include <LwipEthernet.h>
 
-#define W6100_CHPLCKR_UNLOCK 0xCE
-#define W6100_NETLCKR_UNLOCK 0x3A
-#define W6100_PHYLCKR_UNLOCK 0x53
-
-#define W6100_SYSR_CHPL_LOCK (1 << 7)
-#define W6100_SYSR_CHPL_ULOCK (0 << 7)
-
-#define W6100_SYCR1_IEN 0x80
-
-// Socket Interrupt Mask register
-#define W6100_SIMR_S7_INT 0x80
-#define W6100_SIMR_S6_INT 0x40
-#define W6100_SIMR_S5_INT 0x20
-#define W6100_SIMR_S4_INT 0x10
-#define W6100_SIMR_S3_INT 0x08
-#define W6100_SIMR_S2_INT 0x04
-#define W6100_SIMR_S1_INT 0x02
-#define W6100_SIMR_S0_INT 0x01
-
-// Sn_IR Clear register
-#define W6100_Sn_IRCLR_SENDOK 0x10
-#define W6100_Sn_IRCLR_TIMEOUT 0x08
-#define W6100_Sn_IRCLR_RECV 0x04
-#define W6100_Sn_IRCLR_DISCON 0x02
-#define W6100_Sn_IRCLR_CON 0x01
-
-// Socket n Interrupt Mask register
-#define W6100_Sn_IMR_SENDOK 0x10
-#define W6100_Sn_IMR_TIMEOUT 0x08
-#define W6100_Sn_IMR_RECV 0x04
-#define W6100_Sn_IMR_DISCON 0x02
-#define W6100_Sn_IMR_CON 0x01
-
 class Wiznet6100 {
 public:
     /**
@@ -493,6 +460,54 @@ private:
         PHYCFGR_SPD_10      = (0 << 1),
         PHYCFGR_LNK_ON      = (1 << 0),
         PHYCFGR_LNK_OFF     = (0 << 0),
+    };
+    
+    /* Lock register commands */
+    enum {
+        CHPLCKR_UNLOCK      = 0xCE,
+        NETLCKR_UNLOCK      = 0x3A,
+        PHYLCKR_UNLOCK      = 0x53,
+    };
+
+    /* SYS Lock register commands */
+    enum {
+        SYSR_CHPL_LOCK      = (1 << 7),
+        SYSR_CHPL_ULOCK     = (0 << 7),
+    };
+
+    /* SYS1 register commands */
+    enum {
+        SYCR1_IEN           = 0x80,
+    };
+
+    /* Socket Interrupt Mask register */
+    enum {
+        SIMR_S7_INT         = 0x80,
+        SIMR_S6_INT         = 0x40,
+        SIMR_S5_INT         = 0x20,
+        SIMR_S4_INT         = 0x10,
+        SIMR_S3_INT         = 0x08,
+        SIMR_S2_INT         = 0x04,
+        SIMR_S1_INT         = 0x02,
+        SIMR_S0_INT         = 0x01,
+    };
+
+    /* Sn_IR Clear register */
+    enum {
+        Sn_IRCLR_SENDOK     = 0x10,
+        Sn_IRCLR_TIMEOUT    = 0x08,
+        Sn_IRCLR_RECV       = 0x04,
+        Sn_IRCLR_DISCON     = 0x02,
+        Sn_IRCLR_CON        = 0x01,
+    };
+
+    /* Socket n Interrupt Mask register */
+    enum {
+        Sn_IMR_SENDOK       = 0x10,
+        Sn_IMR_TIMEOUT      = 0x08,
+        Sn_IMR_RECV         = 0x04,
+        Sn_IMR_DISCON       = 0x02,
+        Sn_IMR_CON          = 0x01,
     };
 
     enum {


### PR DESCRIPTION
This is a first WIP for supporting the Wiznet W6100 Ethernet chip in the `lwIP_Ethernet`. 
* It was cloned from the `lwip_5500` driver
* I used the same structure and naming for register access

### Preliminary Testing & Known Bugs
- Code works on both chips on otherwise identical boards (W5500-EVB-Pico & W610-EVB-Pico): You only have to change the `W5550` to `W6100`  in the generic of the type for the constructor: `ArduinoEthernet<Wiznet6100> Ethernet(17, SPI, 21)`
- Tested: Pinging (~1.7-2.0ms), UDP, TCP (WebServer), ArduinoOTA (espota)

### Known Bugs
* As of now, both (lwIP_5500 and this lwIP_W6100) cannot run the libraries/WebServer/examples/AdvancedWebServer/AdvancedWebServer.ino due to default stack limits (crashes after few requests because the stack grows too deep. This seems not to be related to any of the Wxx00 drivers but how https://github.com/earlephilhower/arduino-pico/blob/f45db86cc2d0d0392ca8745a7adda698f7c7982b/libraries/lwIP_Ethernet/src/LwipIntfDev.h#L586 calls in the same (IRQ) thread context, which will end up calling into lwIP -> Arduino Ethernet -> EthernetTCP -> Webserver .... -> crash (too deep)