### PR TITLE
Add serial inversion for UART and SerialPIO

### DIFF
--- a/cores/rp2040/SerialPIO.h
+++ b/cores/rp2040/SerialPIO.h
@@ -41,7 +41,22 @@ public:
     void begin(unsigned long baud, uint16_t config) override;
     void end() override;
 
-    void setInverted(bool invTx = true, bool invRx = true);
+    void setInverted(bool invTx = true, bool invRx = true) {
+        setInvertTX(invTx);
+        setInvertRX(invRx);
+    }
+    bool setInvertTX(bool invert = true) {
+        if (!_running) {
+            _invertTX = invert;
+        }
+        return !_running;
+    }
+    bool setInvertRX(bool invert = true) {
+        if (!_running) {
+            _invertRX = invert;
+        }
+        return !_running;
+    }
 
     virtual int peek() override;
     virtual int read() override;
@@ -65,8 +80,8 @@ protected:
     int _stop;
     bool _overflow;
     mutex_t _mutex;
-    bool _txInverted = false;
-    bool _rxInverted = false;
+    bool _invertTX;
+    bool _invertRX;
 
     PIOProgram *_txPgm;
     PIO _txPIO;

--- a/cores/rp2040/SerialUART.cpp
+++ b/cores/rp2040/SerialUART.cpp
@@ -138,6 +138,9 @@ SerialUART::SerialUART(uart_inst_t *uart, pin_size_t tx, pin_size_t rx, pin_size
     _cts = cts;
     mutex_init(&_mutex);
     mutex_init(&_fifoMutex);
+    _invertTX = false;
+    _invertRX = false;
+    _invertControl = false;
 }
 
 static void _uart0IRQ();
@@ -154,14 +157,18 @@ void SerialUART::begin(unsigned long baud, uint16_t config) {
     _fcnTx = gpio_get_function(_tx);
     _fcnRx = gpio_get_function(_rx);
     gpio_set_function(_tx, GPIO_FUNC_UART);
+    gpio_set_outover(_tx, _invertTX ? 1 : 0);
     gpio_set_function(_rx, GPIO_FUNC_UART);
+    gpio_set_inover(_rx, _invertRX ? 1 : 0);
     if (_rts != UART_PIN_NOT_DEFINED) {
         _fcnRts = gpio_get_function(_rts);
         gpio_set_function(_rts, GPIO_FUNC_UART);
+        gpio_set_outover(_rts, _invertControl ? 1 : 0);
     }
     if (_cts != UART_PIN_NOT_DEFINED) {
         _fcnCts = gpio_get_function(_cts);
         gpio_set_function(_cts, GPIO_FUNC_UART);
+        gpio_set_inover(_cts, _invertControl ? 1 : 0);
     }
 
     uart_init(_uart, baud);
@@ -246,12 +253,16 @@ void SerialUART::end() {
 
     // Restore pin functions
     gpio_set_function(_tx, _fcnTx);
+    gpio_set_outover(_tx, 0);
     gpio_set_function(_rx, _fcnRx);
+    gpio_set_inover(_rx, 0);
     if (_rts != UART_PIN_NOT_DEFINED) {
         gpio_set_function(_rts, _fcnRts);
+        gpio_set_outover(_rts, 0);
     }
     if (_cts != UART_PIN_NOT_DEFINED) {
         gpio_set_function(_cts, _fcnCts);
+        gpio_set_inover(_cts, 0);
     }
 }
 

--- a/cores/rp2040/SerialUART.h
+++ b/cores/rp2040/SerialUART.h
@@ -43,6 +43,26 @@ public:
         ret &= setTX(tx);
         return ret;
     }
+
+    bool setInvertTX(bool invert = true) {
+        if (!_running) {
+            _invertTX = invert;
+        }
+        return !_running;
+    }
+    bool setInvertRX(bool invert = true) {
+        if (!_running) {
+            _invertRX = invert;
+        }
+        return !_running;
+    }
+    bool setInvertControl(bool invert = true) {
+        if (!_running) {
+            _invertControl = invert;
+        }
+        return !_running;
+    }
+
     bool setFIFOSize(size_t size);
     bool setPollingMode(bool mode = true);
 
@@ -86,6 +106,7 @@ private:
     bool _polling = false;
     bool _overflow;
     bool _break;
+    bool _invertTX, _invertRX, _invertControl;
 
     // Lockless, IRQ-handled circular queue
     uint32_t _writer;

