### PR TITLE
Don't realloc(nullptr) from PSRAM by default

### DIFF
--- a/cores/rp2040/malloc-lock.cpp
+++ b/cores/rp2040/malloc-lock.cpp
@@ -88,7 +88,7 @@ extern "C" void *__wrap_realloc(void *mem, size_t size) {
     void *rc;
     noInterrupts();
 #ifdef RP2350_PSRAM_CS
-    if (mem < __ram_start) {
+    if (mem && (mem < __ram_start)) {
         rc = __psram_realloc(mem, size);
     } else {
         rc = __real_realloc(mem, size);
@@ -103,7 +103,7 @@ extern "C" void *__wrap_realloc(void *mem, size_t size) {
 extern "C" void __wrap_free(void *mem) {
     noInterrupts();
 #ifdef RP2350_PSRAM_CS
-    if (mem < __ram_start) {
+    if (mem && (mem < __ram_start)) {
         __psram_free(mem);
     } else {
         __real_free(mem);


### PR DESCRIPTION
Several Arduino APIs realloc(NULL) which is legal and equivalent to "malloc()", but the PSRAM logic was placing those malloc calls in PSRAM and not RAM because "0" < RAM_START.

Ensure the realloc address is non-null and before RAM_START before using PSRAM.