### PR TITLE
Adding Cytron IRIC IO Controller to the supported list in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Read the [Contributing Guide](https://github.com/earlephilhower/arduino-pico/blo
 * Breadstick Raspberry
 * BridgeTek IDM2040-7A
 * BridgeTek IDM2040-43A
+* Cytron IRIV IO Controller
 * Cytron Maker Pi RP2040
 * Cytron Maker Nano RP2040
 * Cytron Maker Uno RP2040


### PR DESCRIPTION
I'm sorry I missed this out in #2370 