### PR TITLE
Fix SD compilation error

### DIFF
--- a/libraries/SDFS/src/SDFS.h
+++ b/libraries/SDFS/src/SDFS.h
@@ -284,7 +284,7 @@ public:
     }
 
     int availableForWrite() override {
-        return _opened ? _fd->availableSpaceForWrite() : 0;
+        return _opened ? _fd->availableForWrite() : 0;
     }
 
     size_t write(const uint8_t *buf, size_t size) override {


### PR DESCRIPTION
Trying to compile a simple sketch that includes the SD library for RP2040:

```cpp
#include <SD.h>
void setup() {
  // put your setup code here, to run once:

}

void loop() {
  // put your main code here, to run repeatedly:

}
```

leads to the error: 
```
packages/rp2040/hardware/rp2040/4.0.2/libraries/SDFS/src/SDFS.h:287:31: error: 'using element_type = class File32' {aka 'class File32'} has no member named 'availableSpaceForWrite'; did you mean 'availableForWrite'?
  287 |         return _opened ? _fd->availableSpaceForWrite() : 0;
      |                               ^~~~~~~~~~~~~~~~~~~~~~
      |                               availableForWrite
Multiple libraries were found for "SD.h"
  Used: /home/tom/.arduino15/packages/rp2040/hardware/rp2040/4.0.2/libraries/SD
  Not used: /home/tom/.arduino15/libraries/SD
  Not used: /home/tom/Arduino_sketchbook/libraries/SD
Multiple libraries were found for "SdFat.h"
  Used: /home/tom/Arduino_sketchbook/libraries/SdFat_-_Adafruit_Fork
  Not used: /home/tom/.arduino15/packages/rp2040/hardware/rp2040/4.0.2/libraries/ESP8266SdFat
```

This PR fixes the error, but I have not tried yet if that is actually the correct fix.

---

I spotted this with a code that used to work does not compile anymore. Let me know if that is caused by a stupid mistake on my side (that has happened before…)