### PR TITLE
solderparty_rp2350_stamp_xl: Properly mark as using RP2350B

### DIFF
--- a/variants/solderparty_rp2350_stamp_xl/pins_arduino.h
+++ b/variants/solderparty_rp2350_stamp_xl/pins_arduino.h
@@ -3,6 +3,8 @@
 // Pin definitions taken from:
 //    https://rp2xxx-stamp-carrier-xl.solder.party/
 
+#define PICO_RP2350B   1
+
 // LEDs
 #define PIN_LED        (3u)
 


### PR DESCRIPTION
I saw the define was needed for the PGA2350, so I think it needs to be here as well.