### PR TITLE
Also remove CFG_TUSB_DEBUG from platformio-build.py for rp2350 -- fix for #2469

### DIFF
--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -127,7 +127,6 @@ elif chip == "rp2350":
             "ARDUINO_ARCH_RP2040",
             ("F_CPU", "$BOARD_F_CPU"),
             ("BOARD_NAME", '\\"%s\\"' % env.subst("$BOARD")),
-            ("CFG_TUSB_DEBUG", "0"),
             ("CFG_TUSB_MCU", "OPT_MCU_RP2040"),
             ("CFG_TUSB_OS", "OPT_OS_PICO"),
             ("LIB_BOOT_STAGE2_HEADERS", "1"),


### PR DESCRIPTION
New to the build system; forgot to also exclude CFG_TUSB_DEBUG from platformio-build.py:
https://github.com/earlephilhower/arduino-pico/blob/5fbda352820bb7476db5a29b1a4076640d018a04/tools/platformio-build.py#L130
