### PR TITLE
libraries/PDM/src/rp2040/pdm.pio.h: pio_gpio_init data in pin.

### DIFF
--- a/libraries/PDM/src/rp2040/pdm.pio.h
+++ b/libraries/PDM/src/rp2040/pdm.pio.h
@@ -54,7 +54,7 @@ static inline void pdm_pio_program_init(PIO pio, uint sm, uint offset, uint clkP
     pio_sm_set_consecutive_pindirs(pio, sm, dataPin, 1, false);
     pio_sm_set_consecutive_pindirs(pio, sm, clkPin, 1, true);
     pio_sm_set_pins_with_mask(pio, sm, 0, (1u << clkPin));
-    //pio_gpio_init(pio, dataPin);
+    pio_gpio_init(pio, dataPin);
     pio_gpio_init(pio, clkPin);
     pio_sm_init(pio, sm, offset, &c);
     pio_sm_set_enabled(pio, sm, true);


### PR DESCRIPTION
tl;dr: I had to uncomment the `pio_gpio_init` for the PDM mic data in pin in the PDM library to make code which previously worked on an RP2040 also work on an RP2350.  The modified library also still works with the RP2040 in my project.

Details:

I am using the PDM library to read a [PDM microphone](https://www.adafruit.com/product/4346).  I developed my code on a RP2040 Pico.  It is working correctly.

I recently obtained my first [RP2350 board](https://shop.pimoroni.com/products/pimoroni-pico-plus-2), which is intended to be pin-compatible with the Pico.  I plugged it in and my circuit worked, but the PDM mic was reading as a steady -128.  With a scope, I verified that the PDM clock was still being emitted at the right frequency, and the PDM data in pin was being driven by the mic.

It looked as if the input pin was reading a steady 0.  I saw that in the PIO initialization in the PDM library, there was a command to initialize the data in pin, but it was commented out.  The [pico-sdk documentation](https://www.raspberrypi.com/documentation/pico-sdk/hardware.html#group_hardware_pio_1gafa244b1be8f53a329db9d26298e054bb) claims that it is not necessary to use `pio_gpio_init` for input pins.  However, uncommenting this command made my code work correctly on the RP2350.  It also still works correctly on the RP2040. 