### PR TITLE
Fix compiling assembly

### DIFF
--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -293,7 +293,7 @@ else:
         "-iprefix" + os.path.join(FRAMEWORK_DIR),
         "@%s" % os.path.join(FRAMEWORK_DIR, "lib", chip, "platform_inc.txt"),
         "@%s" % os.path.join(FRAMEWORK_DIR, "lib", "core_inc.txt")
-    ])
+    ] + toolopts)
 
 def configure_usb_flags(cpp_defines):
     if "USE_TINYUSB" in cpp_defines:


### PR DESCRIPTION
The previous ones did not include the `-m..` machine flags when compiling assembly code, leading to linker errors.

Drive-by PR into the WIP riscv PR. Fixes `none.S` compilation and linking.

Wasn't needed for RP2040 files because they have 
```
.cpu cortex-m0plus
.thumb
```
in them to select the `-mcpu` `-mthumb` etc. In any case, this is a sane change to make -- we want other user assembly files to be compiled with the by-default right machine flags.