### PR TITLE
Update PIO platform before compile, add RISC-V PIO build to CI

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -265,10 +265,13 @@ jobs:
         python -m pip install --upgrade pip
         pip install --upgrade platformio
         pio pkg install --global --platform https://github.com/maxgerhardt/platform-raspberrypi.git
+        pio pkg update --global --platform https://github.com/maxgerhardt/platform-raspberrypi.git
         pio pkg install --global --tool symlink://.
         cp -f /home/runner/work/arduino-pico/arduino-pico/tools/json/*.json /home/runner/.platformio/platforms/raspberrypi/boards/.
     - name: Build Multicore Example
       run: pio ci -v --board=rpipico --board=rpipico2 --board=adafruit_feather -O "platform_packages=framework-arduinopico@symlink:///home/runner/work/arduino-pico/arduino-pico" libraries/rp2040/examples/Multicore/Multicore.ino
+    - name: Build Multicore Example (RISC-V)
+      run: pio ci -v --board=rpipico2 -O "board_build.mcu = rp2350-riscv" -O "platform_packages=framework-arduinopico@symlink:///home/runner/work/arduino-pico/arduino-pico" libraries/rp2040/examples/Multicore/Multicore.ino
     - name: Build Fade Example
       run: pio ci --board=rpipico --board=adafruit_feather -O "platform_packages=framework-arduinopico@symlink:///home/runner/work/arduino-pico/arduino-pico" libraries/rp2040/examples/Fade/Fade.ino
     - name: Build TinyUSB Example


### PR DESCRIPTION
Should eliminate the need to occassionally delete the cache for PlatformIO.

The cache is still restored at the stard and the state at the end gets cached, so we still retain the speed advantage if nothing changed in the platform.