### PR TITLE
Update PIO board definition for PSRAM

### DIFF
--- a/tools/json/challenger_2350_bconnect.json
+++ b/tools/json/challenger_2350_bconnect.json
@@ -49,7 +49,8 @@
             "picotool",
             "picoprobe",
             "pico-debug"
-        ]
+        ],
+        "psram_length": 8388608
     },
     "url": "https://www.raspberrypi.org/products/raspberry-pi-pico/",
     "vendor": "iLabs"

--- a/tools/json/challenger_2350_wifi6_ble5.json
+++ b/tools/json/challenger_2350_wifi6_ble5.json
@@ -49,7 +49,8 @@
             "picotool",
             "picoprobe",
             "pico-debug"
-        ]
+        ],
+        "psram_length": 8388608
     },
     "url": "https://www.raspberrypi.org/products/raspberry-pi-pico/",
     "vendor": "iLabs"

--- a/tools/json/sparkfun_promicrorp2350.json
+++ b/tools/json/sparkfun_promicrorp2350.json
@@ -49,7 +49,8 @@
             "picotool",
             "picoprobe",
             "pico-debug"
-        ]
+        ],
+        "psram_length": 8388608
     },
     "url": "https://www.raspberrypi.org/products/raspberry-pi-pico/",
     "vendor": "SparkFun"

--- a/tools/makeboards.py
+++ b/tools/makeboards.py
@@ -331,13 +331,13 @@ def MakeBoard(name, chip, vendor_name, product_name, vid, pid, pwr, boarddefine,
         BuildUploadMethodMenu(name, 256)
     else:
         BuildUploadMethodMenu(name, 512)
-    MakeBoardJSON(name, chip, vendor_name, product_name, vid, pid, pwr, boarddefine, flashsizemb, boot2, extra, board_url)
+    MakeBoardJSON(name, chip, vendor_name, product_name, vid, pid, pwr, boarddefine, flashsizemb, psramsize, boot2, extra, board_url)
     global pkgjson
     thisbrd = {}
     thisbrd['name'] = "%s %s" % (vendor_name, product_name)
     pkgjson['packages'][0]['platforms'][0]['boards'].append(thisbrd)
 
-def MakeBoardJSON(name, chip, vendor_name, product_name, vid, pid, pwr, boarddefine, flashsizemb, boot2, extra, board_url):
+def MakeBoardJSON(name, chip, vendor_name, product_name, vid, pid, pwr, boarddefine, flashsizemb, psramsize, boot2, extra, board_url):
     # TODO FIX: Use the same expanded PID list as in BuildHeader above?
     if isinstance(pid, list):
         pid = pid[0]
@@ -413,6 +413,9 @@ def MakeBoardJSON(name, chip, vendor_name, product_name, vid, pid, pwr, boarddef
     "url": board_url or 'https://www.raspberrypi.org/products/raspberry-pi-pico/',
     "vendor": vendor_name,
     }
+    # add nonzero PSRAM sizes of known boards (can still be overwritten in platformio.ini)
+    if psramsize != 0 and name != "generic_rp2350":
+        j["upload"]["psram_length"] = psramsize * 1024 * 1024
 
     jsondir = os.path.abspath(os.path.dirname(__file__)) + "/json"
     with open(jsondir + "/" + name + ".json", "w", newline='\n') as jout:

--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -22,6 +22,7 @@ board = env.BoardConfig()
 chip = board.get("build.mcu")
 upload_protocol = env.subst("$UPLOAD_PROTOCOL") or "picotool"
 ram_size = int(board.get("upload.maximum_ram_size"))
+psram_len = int(board.get("upload.psram_length", "0"))
 if chip == "rp2040":
     #ram_size = board.get("upload.maximum_ram_size") # PlatformIO gives 264K here
     # but the RAM size we need is without the SCRATCH memory.
@@ -393,6 +394,7 @@ linkerscript_cmd = env.Command(
         "--sub", "__FS_START__", "$FS_START",
         "--sub", "__FS_END__", "$FS_END",
         "--sub", "__RAM_LENGTH__", "%dk" % (ram_size // 1024),
+        "--sub", "__PSRAM_LENGTH__", "%d" % (psram_len)
     ]), "Generating linkerscript $BUILD_DIR/memmap_default.ld")
 )
 


### PR DESCRIPTION
Was used in linkerscript and `boards.txt` but not available to PlatformIO.

Docs will be updated separately after verification.