### PR TITLE
Update PIO USB docs, fixup used VID/PID macros

### DIFF
--- a/docs/platformio.rst
+++ b/docs/platformio.rst
@@ -262,6 +262,18 @@ default Pico SDK USB stack. To change it, add
 Note that the special "No USB" setting is also supported, through the
 shortcut-define ``PIO_FRAMEWORK_ARDUINO_NO_USB``.
 
+USB Customization
+-----------------
+
+If you want to change the USB VID, PID, product or manufacturer name that the device will appear under, configure them as follows:
+
+.. code:: ini
+
+    board_build.arduino.earlephilhower.usb_manufacturer = Custom Manufacturer
+    board_build.arduino.earlephilhower.usb_product = Ultra Cool Product
+    board_build.arduino.earlephilhower.usb_vid = 0xABCD
+    board_build.arduino.earlephilhower.usb_pid = 0x1337
+
 IP Stack
 --------
 

--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -337,11 +337,15 @@ def configure_usb_flags(cpp_defines):
 
     env.Append(CPPDEFINES=[
         ("CFG_TUSB_MCU", "OPT_MCU_RP2040"),
+        # used by TinyUSB stack
         ("USB_VID", usb_vid),
         ("USB_PID", usb_pid),
+        # Used by native USB stack
+        ("USBD_VID", usb_vid),
+        ("USBD_PID", usb_pid),
+        # Used by both stacks
         ("USB_MANUFACTURER", '\\"%s\\"' % usb_manufacturer),
-        ("USB_PRODUCT", '\\"%s\\"' % usb_product),
-        ("SERIALUSB_PID", usb_pid)
+        ("USB_PRODUCT", '\\"%s\\"' % usb_product)
     ])
 
     if "USBD_MAX_POWER_MA" not in env.Flatten(env.get("CPPDEFINES", [])):


### PR DESCRIPTION
Supersedes https://github.com/earlephilhower/arduino-pico/pull/2487

Adds documentation for changing USB VID, PID, manufacturer and product.

Updates used macros.

Confirmed working with
```ini
[env]
platform = raspberrypi
framework = arduino
board_build.arduino.earlephilhower.usb_manufacturer = Custom Manufacturer
board_build.arduino.earlephilhower.usb_product = Ultra Cool Product
board_build.arduino.earlephilhower.usb_vid = 0xABCD
board_build.arduino.earlephilhower.usb_pid = 0x1337

[env:picow]
board = rpipicow
```

![grafik](https://github.com/user-attachments/assets/0387f791-6944-4daf-bdd7-d51241b64361)


