### PR TITLE
Arduino's EEPROMM.length() method should return the number of bytes a…

### DIFF
--- a/libraries/EEPROM/src/EEPROM.h
+++ b/libraries/EEPROM/src/EEPROM.h
@@ -66,7 +66,7 @@ public:
         return put(address, t);
     }
     size_t length() {
-        return _size;
+        return 4096;
     }
 
     uint8_t& operator[](int const address) {


### PR DESCRIPTION
As discussed in (#2506). I would have loved to test it but apparently the toolchain doesn't agree with my system. 