### PR TITLE
Added mutex around malloc/free/... (not for PSRAM yet)

### DIFF
--- a/cores/rp2040/malloc-lock.cpp
+++ b/cores/rp2040/malloc-lock.cpp
@@ -21,6 +21,7 @@
 #include <Arduino.h>
 #include <malloc.h>
 #include <reent.h>
+#include "pico/mutex.h"
 #include "psram.h"
 
 extern "C" void *__real_malloc(size_t size);
@@ -28,6 +29,8 @@ extern "C" void *__real_calloc(size_t count, size_t size);
 extern "C" void *__real_realloc(void *mem, size_t size);
 extern "C" void __real_free(void *mem);
 extern "C" struct mallinfo __real_mallinfo();
+
+auto_init_mutex(malloc_lock_mutex);
 
 #ifdef RP2350_PSRAM_CS
 extern "C" {
@@ -41,14 +44,18 @@ extern "C" {
 
 extern "C" void *__wrap_malloc(size_t size) {
     noInterrupts();
+    mutex_enter_blocking(&malloc_lock_mutex);
     void *rc = __real_malloc(size);
+    mutex_exit(&malloc_lock_mutex);
     interrupts();
     return rc;
 }
 
 extern "C" void *__wrap_calloc(size_t count, size_t size) {
     noInterrupts();
+    mutex_enter_blocking(&malloc_lock_mutex);
     void *rc = __real_calloc(count, size);
+    mutex_exit(&malloc_lock_mutex);
     interrupts();
     return rc;
 }
@@ -85,7 +92,9 @@ extern "C" void *__wrap_realloc(void *mem, size_t size) {
         rc = __real_realloc(mem, size);
     }
 #else
+    mutex_enter_blocking(&malloc_lock_mutex);
     rc = __real_realloc(mem, size);
+    mutex_exit(&malloc_lock_mutex);
 #endif
     interrupts();
     return rc;
@@ -100,7 +109,9 @@ extern "C" void __wrap_free(void *mem) {
         __real_free(mem);
     }
 #else
+    mutex_enter_blocking(&malloc_lock_mutex);
     __real_free(mem);
+    mutex_exit(&malloc_lock_mutex);
 #endif
     interrupts();
 }


### PR DESCRIPTION
See discusion in #2428 for more background. I did some testing and there was no need to use the FreeRTOS heap management functions. Somehow it seems the wrapping of malloc in malloc-lock.cpp undoes the Pico-SDK wrapping (where there is a pico sdk mutex around the malloc function). I've added similar mutex to malloc-lock.cpp. This seems to work (can't generate a crash/lock anymore). 

Note I didn't put the mutexes around the PSRAM calls yet. Can't test this, have no PICO with PSRAM yet.
