### PR TITLE
I2C lib : implement "bus recovery" feature on timeout reset

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -392,7 +392,7 @@ void TwoWire::_handleTimeout(bool reset) {
                     digitalWrite(_sda, HIGH);
                 }
             }
-            
+
             setClock(prev_clkHz);
             begin();
         }

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -366,6 +366,33 @@ void TwoWire::_handleTimeout(bool reset) {
         } else {
             int prev_clkHz = _clkHz;
             end();
+
+            // Attempt bus recovery if SDA is held LOW by another device
+            // See RP2040 datasheet "Bus clear feature" (not implemented in HW)
+            int delay = 5; //5us LOW/HIGH -> 10us period -> 100kHz freq
+            pinMode(_sda, INPUT_PULLUP);
+            pinMode(_scl, INPUT_PULLUP);
+            gpio_set_function(_scl, GPIO_FUNC_SIO);
+            gpio_set_function(_sda, GPIO_FUNC_SIO);
+
+            if (digitalRead(_sda) == LOW) {
+                int sclPulseCount = 0;
+                while (sclPulseCount < 9 && digitalRead(_sda) == LOW) {
+                    sclPulseCount++;
+                    digitalWrite(_scl, LOW);
+                    sleep_us(delay);
+                    digitalWrite(_scl, HIGH);
+                    sleep_us(delay);
+                }
+
+                if (digitalRead(_sda) == HIGH) {
+                    // Bus recovered : send a STOP
+                    digitalWrite(_sda, LOW);
+                    sleep_us(delay);
+                    digitalWrite(_sda, HIGH);
+                }
+            }
+            
             setClock(prev_clkHz);
             begin();
         }


### PR DESCRIPTION
This feature is described in RP2040 datasheet chapter 4.3.13.1 but not implemented in hardware (see https://github.com/raspberrypi/pico-sdk/issues/1595) 
This commit implements it in software, based on code from the probe() function.

My I2C bus is much more robust with this addition :)