--- a/cores/rp2040/SoftwareSerial.h
+++ b/cores/rp2040/SoftwareSerial.h
@@ -30,10 +30,6 @@ public:
     }
 
     ~SoftwareSerial() {
-        if (_invert) {
-            gpio_set_outover(_tx, 0);
-            gpio_set_outover(_rx, 0);
-        }
     }
 
     virtual void begin(unsigned long baud = 115200) override {
@@ -41,11 +37,9 @@ public:
     };
 
     void begin(unsigned long baud, uint16_t config) override {
+        setInvertTX(invert);
+        setInvertRX(invert);
         SerialPIO::begin(baud, config);
-        if (_invert) {
-            gpio_set_outover(_tx, GPIO_OVERRIDE_INVERT);
-            gpio_set_inover(_rx, GPIO_OVERRIDE_INVERT);
-        }
     }
 
     void listen() { /* noop */ }

--- a/cores/rp2040/pio_uart.pio
+++ b/cores/rp2040/pio_uart.pio
@@ -39,28 +39,6 @@ wait_bit:
     jmp y-- wait_bit
     jmp x-- bitloop
 
-    
-
-; inverted-logic version (inverts the stop bit)
-
-.program pio_tx_inv
-.side_set 1 opt
-
-
-; We shift out the start and stop bit as part of the FIFO
-    set x, 9
-
-    pull               side 0 ; Force stop bit low
-
-; Send the bits
-bitloop:
-    out pins, 1
-    mov y, isr                ; ISR is loaded by the setup routine with the period-1 count
-wait_bit:
-    jmp y-- wait_bit
-    jmp x-- bitloop
-
-
 % c-sdk {
 
 static inline void pio_tx_program_init(PIO pio, uint sm, uint offset, uint pin_tx) {
@@ -109,28 +87,6 @@ wait_half:
     jmp x-- bitloop     ; Loop all bits
     
     push                ; Stuff it and wait for next start
-
-
-.program pio_rx_inv
-
-; IN pin 0 and JMP pin are both mapped to the GPIO used as UART RX.
-
-start:
-    set x, 18           ; Preload bit counter...we'll shift in the start bit and stop bit, and each bit will be double-recorded (to be fixed by RP2040 code)
-    wait 1 pin 0        ; Stall until start bit is asserted
-
-bitloop:
-   ; Delay until 1/2 way into the bit time
-    mov y, osr
-wait_half:
-    jmp y-- wait_half
-
-    ; Read in the bit
-    in pins, 1          ; Shift data bit into ISR
-    jmp x-- bitloop     ; Loop all bits
-    
-    push                ; Stuff it and wait for next start
-
 
 % c-sdk {
 static inline void pio_rx_program_init(PIO pio, uint sm, uint offset, uint pin) {

--- a/cores/rp2040/pio_uart.pio.h
+++ b/cores/rp2040/pio_uart.pio.h
@@ -44,44 +44,6 @@ static inline pio_sm_config pio_tx_program_get_default_config(uint offset) {
     sm_config_set_sideset(&c, 2, true, false);
     return c;
 }
-#endif
-
-// ---------- //
-// pio_tx_inv //
-// ---------- //
-
-#define pio_tx_inv_wrap_target 0
-#define pio_tx_inv_wrap 5
-#define pio_tx_inv_pio_version 0
-
-static const uint16_t pio_tx_inv_program_instructions[] = {
-    //     .wrap_target
-    0xe029, //  0: set    x, 9
-    0x90a0, //  1: pull   block           side 0
-    0x6001, //  2: out    pins, 1
-    0xa046, //  3: mov    y, isr
-    0x0084, //  4: jmp    y--, 4
-    0x0042, //  5: jmp    x--, 2
-    //     .wrap
-};
-
-#if !PICO_NO_HARDWARE
-static const struct pio_program pio_tx_inv_program = {
-    .instructions = pio_tx_inv_program_instructions,
-    .length = 6,
-    .origin = -1,
-    .pio_version = 0,
-#if PICO_PIO_VERSION > 0
-    .used_gpio_ranges = 0x0
-#endif
-};
-
-static inline pio_sm_config pio_tx_inv_program_get_default_config(uint offset) {
-    pio_sm_config c = pio_get_default_sm_config();
-    sm_config_set_wrap(&c, offset + pio_tx_inv_wrap_target, offset + pio_tx_inv_wrap);
-    sm_config_set_sideset(&c, 2, true, false);
-    return c;
-}
 
 static inline void pio_tx_program_init(PIO pio, uint sm, uint offset, uint pin_tx) {
     // Tell PIO to initially drive output-high on the selected pin, then map PIO
@@ -138,44 +100,6 @@ static const struct pio_program pio_rx_program = {
 static inline pio_sm_config pio_rx_program_get_default_config(uint offset) {
     pio_sm_config c = pio_get_default_sm_config();
     sm_config_set_wrap(&c, offset + pio_rx_wrap_target, offset + pio_rx_wrap);
-    return c;
-}
-#endif
-
-// ---------- //
-// pio_rx_inv //
-// ---------- //
-
-#define pio_rx_inv_wrap_target 0
-#define pio_rx_inv_wrap 6
-#define pio_rx_inv_pio_version 0
-
-static const uint16_t pio_rx_inv_program_instructions[] = {
-    //     .wrap_target
-    0xe032, //  0: set    x, 18
-    0x20a0, //  1: wait   1 pin, 0
-    0xa047, //  2: mov    y, osr
-    0x0083, //  3: jmp    y--, 3
-    0x4001, //  4: in     pins, 1
-    0x0042, //  5: jmp    x--, 2
-    0x8020, //  6: push   block
-    //     .wrap
-};
-
-#if !PICO_NO_HARDWARE
-static const struct pio_program pio_rx_inv_program = {
-    .instructions = pio_rx_inv_program_instructions,
-    .length = 7,
-    .origin = -1,
-    .pio_version = 0,
-#if PICO_PIO_VERSION > 0
-    .used_gpio_ranges = 0x0
-#endif
-};
-
-static inline pio_sm_config pio_rx_inv_program_get_default_config(uint offset) {
-    pio_sm_config c = pio_get_default_sm_config();
-    sm_config_set_wrap(&c, offset + pio_rx_inv_wrap_target, offset + pio_rx_inv_wrap);
     return c;
 }
 

--- a/docs/piouart.rst
+++ b/docs/piouart.rst
@@ -23,6 +23,12 @@ For example, to make a transmit-only port on GP16
 For detailed information about the Serial ports, see the
 Arduino `Serial Reference <https://www.arduino.cc/reference/en/language/functions/communication/serial/>`_ .
 
+Inversion
+---------
+
+``SoftwareSerial`` and ``SerialPIO`` can both support inverted input and/or outputs via the methods
+``setInvertRX(bool invert)`` and ``setInvertTX(bool invert)``.
+
 
 SoftwareSerial Emulation
 ========================
@@ -31,7 +37,6 @@ with the Arduino `Software Serial <https://docs.arduino.cc/learn/built-in-librar
 library.  Use the normal ``#include <SoftwareSerial.h>`` to include it.   The following
 differences from the Arduino standard are present:
 
-* Inverted mode is not supported
 * All ports are always listening
 * ``listen`` call is a no-op
 * ``isListening()`` always returns ``true``

--- a/docs/serial.rst
+++ b/docs/serial.rst
@@ -47,6 +47,14 @@ For detailed information about the Serial ports, see the
 Arduino `Serial Reference <https://www.arduino.cc/reference/en/language/functions/communication/serial/>`_ .
 
 
+Inversion
+---------
+
+``Serial1`` and ``Serial2`` can both support inverted input and/or outputs via the methods
+``Serial1/2::setInvertRX(bool invert)`` and ``Serial1/2::setInvertTX(bool invert)`` and
+``Serial1/2::serInvertControl(bool invert)``.
+
+
 RP2040 Specific SerialUSB methods
 ---------------------------------
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -73,6 +73,9 @@ prepare	KEYWORD2
 SerialPIO	KEYWORD2
 setFIFOSize	KEYWORD2
 setPollingMode	KEYWORD2
+setInvertTX	KEYWORD2
+setInvertRX	KEYWORD2
+setInvertControl	KEYWORD2
 
 digitalWriteFast	KEYWORD2
 digitalReadFast	KEYWORD2


### PR DESCRIPTION
Use real GPIO pad inversion to allow inverted RX, TX, and controls for the hardware UART and software PIO-emulated serial ports.

Adds ``setInvertTX(bool)`` and ``setInvertRX(bool)`` calls to both ports, with ``setInvertControl(bool)`` for the HW UARTS.
