### PR TITLE
Make USB manufacturer and product name customizable

### DIFF
--- a/cores/rp2040/RP2040USB.cpp
+++ b/cores/rp2040/RP2040USB.cpp
@@ -324,8 +324,16 @@ const uint16_t *tud_descriptor_string_cb(uint8_t index, uint16_t langid) {
 
     static const char *const usbd_desc_str[] = {
         [USBD_STR_0] = "",
+#ifdef CUSTOM_USB_MANUFACTURER
+        [USBD_STR_MANUF] = CUSTOM_USB_MANUFACTURER,
+#else
         [USBD_STR_MANUF] = USB_MANUFACTURER,
+#endif
+#ifdef CUSTOM_USB_PRODUCT
+        [USBD_STR_PRODUCT] = CUSTOM_USB_PRODUCT,
+#else
         [USBD_STR_PRODUCT] = USB_PRODUCT,
+#endif
         [USBD_STR_SERIAL] = idString,
         [USBD_STR_CDC] = "Board CDC",
 #ifdef ENABLE_PICOTOOL_USB


### PR DESCRIPTION
Some devices may pick ready to use rp2040 boards, but need an custom product name, to make configuring easier for example. This patch added customizable manufacturer and product name through `build_flags` (this is my present solution. better solution could be found in the future).