### PR TITLE
Fix Platform.IO ARDUINO_ARCH_xxx define

### DIFF
--- a/tools/json/challenger_2350_bconnect.json
+++ b/tools/json/challenger_2350_bconnect.json
@@ -9,7 +9,7 @@
     },
     "core": "earlephilhower",
     "cpu": "cortex-m33",
-    "extra_flags": "-D ARDUINO_CHALLENGER_2350_BCONNECT_RP2350 -DARDUINO_ARCH_RP2350 -DUSBD_MAX_POWER_MA=500",
+    "extra_flags": "-D ARDUINO_CHALLENGER_2350_BCONNECT_RP2350 -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=500",
     "f_cpu": "133000000L",
     "hwids": [
       [

--- a/tools/json/challenger_2350_wifi6_ble5.json
+++ b/tools/json/challenger_2350_wifi6_ble5.json
@@ -9,7 +9,7 @@
     },
     "core": "earlephilhower",
     "cpu": "cortex-m33",
-    "extra_flags": "-D ARDUINO_CHALLENGER_2350_WIFI_BLE_RP2350 -DARDUINO_ARCH_RP2350 -DUSBD_MAX_POWER_MA=500 -DWIFIESPAT2",
+    "extra_flags": "-D ARDUINO_CHALLENGER_2350_WIFI_BLE_RP2350 -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=500 -DWIFIESPAT2",
     "f_cpu": "133000000L",
     "hwids": [
       [

--- a/tools/json/generic_rp2350.json
+++ b/tools/json/generic_rp2350.json
@@ -9,7 +9,7 @@
     },
     "core": "earlephilhower",
     "cpu": "cortex-m33",
-    "extra_flags": "-D ARDUINO_GENERIC_RP2350 -DARDUINO_ARCH_RP2350 -DUSBD_MAX_POWER_MA=250",
+    "extra_flags": "-D ARDUINO_GENERIC_RP2350 -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=250",
     "f_cpu": "133000000L",
     "hwids": [
       [

--- a/tools/json/rpipico2.json
+++ b/tools/json/rpipico2.json
@@ -9,7 +9,7 @@
     },
     "core": "earlephilhower",
     "cpu": "cortex-m33",
-    "extra_flags": "-D ARDUINO_RASPBERRY_PI_PICO_2 -DARDUINO_ARCH_RP2350 -DUSBD_MAX_POWER_MA=250",
+    "extra_flags": "-D ARDUINO_RASPBERRY_PI_PICO_2 -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=250",
     "f_cpu": "133000000L",
     "hwids": [
       [

--- a/tools/json/solderparty_rp2350_stamp.json
+++ b/tools/json/solderparty_rp2350_stamp.json
@@ -9,7 +9,7 @@
     },
     "core": "earlephilhower",
     "cpu": "cortex-m33",
-    "extra_flags": "-D ARDUINO_SOLDERPARTY_RP2350_STAMP -DARDUINO_ARCH_RP2350 -DUSBD_MAX_POWER_MA=500",
+    "extra_flags": "-D ARDUINO_SOLDERPARTY_RP2350_STAMP -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=500",
     "f_cpu": "133000000L",
     "hwids": [
       [

--- a/tools/json/solderparty_rp2350_stamp_xl.json
+++ b/tools/json/solderparty_rp2350_stamp_xl.json
@@ -9,7 +9,7 @@
     },
     "core": "earlephilhower",
     "cpu": "cortex-m33",
-    "extra_flags": "-D ARDUINO_SOLDERPARTY_RP2350_STAMP_XL -DARDUINO_ARCH_RP2350 -DUSBD_MAX_POWER_MA=500",
+    "extra_flags": "-D ARDUINO_SOLDERPARTY_RP2350_STAMP_XL -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=500",
     "f_cpu": "133000000L",
     "hwids": [
       [

--- a/tools/json/sparkfun_promicrorp2350.json
+++ b/tools/json/sparkfun_promicrorp2350.json
@@ -9,7 +9,7 @@
     },
     "core": "earlephilhower",
     "cpu": "cortex-m33",
-    "extra_flags": "-D ARDUINO_SPARKFUN_PROMICRO_RP2350 -DARDUINO_ARCH_RP2350 -DUSBD_MAX_POWER_MA=250",
+    "extra_flags": "-D ARDUINO_SPARKFUN_PROMICRO_RP2350 -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=250",
     "f_cpu": "133000000L",
     "hwids": [
       [

--- a/tools/makeboards.py
+++ b/tools/makeboards.py
@@ -357,7 +357,7 @@ def MakeBoardJSON(name, chip, vendor_name, product_name, vid, pid, pwr, boarddef
     },
     "core": "earlephilhower",
     "cpu": "CPU",
-    "extra_flags": "-D ARDUINO_BOARDDEFINE -DARDUINO_ARCH_ARCHDEF -DUSBD_MAX_POWER_MA=USBPWR EXTRA_INFO",
+    "extra_flags": "-D ARDUINO_BOARDDEFINE -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=USBPWR EXTRA_INFO",
     "f_cpu": "133000000L",
     "hwids": [
       [
@@ -407,7 +407,6 @@ def MakeBoardJSON(name, chip, vendor_name, product_name, vid, pid, pwr, boarddef
 .replace('BOOT2', boot2)\
 .replace('MCUCHIP', chip)\
 .replace('CPU', cpu)\
-.replace('ARCHDEF', chip.upper())\
 .replace('JLINK', jlink)\
 .replace('VID', vid.upper().replace("X", "x"))\
 .replace('PID', pid.upper().replace("X", "x"))\

--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -136,7 +136,7 @@ elif chip == "rp2350":
     env.Append(
         CPPDEFINES=[
             ("ARDUINO", 10810),
-            "ARDUINO_ARCH_RP2350",
+            "ARDUINO_ARCH_RP2040",
             ("F_CPU", "$BOARD_F_CPU"),
             ("BOARD_NAME", '\\"%s\\"' % env.subst("$BOARD")),
             ("CFG_TUSB_DEBUG", "0"),


### PR DESCRIPTION
The core will be identified (now for historical reasons) as ARDUINO_ARCH_RP2040.