### PR TITLE
Allow IDE install to call RISC-V compiler

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -65,6 +65,7 @@ rpipico.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 rpipico.build.board=RASPBERRY_PI_PICO
 rpipico.build.chip=rp2040
 rpipico.build.toolchain=arm-none-eabi
+rpipico.build.toolchainpkg=pqt-gcc
 rpipico.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 rpipico.build.uf2family=--family rp2040
 rpipico.build.variant=rpipico
@@ -269,6 +270,7 @@ rpipicow.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 rpipicow.build.board=RASPBERRY_PI_PICO_W
 rpipicow.build.chip=rp2040
 rpipicow.build.toolchain=arm-none-eabi
+rpipicow.build.toolchainpkg=pqt-gcc
 rpipicow.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 rpipicow.build.uf2family=--family rp2040
 rpipicow.build.variant=rpipicow
@@ -672,11 +674,13 @@ rpipico2.menu.flash.4194304_3145728.build.fs_end=272621568
 rpipico2.menu.arch.arm=ARM
 rpipico2.menu.arch.arm.build.chip=rp2350
 rpipico2.menu.arch.arm.build.toolchain=arm-none-eabi
+rpipico2.menu.arch.arm.build.toolchainpkg=pqt-gcc
 rpipico2.menu.arch.arm.build.toolchainopts=-mcpu=cortex-m33 -mthumb -march=armv8-m.main+fp+dsp -mfloat-abi=softfp -mcmse
 rpipico2.menu.arch.arm.build.uf2family=--family rp2350-arm-s --abs-block
 rpipico2.menu.arch.riscv=RISC-V
 rpipico2.menu.arch.riscv.build.chip=rp2350-riscv
 rpipico2.menu.arch.riscv.build.toolchain=riscv32-unknown-elf
+rpipico2.menu.arch.riscv.build.toolchainpkg=pqt-gcc-riscv
 rpipico2.menu.arch.riscv.build.toolchainopts=-march=rv32imac_zicsr_zifencei_zba_zbb_zbs_zbkb -mabi=ilp32
 rpipico2.menu.arch.riscv.build.uf2family=--family rp2350-riscv --abs-block
 rpipico2.menu.freq.150=150 MHz
@@ -822,6 +826,7 @@ rpipico2.menu.uploadmethod.picoprobe_cmsis_dap.upload.tool.default=picoprobe_cms
 0xcb_helios.build.board=0XCB_HELIOS
 0xcb_helios.build.chip=rp2040
 0xcb_helios.build.toolchain=arm-none-eabi
+0xcb_helios.build.toolchainpkg=pqt-gcc
 0xcb_helios.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 0xcb_helios.build.uf2family=--family rp2040
 0xcb_helios.build.variant=0xcb_helios
@@ -1132,6 +1137,7 @@ adafruit_feather.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 adafruit_feather.build.board=ADAFRUIT_FEATHER_RP2040
 adafruit_feather.build.chip=rp2040
 adafruit_feather.build.toolchain=arm-none-eabi
+adafruit_feather.build.toolchainpkg=pqt-gcc
 adafruit_feather.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 adafruit_feather.build.uf2family=--family rp2040
 adafruit_feather.build.variant=adafruit_feather
@@ -1378,6 +1384,7 @@ adafruit_feather_scorpio.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 adafruit_feather_scorpio.build.board=ADAFRUIT_FEATHER_RP2040_SCORPIO
 adafruit_feather_scorpio.build.chip=rp2040
 adafruit_feather_scorpio.build.toolchain=arm-none-eabi
+adafruit_feather_scorpio.build.toolchainpkg=pqt-gcc
 adafruit_feather_scorpio.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 adafruit_feather_scorpio.build.uf2family=--family rp2040
 adafruit_feather_scorpio.build.variant=adafruit_feather_scorpio
@@ -1628,6 +1635,7 @@ adafruit_feather_dvi.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 adafruit_feather_dvi.build.board=ADAFRUIT_FEATHER_RP2040_DVI
 adafruit_feather_dvi.build.chip=rp2040
 adafruit_feather_dvi.build.toolchain=arm-none-eabi
+adafruit_feather_dvi.build.toolchainpkg=pqt-gcc
 adafruit_feather_dvi.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 adafruit_feather_dvi.build.uf2family=--family rp2040
 adafruit_feather_dvi.build.variant=adafruit_feather_dvi
@@ -1878,6 +1886,7 @@ adafruit_feather_adalogger.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 adafruit_feather_adalogger.build.board=ADAFRUIT_FEATHER_RP2040_ADALOGGER
 adafruit_feather_adalogger.build.chip=rp2040
 adafruit_feather_adalogger.build.toolchain=arm-none-eabi
+adafruit_feather_adalogger.build.toolchainpkg=pqt-gcc
 adafruit_feather_adalogger.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 adafruit_feather_adalogger.build.uf2family=--family rp2040
 adafruit_feather_adalogger.build.variant=adafruit_feather_adalogger
@@ -2128,6 +2137,7 @@ adafruit_feather_rfm.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 adafruit_feather_rfm.build.board=ADAFRUIT_FEATHER_RP2040_RFM
 adafruit_feather_rfm.build.chip=rp2040
 adafruit_feather_rfm.build.toolchain=arm-none-eabi
+adafruit_feather_rfm.build.toolchainpkg=pqt-gcc
 adafruit_feather_rfm.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 adafruit_feather_rfm.build.uf2family=--family rp2040
 adafruit_feather_rfm.build.variant=adafruit_feather_rfm
@@ -2378,6 +2388,7 @@ adafruit_feather_thinkink.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 adafruit_feather_thinkink.build.board=ADAFRUIT_FEATHER_RP2040_THINKINK
 adafruit_feather_thinkink.build.chip=rp2040
 adafruit_feather_thinkink.build.toolchain=arm-none-eabi
+adafruit_feather_thinkink.build.toolchainpkg=pqt-gcc
 adafruit_feather_thinkink.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 adafruit_feather_thinkink.build.uf2family=--family rp2040
 adafruit_feather_thinkink.build.variant=adafruit_feather_thinkink
@@ -2628,6 +2639,7 @@ adafruit_feather_usb_host.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 adafruit_feather_usb_host.build.board=ADAFRUIT_FEATHER_RP2040_USB_HOST
 adafruit_feather_usb_host.build.chip=rp2040
 adafruit_feather_usb_host.build.toolchain=arm-none-eabi
+adafruit_feather_usb_host.build.toolchainpkg=pqt-gcc
 adafruit_feather_usb_host.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 adafruit_feather_usb_host.build.uf2family=--family rp2040
 adafruit_feather_usb_host.build.variant=adafruit_feather_usb_host
@@ -2878,6 +2890,7 @@ adafruit_feather_can.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 adafruit_feather_can.build.board=ADAFRUIT_FEATHER_RP2040_CAN
 adafruit_feather_can.build.chip=rp2040
 adafruit_feather_can.build.toolchain=arm-none-eabi
+adafruit_feather_can.build.toolchainpkg=pqt-gcc
 adafruit_feather_can.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 adafruit_feather_can.build.uf2family=--family rp2040
 adafruit_feather_can.build.variant=adafruit_feather_can
@@ -3128,6 +3141,7 @@ adafruit_feather_prop_maker.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 adafruit_feather_prop_maker.build.board=ADAFRUIT_FEATHER_RP2040_PROP_MAKER
 adafruit_feather_prop_maker.build.chip=rp2040
 adafruit_feather_prop_maker.build.toolchain=arm-none-eabi
+adafruit_feather_prop_maker.build.toolchainpkg=pqt-gcc
 adafruit_feather_prop_maker.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 adafruit_feather_prop_maker.build.uf2family=--family rp2040
 adafruit_feather_prop_maker.build.variant=adafruit_feather_prop_maker
@@ -3386,6 +3400,7 @@ adafruit_itsybitsy.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 adafruit_itsybitsy.build.board=ADAFRUIT_ITSYBITSY_RP2040
 adafruit_itsybitsy.build.chip=rp2040
 adafruit_itsybitsy.build.toolchain=arm-none-eabi
+adafruit_itsybitsy.build.toolchainpkg=pqt-gcc
 adafruit_itsybitsy.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 adafruit_itsybitsy.build.uf2family=--family rp2040
 adafruit_itsybitsy.build.variant=adafruit_itsybitsy
@@ -3636,6 +3651,7 @@ adafruit_metro.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 adafruit_metro.build.board=ADAFRUIT_METRO_RP2040
 adafruit_metro.build.chip=rp2040
 adafruit_metro.build.toolchain=arm-none-eabi
+adafruit_metro.build.toolchainpkg=pqt-gcc
 adafruit_metro.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 adafruit_metro.build.uf2family=--family rp2040
 adafruit_metro.build.variant=adafruit_metro
@@ -3950,6 +3966,7 @@ adafruit_qtpy.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 adafruit_qtpy.build.board=ADAFRUIT_QTPY_RP2040
 adafruit_qtpy.build.chip=rp2040
 adafruit_qtpy.build.toolchain=arm-none-eabi
+adafruit_qtpy.build.toolchainpkg=pqt-gcc
 adafruit_qtpy.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 adafruit_qtpy.build.uf2family=--family rp2040
 adafruit_qtpy.build.variant=adafruit_qtpy
@@ -4208,6 +4225,7 @@ adafruit_stemmafriend.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 adafruit_stemmafriend.build.board=ADAFRUIT_STEMMAFRIEND_RP2040
 adafruit_stemmafriend.build.chip=rp2040
 adafruit_stemmafriend.build.toolchain=arm-none-eabi
+adafruit_stemmafriend.build.toolchainpkg=pqt-gcc
 adafruit_stemmafriend.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 adafruit_stemmafriend.build.uf2family=--family rp2040
 adafruit_stemmafriend.build.variant=adafruit_stemmafriend
@@ -4458,6 +4476,7 @@ adafruit_trinkeyrp2040qt.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 adafruit_trinkeyrp2040qt.build.board=ADAFRUIT_TRINKEYQT_RP2040
 adafruit_trinkeyrp2040qt.build.chip=rp2040
 adafruit_trinkeyrp2040qt.build.toolchain=arm-none-eabi
+adafruit_trinkeyrp2040qt.build.toolchainpkg=pqt-gcc
 adafruit_trinkeyrp2040qt.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 adafruit_trinkeyrp2040qt.build.uf2family=--family rp2040
 adafruit_trinkeyrp2040qt.build.variant=adafruit_trinkeyrp2040qt
@@ -4708,6 +4727,7 @@ adafruit_macropad2040.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 adafruit_macropad2040.build.board=ADAFRUIT_MACROPAD_RP2040
 adafruit_macropad2040.build.chip=rp2040
 adafruit_macropad2040.build.toolchain=arm-none-eabi
+adafruit_macropad2040.build.toolchainpkg=pqt-gcc
 adafruit_macropad2040.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 adafruit_macropad2040.build.uf2family=--family rp2040
 adafruit_macropad2040.build.variant=adafruit_macropad2040
@@ -4958,6 +4978,7 @@ adafruit_kb2040.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 adafruit_kb2040.build.board=ADAFRUIT_KB2040_RP2040
 adafruit_kb2040.build.chip=rp2040
 adafruit_kb2040.build.toolchain=arm-none-eabi
+adafruit_kb2040.build.toolchainpkg=pqt-gcc
 adafruit_kb2040.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 adafruit_kb2040.build.uf2family=--family rp2040
 adafruit_kb2040.build.variant=adafruit_kb2040
@@ -5307,11 +5328,13 @@ adafruit_feather_rp2350_hstx.menu.flash.8388608_7340032.build.fs_end=276815872
 adafruit_feather_rp2350_hstx.menu.arch.arm=ARM
 adafruit_feather_rp2350_hstx.menu.arch.arm.build.chip=rp2350
 adafruit_feather_rp2350_hstx.menu.arch.arm.build.toolchain=arm-none-eabi
+adafruit_feather_rp2350_hstx.menu.arch.arm.build.toolchainpkg=pqt-gcc
 adafruit_feather_rp2350_hstx.menu.arch.arm.build.toolchainopts=-mcpu=cortex-m33 -mthumb -march=armv8-m.main+fp+dsp -mfloat-abi=softfp -mcmse
 adafruit_feather_rp2350_hstx.menu.arch.arm.build.uf2family=--family rp2350-arm-s --abs-block
 adafruit_feather_rp2350_hstx.menu.arch.riscv=RISC-V
 adafruit_feather_rp2350_hstx.menu.arch.riscv.build.chip=rp2350-riscv
 adafruit_feather_rp2350_hstx.menu.arch.riscv.build.toolchain=riscv32-unknown-elf
+adafruit_feather_rp2350_hstx.menu.arch.riscv.build.toolchainpkg=pqt-gcc-riscv
 adafruit_feather_rp2350_hstx.menu.arch.riscv.build.toolchainopts=-march=rv32imac_zicsr_zifencei_zba_zbb_zbs_zbkb -mabi=ilp32
 adafruit_feather_rp2350_hstx.menu.arch.riscv.build.uf2family=--family rp2350-riscv --abs-block
 adafruit_feather_rp2350_hstx.menu.freq.150=150 MHz
@@ -5457,6 +5480,7 @@ amken_bunny.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 amken_bunny.build.board=AMKEN_BB
 amken_bunny.build.chip=rp2040
 amken_bunny.build.toolchain=arm-none-eabi
+amken_bunny.build.toolchainpkg=pqt-gcc
 amken_bunny.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 amken_bunny.build.uf2family=--family rp2040
 amken_bunny.build.variant=amken_bunny
@@ -6540,6 +6564,7 @@ amken_revelop.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 amken_revelop.build.board=AMKEN_REVELOP
 amken_revelop.build.chip=rp2040
 amken_revelop.build.toolchain=arm-none-eabi
+amken_revelop.build.toolchainpkg=pqt-gcc
 amken_revelop.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 amken_revelop.build.uf2family=--family rp2040
 amken_revelop.build.variant=amken_revelop
@@ -6951,6 +6976,7 @@ amken_revelop_plus.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 amken_revelop_plus.build.board=AMKEN_REVELOP_PLUS
 amken_revelop_plus.build.chip=rp2040
 amken_revelop_plus.build.toolchain=arm-none-eabi
+amken_revelop_plus.build.toolchainpkg=pqt-gcc
 amken_revelop_plus.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 amken_revelop_plus.build.uf2family=--family rp2040
 amken_revelop_plus.build.variant=amken_revelop_plus
@@ -7362,6 +7388,7 @@ amken_revelop_es.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 amken_revelop_es.build.board=AMKEN_ES
 amken_revelop_es.build.chip=rp2040
 amken_revelop_es.build.toolchain=arm-none-eabi
+amken_revelop_es.build.toolchainpkg=pqt-gcc
 amken_revelop_es.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 amken_revelop_es.build.uf2family=--family rp2040
 amken_revelop_es.build.variant=amken_revelop_es
@@ -7673,6 +7700,7 @@ arduino_nano_connect.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 arduino_nano_connect.build.board=NANO_RP2040_CONNECT
 arduino_nano_connect.build.chip=rp2040
 arduino_nano_connect.build.toolchain=arm-none-eabi
+arduino_nano_connect.build.toolchainpkg=pqt-gcc
 arduino_nano_connect.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 arduino_nano_connect.build.uf2family=--family rp2040
 arduino_nano_connect.build.variant=arduino_nano_connect
@@ -7999,6 +8027,7 @@ artronshop_rp2_nano.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 artronshop_rp2_nano.build.board=ARTRONSHOP_RP2_NANO
 artronshop_rp2_nano.build.chip=rp2040
 artronshop_rp2_nano.build.toolchain=arm-none-eabi
+artronshop_rp2_nano.build.toolchainpkg=pqt-gcc
 artronshop_rp2_nano.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 artronshop_rp2_nano.build.uf2family=--family rp2040
 artronshop_rp2_nano.build.variant=artronshop_rp2_nano
@@ -8227,6 +8256,7 @@ breadstick_raspberry.build.usbpwr=-DUSBD_MAX_POWER_MA=500
 breadstick_raspberry.build.board=Breadstick_Raspberry
 breadstick_raspberry.build.chip=rp2040
 breadstick_raspberry.build.toolchain=arm-none-eabi
+breadstick_raspberry.build.toolchainpkg=pqt-gcc
 breadstick_raspberry.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 breadstick_raspberry.build.uf2family=--family rp2040
 breadstick_raspberry.build.variant=breadstick_raspberry
@@ -8553,6 +8583,7 @@ bridgetek_idm2040_7a.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 bridgetek_idm2040_7a.build.board=BRIDGETEK_IDM2040_7A
 bridgetek_idm2040_7a.build.chip=rp2040
 bridgetek_idm2040_7a.build.toolchain=arm-none-eabi
+bridgetek_idm2040_7a.build.toolchainpkg=pqt-gcc
 bridgetek_idm2040_7a.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 bridgetek_idm2040_7a.build.uf2family=--family rp2040
 bridgetek_idm2040_7a.build.variant=bridgetek_idm2040_7a
@@ -8800,6 +8831,7 @@ bridgetek_idm2040_43a.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 bridgetek_idm2040_43a.build.board=BRIDGETEK_IDM2040_43A
 bridgetek_idm2040_43a.build.chip=rp2040
 bridgetek_idm2040_43a.build.toolchain=arm-none-eabi
+bridgetek_idm2040_43a.build.toolchainpkg=pqt-gcc
 bridgetek_idm2040_43a.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 bridgetek_idm2040_43a.build.uf2family=--family rp2040
 bridgetek_idm2040_43a.build.variant=bridgetek_idm2040_43a
@@ -9128,11 +9160,13 @@ cytron_iriv_io_controller.menu.flash.2097152_1048576.build.fs_end=270524416
 cytron_iriv_io_controller.menu.arch.arm=ARM
 cytron_iriv_io_controller.menu.arch.arm.build.chip=rp2350
 cytron_iriv_io_controller.menu.arch.arm.build.toolchain=arm-none-eabi
+cytron_iriv_io_controller.menu.arch.arm.build.toolchainpkg=pqt-gcc
 cytron_iriv_io_controller.menu.arch.arm.build.toolchainopts=-mcpu=cortex-m33 -mthumb -march=armv8-m.main+fp+dsp -mfloat-abi=softfp -mcmse
 cytron_iriv_io_controller.menu.arch.arm.build.uf2family=--family rp2350-arm-s --abs-block
 cytron_iriv_io_controller.menu.arch.riscv=RISC-V
 cytron_iriv_io_controller.menu.arch.riscv.build.chip=rp2350-riscv
 cytron_iriv_io_controller.menu.arch.riscv.build.toolchain=riscv32-unknown-elf
+cytron_iriv_io_controller.menu.arch.riscv.build.toolchainpkg=pqt-gcc-riscv
 cytron_iriv_io_controller.menu.arch.riscv.build.toolchainopts=-march=rv32imac_zicsr_zifencei_zba_zbb_zbs_zbkb -mabi=ilp32
 cytron_iriv_io_controller.menu.arch.riscv.build.uf2family=--family rp2350-riscv --abs-block
 cytron_iriv_io_controller.menu.freq.150=150 MHz
@@ -9306,6 +9340,7 @@ cytron_maker_nano_rp2040.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 cytron_maker_nano_rp2040.build.board=CYTRON_MAKER_NANO_RP2040
 cytron_maker_nano_rp2040.build.chip=rp2040
 cytron_maker_nano_rp2040.build.toolchain=arm-none-eabi
+cytron_maker_nano_rp2040.build.toolchainpkg=pqt-gcc
 cytron_maker_nano_rp2040.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 cytron_maker_nano_rp2040.build.uf2family=--family rp2040
 cytron_maker_nano_rp2040.build.variant=cytron_maker_nano_rp2040
@@ -9534,6 +9569,7 @@ cytron_maker_pi_rp2040.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 cytron_maker_pi_rp2040.build.board=CYTRON_MAKER_PI_RP2040
 cytron_maker_pi_rp2040.build.chip=rp2040
 cytron_maker_pi_rp2040.build.toolchain=arm-none-eabi
+cytron_maker_pi_rp2040.build.toolchainpkg=pqt-gcc
 cytron_maker_pi_rp2040.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 cytron_maker_pi_rp2040.build.uf2family=--family rp2040
 cytron_maker_pi_rp2040.build.variant=cytron_maker_pi_rp2040
@@ -9762,6 +9798,7 @@ cytron_maker_uno_rp2040.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 cytron_maker_uno_rp2040.build.board=CYTRON_MAKER_UNO_RP2040
 cytron_maker_uno_rp2040.build.chip=rp2040
 cytron_maker_uno_rp2040.build.toolchain=arm-none-eabi
+cytron_maker_uno_rp2040.build.toolchainpkg=pqt-gcc
 cytron_maker_uno_rp2040.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 cytron_maker_uno_rp2040.build.uf2family=--family rp2040
 cytron_maker_uno_rp2040.build.variant=cytron_maker_uno_rp2040
@@ -10047,11 +10084,13 @@ cytron_motion_2350_pro.menu.flash.2097152_1048576.build.fs_end=270524416
 cytron_motion_2350_pro.menu.arch.arm=ARM
 cytron_motion_2350_pro.menu.arch.arm.build.chip=rp2350
 cytron_motion_2350_pro.menu.arch.arm.build.toolchain=arm-none-eabi
+cytron_motion_2350_pro.menu.arch.arm.build.toolchainpkg=pqt-gcc
 cytron_motion_2350_pro.menu.arch.arm.build.toolchainopts=-mcpu=cortex-m33 -mthumb -march=armv8-m.main+fp+dsp -mfloat-abi=softfp -mcmse
 cytron_motion_2350_pro.menu.arch.arm.build.uf2family=--family rp2350-arm-s --abs-block
 cytron_motion_2350_pro.menu.arch.riscv=RISC-V
 cytron_motion_2350_pro.menu.arch.riscv.build.chip=rp2350-riscv
 cytron_motion_2350_pro.menu.arch.riscv.build.toolchain=riscv32-unknown-elf
+cytron_motion_2350_pro.menu.arch.riscv.build.toolchainpkg=pqt-gcc-riscv
 cytron_motion_2350_pro.menu.arch.riscv.build.toolchainopts=-march=rv32imac_zicsr_zifencei_zba_zbb_zbs_zbkb -mabi=ilp32
 cytron_motion_2350_pro.menu.arch.riscv.build.uf2family=--family rp2350-riscv --abs-block
 cytron_motion_2350_pro.menu.freq.150=150 MHz
@@ -10225,6 +10264,7 @@ datanoisetv_picoadk.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 datanoisetv_picoadk.build.board=DATANOISETV_PICOADK
 datanoisetv_picoadk.build.chip=rp2040
 datanoisetv_picoadk.build.toolchain=arm-none-eabi
+datanoisetv_picoadk.build.toolchainpkg=pqt-gcc
 datanoisetv_picoadk.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 datanoisetv_picoadk.build.uf2family=--family rp2040
 datanoisetv_picoadk.build.variant=datanoisetv_picoadk
@@ -10524,11 +10564,13 @@ datanoisetv_picoadk_v2.menu.flash.4194304_3145728.build.fs_end=272621568
 datanoisetv_picoadk_v2.menu.arch.arm=ARM
 datanoisetv_picoadk_v2.menu.arch.arm.build.chip=rp2350
 datanoisetv_picoadk_v2.menu.arch.arm.build.toolchain=arm-none-eabi
+datanoisetv_picoadk_v2.menu.arch.arm.build.toolchainpkg=pqt-gcc
 datanoisetv_picoadk_v2.menu.arch.arm.build.toolchainopts=-mcpu=cortex-m33 -mthumb -march=armv8-m.main+fp+dsp -mfloat-abi=softfp -mcmse
 datanoisetv_picoadk_v2.menu.arch.arm.build.uf2family=--family rp2350-arm-s --abs-block
 datanoisetv_picoadk_v2.menu.arch.riscv=RISC-V
 datanoisetv_picoadk_v2.menu.arch.riscv.build.chip=rp2350-riscv
 datanoisetv_picoadk_v2.menu.arch.riscv.build.toolchain=riscv32-unknown-elf
+datanoisetv_picoadk_v2.menu.arch.riscv.build.toolchainpkg=pqt-gcc-riscv
 datanoisetv_picoadk_v2.menu.arch.riscv.build.toolchainopts=-march=rv32imac_zicsr_zifencei_zba_zbb_zbs_zbkb -mabi=ilp32
 datanoisetv_picoadk_v2.menu.arch.riscv.build.uf2family=--family rp2350-riscv --abs-block
 datanoisetv_picoadk_v2.menu.freq.150=150 MHz
@@ -10678,6 +10720,7 @@ degz_suibo.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 degz_suibo.build.board=DEGZ_SUIBO_RP2040
 degz_suibo.build.chip=rp2040
 degz_suibo.build.toolchain=arm-none-eabi
+degz_suibo.build.toolchainpkg=pqt-gcc
 degz_suibo.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 degz_suibo.build.uf2family=--family rp2040
 degz_suibo.build.variant=degz_suibo
@@ -11004,6 +11047,7 @@ flyboard2040_core.build.usbpwr=-DUSBD_MAX_POWER_MA=500
 flyboard2040_core.build.board=FLYBOARD2040_CORE
 flyboard2040_core.build.chip=rp2040
 flyboard2040_core.build.toolchain=arm-none-eabi
+flyboard2040_core.build.toolchainpkg=pqt-gcc
 flyboard2040_core.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 flyboard2040_core.build.uf2family=--family rp2040
 flyboard2040_core.build.variant=flyboard2040_core
@@ -11230,6 +11274,7 @@ dfrobot_beetle_rp2040.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 dfrobot_beetle_rp2040.build.board=DFROBOT_BEETLE_RP2040
 dfrobot_beetle_rp2040.build.chip=rp2040
 dfrobot_beetle_rp2040.build.toolchain=arm-none-eabi
+dfrobot_beetle_rp2040.build.toolchainpkg=pqt-gcc
 dfrobot_beetle_rp2040.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 dfrobot_beetle_rp2040.build.uf2family=--family rp2040
 dfrobot_beetle_rp2040.build.variant=dfrobot_beetle_rp2040
@@ -11458,6 +11503,7 @@ DudesCab.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 DudesCab.build.board=RASPBERRY_PI_PICO
 DudesCab.build.chip=rp2040
 DudesCab.build.toolchain=arm-none-eabi
+DudesCab.build.toolchainpkg=pqt-gcc
 DudesCab.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 DudesCab.build.uf2family=--family rp2040
 DudesCab.build.variant=DudesCab
@@ -11700,6 +11746,7 @@ electroniccats_huntercat_nfc.build.usbpwr=-DUSBD_MAX_POWER_MA=500
 electroniccats_huntercat_nfc.build.board=ELECTRONICCATS_HUNTERCAT_NFC
 electroniccats_huntercat_nfc.build.chip=rp2040
 electroniccats_huntercat_nfc.build.toolchain=arm-none-eabi
+electroniccats_huntercat_nfc.build.toolchainpkg=pqt-gcc
 electroniccats_huntercat_nfc.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 electroniccats_huntercat_nfc.build.uf2family=--family rp2040
 electroniccats_huntercat_nfc.build.variant=electroniccats_huntercat_nfc
@@ -11904,6 +11951,7 @@ evn_alpha.build.usbpwr=-DUSBD_MAX_POWER_MA=500
 evn_alpha.build.board=EVN_ALPHA
 evn_alpha.build.chip=rp2040
 evn_alpha.build.toolchain=arm-none-eabi
+evn_alpha.build.toolchainpkg=pqt-gcc
 evn_alpha.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 evn_alpha.build.uf2family=--family rp2040
 evn_alpha.build.variant=evn_alpha
@@ -12206,6 +12254,7 @@ extelec_rc2040.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 extelec_rc2040.build.board=EXTREMEELEXTRONICS_RC2040
 extelec_rc2040.build.chip=rp2040
 extelec_rc2040.build.toolchain=arm-none-eabi
+extelec_rc2040.build.toolchainpkg=pqt-gcc
 extelec_rc2040.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 extelec_rc2040.build.uf2family=--family rp2040
 extelec_rc2040.build.variant=extelec_rc2040
@@ -12434,6 +12483,7 @@ groundstudio_marble_pico.build.usbpwr=-DUSBD_MAX_POWER_MA=500
 groundstudio_marble_pico.build.board=MARBLE_PICO
 groundstudio_marble_pico.build.chip=rp2040
 groundstudio_marble_pico.build.toolchain=arm-none-eabi
+groundstudio_marble_pico.build.toolchainpkg=pqt-gcc
 groundstudio_marble_pico.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 groundstudio_marble_pico.build.uf2family=--family rp2040
 groundstudio_marble_pico.build.variant=groundstudio_marble_pico
@@ -12704,6 +12754,7 @@ challenger_2040_lte.build.usbpwr=-DUSBD_MAX_POWER_MA=500
 challenger_2040_lte.build.board=CHALLENGER_2040_LTE_RP2040
 challenger_2040_lte.build.chip=rp2040
 challenger_2040_lte.build.toolchain=arm-none-eabi
+challenger_2040_lte.build.toolchainpkg=pqt-gcc
 challenger_2040_lte.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 challenger_2040_lte.build.uf2family=--family rp2040
 challenger_2040_lte.build.variant=challenger_2040_lte
@@ -12974,6 +13025,7 @@ challenger_2040_lora.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 challenger_2040_lora.build.board=CHALLENGER_2040_LORA_RP2040
 challenger_2040_lora.build.chip=rp2040
 challenger_2040_lora.build.toolchain=arm-none-eabi
+challenger_2040_lora.build.toolchainpkg=pqt-gcc
 challenger_2040_lora.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 challenger_2040_lora.build.uf2family=--family rp2040
 challenger_2040_lora.build.variant=challenger_2040_lora
@@ -13244,6 +13296,7 @@ challenger_2040_subghz.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 challenger_2040_subghz.build.board=CHALLENGER_2040_SUBGHZ_RP2040
 challenger_2040_subghz.build.chip=rp2040
 challenger_2040_subghz.build.toolchain=arm-none-eabi
+challenger_2040_subghz.build.toolchainpkg=pqt-gcc
 challenger_2040_subghz.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 challenger_2040_subghz.build.uf2family=--family rp2040
 challenger_2040_subghz.build.variant=challenger_2040_subghz
@@ -13514,6 +13567,7 @@ challenger_2040_wifi.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 challenger_2040_wifi.build.board=CHALLENGER_2040_WIFI_RP2040
 challenger_2040_wifi.build.chip=rp2040
 challenger_2040_wifi.build.toolchain=arm-none-eabi
+challenger_2040_wifi.build.toolchainpkg=pqt-gcc
 challenger_2040_wifi.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 challenger_2040_wifi.build.uf2family=--family rp2040
 challenger_2040_wifi.build.variant=challenger_2040_wifi
@@ -13785,6 +13839,7 @@ challenger_2040_wifi_ble.build.usbpwr=-DUSBD_MAX_POWER_MA=500
 challenger_2040_wifi_ble.build.board=CHALLENGER_2040_WIFI_BLE_RP2040
 challenger_2040_wifi_ble.build.chip=rp2040
 challenger_2040_wifi_ble.build.toolchain=arm-none-eabi
+challenger_2040_wifi_ble.build.toolchainpkg=pqt-gcc
 challenger_2040_wifi_ble.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 challenger_2040_wifi_ble.build.uf2family=--family rp2040
 challenger_2040_wifi_ble.build.variant=challenger_2040_wifi_ble
@@ -14156,6 +14211,7 @@ challenger_2040_wifi6_ble.build.usbpwr=-DUSBD_MAX_POWER_MA=500
 challenger_2040_wifi6_ble.build.board=CHALLENGER_2040_WIFI6_BLE_RP2040
 challenger_2040_wifi6_ble.build.chip=rp2040
 challenger_2040_wifi6_ble.build.toolchain=arm-none-eabi
+challenger_2040_wifi6_ble.build.toolchainpkg=pqt-gcc
 challenger_2040_wifi6_ble.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 challenger_2040_wifi6_ble.build.uf2family=--family rp2040
 challenger_2040_wifi6_ble.build.variant=challenger_2040_wifi6_ble
@@ -14427,6 +14483,7 @@ challenger_nb_2040_wifi.build.usbpwr=-DUSBD_MAX_POWER_MA=500
 challenger_nb_2040_wifi.build.board=CHALLENGER_NB_2040_WIFI_RP2040
 challenger_nb_2040_wifi.build.chip=rp2040
 challenger_nb_2040_wifi.build.toolchain=arm-none-eabi
+challenger_nb_2040_wifi.build.toolchainpkg=pqt-gcc
 challenger_nb_2040_wifi.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 challenger_nb_2040_wifi.build.uf2family=--family rp2040
 challenger_nb_2040_wifi.build.variant=challenger_nb_2040_wifi
@@ -14698,6 +14755,7 @@ challenger_2040_sdrtc.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 challenger_2040_sdrtc.build.board=CHALLENGER_2040_SDRTC_RP2040
 challenger_2040_sdrtc.build.chip=rp2040
 challenger_2040_sdrtc.build.toolchain=arm-none-eabi
+challenger_2040_sdrtc.build.toolchainpkg=pqt-gcc
 challenger_2040_sdrtc.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 challenger_2040_sdrtc.build.uf2family=--family rp2040
 challenger_2040_sdrtc.build.variant=challenger_2040_sdrtc
@@ -14968,6 +15026,7 @@ challenger_2040_nfc.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 challenger_2040_nfc.build.board=CHALLENGER_2040_NFC_RP2040
 challenger_2040_nfc.build.chip=rp2040
 challenger_2040_nfc.build.toolchain=arm-none-eabi
+challenger_2040_nfc.build.toolchainpkg=pqt-gcc
 challenger_2040_nfc.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 challenger_2040_nfc.build.uf2family=--family rp2040
 challenger_2040_nfc.build.variant=challenger_2040_nfc
@@ -15238,6 +15297,7 @@ challenger_2040_uwb.build.usbpwr=-DUSBD_MAX_POWER_MA=500
 challenger_2040_uwb.build.board=CHALLENGER_2040_UWB_RP2040
 challenger_2040_uwb.build.chip=rp2040
 challenger_2040_uwb.build.toolchain=arm-none-eabi
+challenger_2040_uwb.build.toolchainpkg=pqt-gcc
 challenger_2040_uwb.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 challenger_2040_uwb.build.uf2family=--family rp2040
 challenger_2040_uwb.build.variant=challenger_2040_uwb
@@ -15508,6 +15568,7 @@ connectivity_2040_lte_wifi_ble.build.usbpwr=-DUSBD_MAX_POWER_MA=500
 connectivity_2040_lte_wifi_ble.build.board=CONNECTIVITY_2040_LTE_WIFI_BLE_RP2040
 connectivity_2040_lte_wifi_ble.build.chip=rp2040
 connectivity_2040_lte_wifi_ble.build.toolchain=arm-none-eabi
+connectivity_2040_lte_wifi_ble.build.toolchainpkg=pqt-gcc
 connectivity_2040_lte_wifi_ble.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 connectivity_2040_lte_wifi_ble.build.uf2family=--family rp2040
 connectivity_2040_lte_wifi_ble.build.variant=connectivity_2040_lte_wifi_ble
@@ -15779,6 +15840,7 @@ ilabs_rpico32.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 ilabs_rpico32.build.board=ILABS_2040_RPICO32_RP2040
 ilabs_rpico32.build.chip=rp2040
 ilabs_rpico32.build.toolchain=arm-none-eabi
+ilabs_rpico32.build.toolchainpkg=pqt-gcc
 ilabs_rpico32.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 ilabs_rpico32.build.uf2family=--family rp2040
 ilabs_rpico32.build.variant=ilabs_rpico32
@@ -16250,11 +16312,13 @@ challenger_2350_wifi6_ble5.menu.flash.16777216_2097152.build.fs_end=285204480
 challenger_2350_wifi6_ble5.menu.arch.arm=ARM
 challenger_2350_wifi6_ble5.menu.arch.arm.build.chip=rp2350
 challenger_2350_wifi6_ble5.menu.arch.arm.build.toolchain=arm-none-eabi
+challenger_2350_wifi6_ble5.menu.arch.arm.build.toolchainpkg=pqt-gcc
 challenger_2350_wifi6_ble5.menu.arch.arm.build.toolchainopts=-mcpu=cortex-m33 -mthumb -march=armv8-m.main+fp+dsp -mfloat-abi=softfp -mcmse
 challenger_2350_wifi6_ble5.menu.arch.arm.build.uf2family=--family rp2350-arm-s --abs-block
 challenger_2350_wifi6_ble5.menu.arch.riscv=RISC-V
 challenger_2350_wifi6_ble5.menu.arch.riscv.build.chip=rp2350-riscv
 challenger_2350_wifi6_ble5.menu.arch.riscv.build.toolchain=riscv32-unknown-elf
+challenger_2350_wifi6_ble5.menu.arch.riscv.build.toolchainpkg=pqt-gcc-riscv
 challenger_2350_wifi6_ble5.menu.arch.riscv.build.toolchainopts=-march=rv32imac_zicsr_zifencei_zba_zbb_zbs_zbkb -mabi=ilp32
 challenger_2350_wifi6_ble5.menu.arch.riscv.build.uf2family=--family rp2350-riscv --abs-block
 challenger_2350_wifi6_ble5.menu.freq.150=150 MHz
@@ -16527,11 +16591,13 @@ challenger_2350_bconnect.menu.flash.8388608_7340032.build.fs_end=276815872
 challenger_2350_bconnect.menu.arch.arm=ARM
 challenger_2350_bconnect.menu.arch.arm.build.chip=rp2350
 challenger_2350_bconnect.menu.arch.arm.build.toolchain=arm-none-eabi
+challenger_2350_bconnect.menu.arch.arm.build.toolchainpkg=pqt-gcc
 challenger_2350_bconnect.menu.arch.arm.build.toolchainopts=-mcpu=cortex-m33 -mthumb -march=armv8-m.main+fp+dsp -mfloat-abi=softfp -mcmse
 challenger_2350_bconnect.menu.arch.arm.build.uf2family=--family rp2350-arm-s --abs-block
 challenger_2350_bconnect.menu.arch.riscv=RISC-V
 challenger_2350_bconnect.menu.arch.riscv.build.chip=rp2350-riscv
 challenger_2350_bconnect.menu.arch.riscv.build.toolchain=riscv32-unknown-elf
+challenger_2350_bconnect.menu.arch.riscv.build.toolchainpkg=pqt-gcc-riscv
 challenger_2350_bconnect.menu.arch.riscv.build.toolchainopts=-march=rv32imac_zicsr_zifencei_zba_zbb_zbs_zbkb -mabi=ilp32
 challenger_2350_bconnect.menu.arch.riscv.build.uf2family=--family rp2350-riscv --abs-block
 challenger_2350_bconnect.menu.freq.150=150 MHz
@@ -16705,6 +16771,7 @@ melopero_cookie_rp2040.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 melopero_cookie_rp2040.build.board=MELOPERO_COOKIE_RP2040
 melopero_cookie_rp2040.build.chip=rp2040
 melopero_cookie_rp2040.build.toolchain=arm-none-eabi
+melopero_cookie_rp2040.build.toolchainpkg=pqt-gcc
 melopero_cookie_rp2040.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 melopero_cookie_rp2040.build.uf2family=--family rp2040
 melopero_cookie_rp2040.build.variant=melopero_cookie_rp2040
@@ -16975,6 +17042,7 @@ melopero_shake_rp2040.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 melopero_shake_rp2040.build.board=MELOPERO_SHAKE_RP2040
 melopero_shake_rp2040.build.chip=rp2040
 melopero_shake_rp2040.build.toolchain=arm-none-eabi
+melopero_shake_rp2040.build.toolchainpkg=pqt-gcc
 melopero_shake_rp2040.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 melopero_shake_rp2040.build.uf2family=--family rp2040
 melopero_shake_rp2040.build.variant=melopero_shake_rp2040
@@ -17301,6 +17369,7 @@ akana_r1.build.usbpwr=-DUSBD_MAX_POWER_MA=500
 akana_r1.build.board=METEHOCA_AKANA_R1
 akana_r1.build.chip=rp2040
 akana_r1.build.toolchain=arm-none-eabi
+akana_r1.build.toolchainpkg=pqt-gcc
 akana_r1.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 akana_r1.build.uf2family=--family rp2040
 akana_r1.build.variant=akana_r1
@@ -17578,6 +17647,7 @@ nekosystems_bl2040_mini.build.usbpwr=-DUSBD_MAX_POWER_MA=500
 nekosystems_bl2040_mini.build.board=NEKOSYSTEMS_BL2040_MINI
 nekosystems_bl2040_mini.build.chip=rp2040
 nekosystems_bl2040_mini.build.toolchain=arm-none-eabi
+nekosystems_bl2040_mini.build.toolchainpkg=pqt-gcc
 nekosystems_bl2040_mini.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 nekosystems_bl2040_mini.build.uf2family=--family rp2040
 nekosystems_bl2040_mini.build.variant=nekosystems_bl2040_mini
@@ -17820,6 +17890,7 @@ newsan_archi.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 newsan_archi.build.board=NEWSAN_ARCHI
 newsan_archi.build.chip=rp2040
 newsan_archi.build.toolchain=arm-none-eabi
+newsan_archi.build.toolchainpkg=pqt-gcc
 newsan_archi.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 newsan_archi.build.uf2family=--family rp2040
 newsan_archi.build.variant=newsan_archi
@@ -18046,6 +18117,7 @@ nullbits_bit_c_pro.build.usbpwr=-DUSBD_MAX_POWER_MA=500
 nullbits_bit_c_pro.build.board=NULLBITS_BIT_C_PRO
 nullbits_bit_c_pro.build.chip=rp2040
 nullbits_bit_c_pro.build.toolchain=arm-none-eabi
+nullbits_bit_c_pro.build.toolchainpkg=pqt-gcc
 nullbits_bit_c_pro.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 nullbits_bit_c_pro.build.uf2family=--family rp2040
 nullbits_bit_c_pro.build.variant=nullbits_bit_c_pro
@@ -18288,6 +18360,7 @@ olimex_rp2040pico30_2mb.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 olimex_rp2040pico30_2mb.build.board=OLIMEX_RP2040_PICO30_2MB
 olimex_rp2040pico30_2mb.build.chip=rp2040
 olimex_rp2040pico30_2mb.build.toolchain=arm-none-eabi
+olimex_rp2040pico30_2mb.build.toolchainpkg=pqt-gcc
 olimex_rp2040pico30_2mb.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 olimex_rp2040pico30_2mb.build.uf2family=--family rp2040
 olimex_rp2040pico30_2mb.build.variant=olimex_rp2040pico30_2mb
@@ -18516,6 +18589,7 @@ olimex_rp2040pico30_16mb.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 olimex_rp2040pico30_16mb.build.board=OLIMEX_RP2040_PICO30_16MB
 olimex_rp2040pico30_16mb.build.chip=rp2040
 olimex_rp2040pico30_16mb.build.toolchain=arm-none-eabi
+olimex_rp2040pico30_16mb.build.toolchainpkg=pqt-gcc
 olimex_rp2040pico30_16mb.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 olimex_rp2040pico30_16mb.build.uf2family=--family rp2040
 olimex_rp2040pico30_16mb.build.variant=olimex_rp2040pico30_16mb
@@ -18842,6 +18916,7 @@ pimoroni_pga2040.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 pimoroni_pga2040.build.board=PIMORONI_PGA2040
 pimoroni_pga2040.build.chip=rp2040
 pimoroni_pga2040.build.toolchain=arm-none-eabi
+pimoroni_pga2040.build.toolchainpkg=pqt-gcc
 pimoroni_pga2040.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 pimoroni_pga2040.build.uf2family=--family rp2040
 pimoroni_pga2040.build.variant=pimoroni_pga2040
@@ -19267,11 +19342,13 @@ pimoroni_pga2350.menu.flash.16777216_15728640.build.fs_end=285204480
 pimoroni_pga2350.menu.arch.arm=ARM
 pimoroni_pga2350.menu.arch.arm.build.chip=rp2350
 pimoroni_pga2350.menu.arch.arm.build.toolchain=arm-none-eabi
+pimoroni_pga2350.menu.arch.arm.build.toolchainpkg=pqt-gcc
 pimoroni_pga2350.menu.arch.arm.build.toolchainopts=-mcpu=cortex-m33 -mthumb -march=armv8-m.main+fp+dsp -mfloat-abi=softfp -mcmse
 pimoroni_pga2350.menu.arch.arm.build.uf2family=--family rp2350-arm-s --abs-block
 pimoroni_pga2350.menu.arch.riscv=RISC-V
 pimoroni_pga2350.menu.arch.riscv.build.chip=rp2350-riscv
 pimoroni_pga2350.menu.arch.riscv.build.toolchain=riscv32-unknown-elf
+pimoroni_pga2350.menu.arch.riscv.build.toolchainpkg=pqt-gcc-riscv
 pimoroni_pga2350.menu.arch.riscv.build.toolchainopts=-march=rv32imac_zicsr_zifencei_zba_zbb_zbs_zbkb -mabi=ilp32
 pimoroni_pga2350.menu.arch.riscv.build.uf2family=--family rp2350-riscv --abs-block
 pimoroni_pga2350.menu.freq.150=150 MHz
@@ -19600,11 +19677,13 @@ pimoroni_pico_plus_2.menu.flash.16777216_15728640.build.fs_end=285204480
 pimoroni_pico_plus_2.menu.arch.arm=ARM
 pimoroni_pico_plus_2.menu.arch.arm.build.chip=rp2350
 pimoroni_pico_plus_2.menu.arch.arm.build.toolchain=arm-none-eabi
+pimoroni_pico_plus_2.menu.arch.arm.build.toolchainpkg=pqt-gcc
 pimoroni_pico_plus_2.menu.arch.arm.build.toolchainopts=-mcpu=cortex-m33 -mthumb -march=armv8-m.main+fp+dsp -mfloat-abi=softfp -mcmse
 pimoroni_pico_plus_2.menu.arch.arm.build.uf2family=--family rp2350-arm-s --abs-block
 pimoroni_pico_plus_2.menu.arch.riscv=RISC-V
 pimoroni_pico_plus_2.menu.arch.riscv.build.chip=rp2350-riscv
 pimoroni_pico_plus_2.menu.arch.riscv.build.toolchain=riscv32-unknown-elf
+pimoroni_pico_plus_2.menu.arch.riscv.build.toolchainpkg=pqt-gcc-riscv
 pimoroni_pico_plus_2.menu.arch.riscv.build.toolchainopts=-march=rv32imac_zicsr_zifencei_zba_zbb_zbs_zbkb -mabi=ilp32
 pimoroni_pico_plus_2.menu.arch.riscv.build.uf2family=--family rp2350-riscv --abs-block
 pimoroni_pico_plus_2.menu.freq.150=150 MHz
@@ -19778,6 +19857,7 @@ pimoroni_plasma2040.build.usbpwr=-DUSBD_MAX_POWER_MA=500
 pimoroni_plasma2040.build.board=PIMORONI_PLASMA2040
 pimoroni_plasma2040.build.chip=rp2040
 pimoroni_plasma2040.build.toolchain=arm-none-eabi
+pimoroni_plasma2040.build.toolchainpkg=pqt-gcc
 pimoroni_plasma2040.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 pimoroni_plasma2040.build.uf2family=--family rp2040
 pimoroni_plasma2040.build.variant=pimoroni_plasma2040
@@ -20006,6 +20086,7 @@ pimoroni_tiny2040.build.usbpwr=-DUSBD_MAX_POWER_MA=500
 pimoroni_tiny2040.build.board=PIMORONI_TINY2040
 pimoroni_tiny2040.build.chip=rp2040
 pimoroni_tiny2040.build.toolchain=arm-none-eabi
+pimoroni_tiny2040.build.toolchainpkg=pqt-gcc
 pimoroni_tiny2040.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 pimoroni_tiny2040.build.uf2family=--family rp2040
 pimoroni_tiny2040.build.variant=pimoroni_tiny2040
@@ -20333,11 +20414,13 @@ pimoroni_tiny2350.menu.flash.4194304_3145728.build.fs_end=272621568
 pimoroni_tiny2350.menu.arch.arm=ARM
 pimoroni_tiny2350.menu.arch.arm.build.chip=rp2350
 pimoroni_tiny2350.menu.arch.arm.build.toolchain=arm-none-eabi
+pimoroni_tiny2350.menu.arch.arm.build.toolchainpkg=pqt-gcc
 pimoroni_tiny2350.menu.arch.arm.build.toolchainopts=-mcpu=cortex-m33 -mthumb -march=armv8-m.main+fp+dsp -mfloat-abi=softfp -mcmse
 pimoroni_tiny2350.menu.arch.arm.build.uf2family=--family rp2350-arm-s --abs-block
 pimoroni_tiny2350.menu.arch.riscv=RISC-V
 pimoroni_tiny2350.menu.arch.riscv.build.chip=rp2350-riscv
 pimoroni_tiny2350.menu.arch.riscv.build.toolchain=riscv32-unknown-elf
+pimoroni_tiny2350.menu.arch.riscv.build.toolchainpkg=pqt-gcc-riscv
 pimoroni_tiny2350.menu.arch.riscv.build.toolchainopts=-march=rv32imac_zicsr_zifencei_zba_zbb_zbs_zbkb -mabi=ilp32
 pimoroni_tiny2350.menu.arch.riscv.build.uf2family=--family rp2350-riscv --abs-block
 pimoroni_tiny2350.menu.freq.150=150 MHz
@@ -20487,6 +20570,7 @@ pintronix_pinmax.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 pintronix_pinmax.build.board=PINTRONIX_PINMAX
 pintronix_pinmax.build.chip=rp2040
 pintronix_pinmax.build.toolchain=arm-none-eabi
+pintronix_pinmax.build.toolchainpkg=pqt-gcc
 pintronix_pinmax.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 pintronix_pinmax.build.uf2family=--family rp2040
 pintronix_pinmax.build.variant=pintronix_pinmax
@@ -20729,6 +20813,7 @@ rakwireless_rak11300.build.usbpwr=-DUSBD_MAX_POWER_MA=500
 rakwireless_rak11300.build.board=RAKWIRELESS_RAK11300
 rakwireless_rak11300.build.chip=rp2040
 rakwireless_rak11300.build.toolchain=arm-none-eabi
+rakwireless_rak11300.build.toolchainpkg=pqt-gcc
 rakwireless_rak11300.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 rakwireless_rak11300.build.uf2family=--family rp2040
 rakwireless_rak11300.build.variant=rakwireless_rak11300
@@ -20941,6 +21026,7 @@ redscorp_rp2040_eins.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 redscorp_rp2040_eins.build.board=REDSCORP_RP2040_EINS
 redscorp_rp2040_eins.build.chip=rp2040
 redscorp_rp2040_eins.build.toolchain=arm-none-eabi
+redscorp_rp2040_eins.build.toolchainpkg=pqt-gcc
 redscorp_rp2040_eins.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 redscorp_rp2040_eins.build.uf2family=--family rp2040
 redscorp_rp2040_eins.build.variant=redscorp_rp2040_eins
@@ -21251,6 +21337,7 @@ redscorp_rp2040_promini.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 redscorp_rp2040_promini.build.board=REDSCORP_RP2040_PROMINI
 redscorp_rp2040_promini.build.chip=rp2040
 redscorp_rp2040_promini.build.toolchain=arm-none-eabi
+redscorp_rp2040_promini.build.toolchainpkg=pqt-gcc
 redscorp_rp2040_promini.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 redscorp_rp2040_promini.build.uf2family=--family rp2040
 redscorp_rp2040_promini.build.variant=redscorp_rp2040_promini
@@ -21553,6 +21640,7 @@ sea_picro.build.usbpwr=-DUSBD_MAX_POWER_MA=500
 sea_picro.build.board=SEA_PICRO
 sea_picro.build.chip=rp2040
 sea_picro.build.toolchain=arm-none-eabi
+sea_picro.build.toolchainpkg=pqt-gcc
 sea_picro.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 sea_picro.build.uf2family=--family rp2040
 sea_picro.build.variant=sea_picro
@@ -21795,6 +21883,7 @@ silicognition_rp2040_shim.build.usbpwr=-DUSBD_MAX_POWER_MA=500
 silicognition_rp2040_shim.build.board=SILICOGNITION_RP2040_SHIM
 silicognition_rp2040_shim.build.chip=rp2040
 silicognition_rp2040_shim.build.toolchain=arm-none-eabi
+silicognition_rp2040_shim.build.toolchainpkg=pqt-gcc
 silicognition_rp2040_shim.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 silicognition_rp2040_shim.build.uf2family=--family rp2040
 silicognition_rp2040_shim.build.variant=silicognition_rp2040_shim
@@ -22013,6 +22102,7 @@ solderparty_rp2040_stamp.build.usbpwr=-DUSBD_MAX_POWER_MA=500
 solderparty_rp2040_stamp.build.board=SOLDERPARTY_RP2040_STAMP
 solderparty_rp2040_stamp.build.chip=rp2040
 solderparty_rp2040_stamp.build.toolchain=arm-none-eabi
+solderparty_rp2040_stamp.build.toolchainpkg=pqt-gcc
 solderparty_rp2040_stamp.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 solderparty_rp2040_stamp.build.uf2family=--family rp2040
 solderparty_rp2040_stamp.build.variant=solderparty_rp2040_stamp
@@ -22414,11 +22504,13 @@ solderparty_rp2350_stamp.menu.flash.16777216_15728640.build.fs_end=285204480
 solderparty_rp2350_stamp.menu.arch.arm=ARM
 solderparty_rp2350_stamp.menu.arch.arm.build.chip=rp2350
 solderparty_rp2350_stamp.menu.arch.arm.build.toolchain=arm-none-eabi
+solderparty_rp2350_stamp.menu.arch.arm.build.toolchainpkg=pqt-gcc
 solderparty_rp2350_stamp.menu.arch.arm.build.toolchainopts=-mcpu=cortex-m33 -mthumb -march=armv8-m.main+fp+dsp -mfloat-abi=softfp -mcmse
 solderparty_rp2350_stamp.menu.arch.arm.build.uf2family=--family rp2350-arm-s --abs-block
 solderparty_rp2350_stamp.menu.arch.riscv=RISC-V
 solderparty_rp2350_stamp.menu.arch.riscv.build.chip=rp2350-riscv
 solderparty_rp2350_stamp.menu.arch.riscv.build.toolchain=riscv32-unknown-elf
+solderparty_rp2350_stamp.menu.arch.riscv.build.toolchainpkg=pqt-gcc-riscv
 solderparty_rp2350_stamp.menu.arch.riscv.build.toolchainopts=-march=rv32imac_zicsr_zifencei_zba_zbb_zbs_zbkb -mabi=ilp32
 solderparty_rp2350_stamp.menu.arch.riscv.build.uf2family=--family rp2350-riscv --abs-block
 solderparty_rp2350_stamp.menu.freq.150=150 MHz
@@ -22723,11 +22815,13 @@ solderparty_rp2350_stamp_xl.menu.flash.16777216_15728640.build.fs_end=285204480
 solderparty_rp2350_stamp_xl.menu.arch.arm=ARM
 solderparty_rp2350_stamp_xl.menu.arch.arm.build.chip=rp2350
 solderparty_rp2350_stamp_xl.menu.arch.arm.build.toolchain=arm-none-eabi
+solderparty_rp2350_stamp_xl.menu.arch.arm.build.toolchainpkg=pqt-gcc
 solderparty_rp2350_stamp_xl.menu.arch.arm.build.toolchainopts=-mcpu=cortex-m33 -mthumb -march=armv8-m.main+fp+dsp -mfloat-abi=softfp -mcmse
 solderparty_rp2350_stamp_xl.menu.arch.arm.build.uf2family=--family rp2350-arm-s --abs-block
 solderparty_rp2350_stamp_xl.menu.arch.riscv=RISC-V
 solderparty_rp2350_stamp_xl.menu.arch.riscv.build.chip=rp2350-riscv
 solderparty_rp2350_stamp_xl.menu.arch.riscv.build.toolchain=riscv32-unknown-elf
+solderparty_rp2350_stamp_xl.menu.arch.riscv.build.toolchainpkg=pqt-gcc-riscv
 solderparty_rp2350_stamp_xl.menu.arch.riscv.build.toolchainopts=-march=rv32imac_zicsr_zifencei_zba_zbb_zbs_zbkb -mabi=ilp32
 solderparty_rp2350_stamp_xl.menu.arch.riscv.build.uf2family=--family rp2350-riscv --abs-block
 solderparty_rp2350_stamp_xl.menu.freq.150=150 MHz
@@ -22901,6 +22995,7 @@ sparkfun_micromodrp2040.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 sparkfun_micromodrp2040.build.board=SPARKFUN_MICROMOD_RP2040
 sparkfun_micromodrp2040.build.chip=rp2040
 sparkfun_micromodrp2040.build.toolchain=arm-none-eabi
+sparkfun_micromodrp2040.build.toolchainpkg=pqt-gcc
 sparkfun_micromodrp2040.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 sparkfun_micromodrp2040.build.uf2family=--family rp2040
 sparkfun_micromodrp2040.build.variant=sparkfun_micromodrp2040
@@ -23227,6 +23322,7 @@ sparkfun_promicrorp2040.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 sparkfun_promicrorp2040.build.board=SPARKFUN_PROMICRO_RP2040
 sparkfun_promicrorp2040.build.chip=rp2040
 sparkfun_promicrorp2040.build.toolchain=arm-none-eabi
+sparkfun_promicrorp2040.build.toolchainpkg=pqt-gcc
 sparkfun_promicrorp2040.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 sparkfun_promicrorp2040.build.uf2family=--family rp2040
 sparkfun_promicrorp2040.build.variant=sparkfun_promicrorp2040
@@ -23708,11 +23804,13 @@ sparkfun_promicrorp2350.menu.flash.16777216_15728640.build.fs_end=285204480
 sparkfun_promicrorp2350.menu.arch.arm=ARM
 sparkfun_promicrorp2350.menu.arch.arm.build.chip=rp2350
 sparkfun_promicrorp2350.menu.arch.arm.build.toolchain=arm-none-eabi
+sparkfun_promicrorp2350.menu.arch.arm.build.toolchainpkg=pqt-gcc
 sparkfun_promicrorp2350.menu.arch.arm.build.toolchainopts=-mcpu=cortex-m33 -mthumb -march=armv8-m.main+fp+dsp -mfloat-abi=softfp -mcmse
 sparkfun_promicrorp2350.menu.arch.arm.build.uf2family=--family rp2350-arm-s --abs-block
 sparkfun_promicrorp2350.menu.arch.riscv=RISC-V
 sparkfun_promicrorp2350.menu.arch.riscv.build.chip=rp2350-riscv
 sparkfun_promicrorp2350.menu.arch.riscv.build.toolchain=riscv32-unknown-elf
+sparkfun_promicrorp2350.menu.arch.riscv.build.toolchainpkg=pqt-gcc-riscv
 sparkfun_promicrorp2350.menu.arch.riscv.build.toolchainopts=-march=rv32imac_zicsr_zifencei_zba_zbb_zbs_zbkb -mabi=ilp32
 sparkfun_promicrorp2350.menu.arch.riscv.build.uf2family=--family rp2350-riscv --abs-block
 sparkfun_promicrorp2350.menu.freq.150=150 MHz
@@ -23886,6 +23984,7 @@ sparkfun_thingplusrp2040.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 sparkfun_thingplusrp2040.build.board=SPARKFUN_THINGPLUS_RP2040
 sparkfun_thingplusrp2040.build.chip=rp2040
 sparkfun_thingplusrp2040.build.toolchain=arm-none-eabi
+sparkfun_thingplusrp2040.build.toolchainpkg=pqt-gcc
 sparkfun_thingplusrp2040.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 sparkfun_thingplusrp2040.build.uf2family=--family rp2040
 sparkfun_thingplusrp2040.build.variant=sparkfun_thingplusrp2040
@@ -24212,6 +24311,7 @@ upesy_rp2040_devkit.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 upesy_rp2040_devkit.build.board=UPESY_RP2040_DEVKIT
 upesy_rp2040_devkit.build.chip=rp2040
 upesy_rp2040_devkit.build.toolchain=arm-none-eabi
+upesy_rp2040_devkit.build.toolchainpkg=pqt-gcc
 upesy_rp2040_devkit.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 upesy_rp2040_devkit.build.uf2family=--family rp2040
 upesy_rp2040_devkit.build.variant=upesy_rp2040_devkit
@@ -24440,6 +24540,7 @@ seeed_indicator_rp2040.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 seeed_indicator_rp2040.build.board=SEEED_INDICATOR_RP2040
 seeed_indicator_rp2040.build.chip=rp2040
 seeed_indicator_rp2040.build.toolchain=arm-none-eabi
+seeed_indicator_rp2040.build.toolchainpkg=pqt-gcc
 seeed_indicator_rp2040.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 seeed_indicator_rp2040.build.uf2family=--family rp2040
 seeed_indicator_rp2040.build.variant=seeed_indicator_rp2040
@@ -24668,6 +24769,7 @@ seeed_xiao_rp2040.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 seeed_xiao_rp2040.build.board=SEEED_XIAO_RP2040
 seeed_xiao_rp2040.build.chip=rp2040
 seeed_xiao_rp2040.build.toolchain=arm-none-eabi
+seeed_xiao_rp2040.build.toolchainpkg=pqt-gcc
 seeed_xiao_rp2040.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 seeed_xiao_rp2040.build.uf2family=--family rp2040
 seeed_xiao_rp2040.build.variant=seeed_xiao_rp2040
@@ -24880,6 +24982,7 @@ vccgnd_yd_rp2040.build.usbpwr=-DUSBD_MAX_POWER_MA=500
 vccgnd_yd_rp2040.build.board=YD_RP2040
 vccgnd_yd_rp2040.build.chip=rp2040
 vccgnd_yd_rp2040.build.toolchain=arm-none-eabi
+vccgnd_yd_rp2040.build.toolchainpkg=pqt-gcc
 vccgnd_yd_rp2040.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 vccgnd_yd_rp2040.build.uf2family=--family rp2040
 vccgnd_yd_rp2040.build.variant=vccgnd_yd_rp2040
@@ -25178,6 +25281,7 @@ viyalab_mizu.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 viyalab_mizu.build.board=VIYALAB_MIZU_RP2040
 viyalab_mizu.build.chip=rp2040
 viyalab_mizu.build.toolchain=arm-none-eabi
+viyalab_mizu.build.toolchainpkg=pqt-gcc
 viyalab_mizu.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 viyalab_mizu.build.uf2family=--family rp2040
 viyalab_mizu.build.variant=viyalab_mizu
@@ -25448,6 +25552,7 @@ waveshare_rp2040_zero.build.usbpwr=-DUSBD_MAX_POWER_MA=500
 waveshare_rp2040_zero.build.board=WAVESHARE_RP2040_ZERO
 waveshare_rp2040_zero.build.chip=rp2040
 waveshare_rp2040_zero.build.toolchain=arm-none-eabi
+waveshare_rp2040_zero.build.toolchainpkg=pqt-gcc
 waveshare_rp2040_zero.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 waveshare_rp2040_zero.build.uf2family=--family rp2040
 waveshare_rp2040_zero.build.variant=waveshare_rp2040_zero
@@ -25676,6 +25781,7 @@ waveshare_rp2040_one.build.usbpwr=-DUSBD_MAX_POWER_MA=500
 waveshare_rp2040_one.build.board=WAVESHARE_RP2040_ONE
 waveshare_rp2040_one.build.chip=rp2040
 waveshare_rp2040_one.build.toolchain=arm-none-eabi
+waveshare_rp2040_one.build.toolchainpkg=pqt-gcc
 waveshare_rp2040_one.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 waveshare_rp2040_one.build.uf2family=--family rp2040
 waveshare_rp2040_one.build.variant=waveshare_rp2040_one
@@ -25918,6 +26024,7 @@ waveshare_rp2040_matrix.build.usbpwr=-DUSBD_MAX_POWER_MA=500
 waveshare_rp2040_matrix.build.board=WAVESHARE_RP2040_MATRIX
 waveshare_rp2040_matrix.build.chip=rp2040
 waveshare_rp2040_matrix.build.toolchain=arm-none-eabi
+waveshare_rp2040_matrix.build.toolchainpkg=pqt-gcc
 waveshare_rp2040_matrix.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 waveshare_rp2040_matrix.build.uf2family=--family rp2040
 waveshare_rp2040_matrix.build.variant=waveshare_rp2040_matrix
@@ -26146,6 +26253,7 @@ waveshare_rp2040_pizero.build.usbpwr=-DUSBD_MAX_POWER_MA=500
 waveshare_rp2040_pizero.build.board=WAVESHARE_RP2040_PIZERO
 waveshare_rp2040_pizero.build.chip=rp2040
 waveshare_rp2040_pizero.build.toolchain=arm-none-eabi
+waveshare_rp2040_pizero.build.toolchainpkg=pqt-gcc
 waveshare_rp2040_pizero.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 waveshare_rp2040_pizero.build.uf2family=--family rp2040
 waveshare_rp2040_pizero.build.variant=waveshare_rp2040_pizero
@@ -26472,6 +26580,7 @@ waveshare_rp2040_plus_4mb.build.usbpwr=-DUSBD_MAX_POWER_MA=500
 waveshare_rp2040_plus_4mb.build.board=WAVESHARE_RP2040_PLUS
 waveshare_rp2040_plus_4mb.build.chip=rp2040
 waveshare_rp2040_plus_4mb.build.toolchain=arm-none-eabi
+waveshare_rp2040_plus_4mb.build.toolchainpkg=pqt-gcc
 waveshare_rp2040_plus_4mb.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 waveshare_rp2040_plus_4mb.build.uf2family=--family rp2040
 waveshare_rp2040_plus_4mb.build.variant=waveshare_rp2040_plus_4mb
@@ -26714,6 +26823,7 @@ waveshare_rp2040_plus_16mb.build.usbpwr=-DUSBD_MAX_POWER_MA=500
 waveshare_rp2040_plus_16mb.build.board=WAVESHARE_RP2040_PLUS
 waveshare_rp2040_plus_16mb.build.chip=rp2040
 waveshare_rp2040_plus_16mb.build.toolchain=arm-none-eabi
+waveshare_rp2040_plus_16mb.build.toolchainpkg=pqt-gcc
 waveshare_rp2040_plus_16mb.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 waveshare_rp2040_plus_16mb.build.uf2family=--family rp2040
 waveshare_rp2040_plus_16mb.build.variant=waveshare_rp2040_plus_16mb
@@ -27040,6 +27150,7 @@ waveshare_rp2040_lcd_0_96.build.usbpwr=-DUSBD_MAX_POWER_MA=500
 waveshare_rp2040_lcd_0_96.build.board=WAVESHARE_RP2040_LCD_0_96
 waveshare_rp2040_lcd_0_96.build.chip=rp2040
 waveshare_rp2040_lcd_0_96.build.toolchain=arm-none-eabi
+waveshare_rp2040_lcd_0_96.build.toolchainpkg=pqt-gcc
 waveshare_rp2040_lcd_0_96.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 waveshare_rp2040_lcd_0_96.build.uf2family=--family rp2040
 waveshare_rp2040_lcd_0_96.build.variant=waveshare_rp2040_lcd_0_96
@@ -27268,6 +27379,7 @@ waveshare_rp2040_lcd_1_28.build.usbpwr=-DUSBD_MAX_POWER_MA=500
 waveshare_rp2040_lcd_1_28.build.board=WAVESHARE_RP2040_LCD_1_28
 waveshare_rp2040_lcd_1_28.build.chip=rp2040
 waveshare_rp2040_lcd_1_28.build.toolchain=arm-none-eabi
+waveshare_rp2040_lcd_1_28.build.toolchainpkg=pqt-gcc
 waveshare_rp2040_lcd_1_28.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 waveshare_rp2040_lcd_1_28.build.uf2family=--family rp2040
 waveshare_rp2040_lcd_1_28.build.variant=waveshare_rp2040_lcd_1_28
@@ -27496,6 +27608,7 @@ wiznet_5100s_evb_pico.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 wiznet_5100s_evb_pico.build.board=WIZNET_5100S_EVB_PICO
 wiznet_5100s_evb_pico.build.chip=rp2040
 wiznet_5100s_evb_pico.build.toolchain=arm-none-eabi
+wiznet_5100s_evb_pico.build.toolchainpkg=pqt-gcc
 wiznet_5100s_evb_pico.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 wiznet_5100s_evb_pico.build.uf2family=--family rp2040
 wiznet_5100s_evb_pico.build.variant=wiznet_5100s_evb_pico
@@ -27724,6 +27837,7 @@ wiznet_wizfi360_evb_pico.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 wiznet_wizfi360_evb_pico.build.board=WIZNET_WIZFI360_EVB_PICO
 wiznet_wizfi360_evb_pico.build.chip=rp2040
 wiznet_wizfi360_evb_pico.build.toolchain=arm-none-eabi
+wiznet_wizfi360_evb_pico.build.toolchainpkg=pqt-gcc
 wiznet_wizfi360_evb_pico.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 wiznet_wizfi360_evb_pico.build.uf2family=--family rp2040
 wiznet_wizfi360_evb_pico.build.variant=wiznet_wizfi360_evb_pico
@@ -27952,6 +28066,7 @@ wiznet_5500_evb_pico.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 wiznet_5500_evb_pico.build.board=WIZNET_5500_EVB_PICO
 wiznet_5500_evb_pico.build.chip=rp2040
 wiznet_5500_evb_pico.build.toolchain=arm-none-eabi
+wiznet_5500_evb_pico.build.toolchainpkg=pqt-gcc
 wiznet_5500_evb_pico.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 wiznet_5500_evb_pico.build.uf2family=--family rp2040
 wiznet_5500_evb_pico.build.variant=wiznet_5500_evb_pico
@@ -28156,6 +28271,7 @@ generic.build.usbpwr=-DUSBD_MAX_POWER_MA=250
 generic.build.board=GENERIC_RP2040
 generic.build.chip=rp2040
 generic.build.toolchain=arm-none-eabi
+generic.build.toolchainpkg=pqt-gcc
 generic.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
 generic.build.uf2family=--family rp2040
 generic.build.variant=generic
@@ -28578,11 +28694,13 @@ generic_rp2350.menu.flash.16777216_2097152.build.fs_end=285204480
 generic_rp2350.menu.arch.arm=ARM
 generic_rp2350.menu.arch.arm.build.chip=rp2350
 generic_rp2350.menu.arch.arm.build.toolchain=arm-none-eabi
+generic_rp2350.menu.arch.arm.build.toolchainpkg=pqt-gcc
 generic_rp2350.menu.arch.arm.build.toolchainopts=-mcpu=cortex-m33 -mthumb -march=armv8-m.main+fp+dsp -mfloat-abi=softfp -mcmse
 generic_rp2350.menu.arch.arm.build.uf2family=--family rp2350-arm-s --abs-block
 generic_rp2350.menu.arch.riscv=RISC-V
 generic_rp2350.menu.arch.riscv.build.chip=rp2350-riscv
 generic_rp2350.menu.arch.riscv.build.toolchain=riscv32-unknown-elf
+generic_rp2350.menu.arch.riscv.build.toolchainpkg=pqt-gcc-riscv
 generic_rp2350.menu.arch.riscv.build.toolchainopts=-march=rv32imac_zicsr_zifencei_zba_zbb_zbs_zbkb -mabi=ilp32
 generic_rp2350.menu.arch.riscv.build.uf2family=--family rp2350-riscv --abs-block
 generic_rp2350.menu.freq.150=150 MHz

--- a/platform.txt
+++ b/platform.txt
@@ -28,14 +28,15 @@ pluggable_discovery.required.0=builtin:serial-discovery
 pluggable_discovery.required.1=builtin:mdns-discovery
 pluggable_monitor.required.serial=builtin:serial-monitor
 
-runtime.tools.pqt-gcc.path={runtime.platform.path}/system/{build.toolchain}
+runtime.tools.pqt-gcc.path={runtime.platform.path}/system/arm-none-eabi
+runtime.tools.pqt-gcc-riscv.path={runtime.platform.path}/system/riscv32-unknown-elf
 runtime.tools.pqt-python3.path={runtime.platform.path}/system/python3
 runtime.tools.pqt-mklittlefs.path={runtime.platform.path}/system/mklittlefs
 runtime.tools.pqt-pioasm.path={runtime.platform.path}/system/pioasm
 runtime.tools.pqt-elf2uf2.path={runtime.platform.path}/system/elf2uf2
 runtime.tools.pqt-openocd.path={runtime.platform.path}/system/openocd
 runtime.tools.pqt-picotool.path={runtime.platform.path}/system/picotool
-compiler.path={runtime.tools.pqt-gcc.path}/bin/
+compiler.path={runtime.tools.{build.toolchainpkg}.path}/bin/
 
 compiler.libraries.ldflags=
 

--- a/tools/makeboards.py
+++ b/tools/makeboards.py
@@ -53,12 +53,14 @@ def BuildArch(name):
     print("%s.menu.arch.arm=ARM" % (name))
     print("%s.menu.arch.arm.build.chip=%s" % (name, "rp2350"))
     print("%s.menu.arch.arm.build.toolchain=arm-none-eabi" % (name))
+    print("%s.menu.arch.arm.build.toolchainpkg=pqt-gcc" % (name))
     print("%s.menu.arch.arm.build.toolchainopts=-mcpu=cortex-m33 -mthumb -march=armv8-m.main+fp+dsp -mfloat-abi=softfp -mcmse" % (name))
     print("%s.menu.arch.arm.build.uf2family=--family rp2350-arm-s --abs-block" % (name))
     # RISC-V Hazard3
     print("%s.menu.arch.riscv=RISC-V" % (name))
     print("%s.menu.arch.riscv.build.chip=%s" % (name, "rp2350-riscv"))
     print("%s.menu.arch.riscv.build.toolchain=riscv32-unknown-elf" % (name))
+    print("%s.menu.arch.riscv.build.toolchainpkg=pqt-gcc-riscv" % (name))
     print("%s.menu.arch.riscv.build.toolchainopts=-march=rv32imac_zicsr_zifencei_zba_zbb_zbs_zbkb -mabi=ilp32" % (name))
     print("%s.menu.arch.riscv.build.uf2family=--family rp2350-riscv --abs-block" % (name))
 
@@ -239,6 +241,7 @@ def BuildHeader(name, chip, chaintuple, chipoptions, vendor_name, product_name, 
     if chip == "rp2040":  # RP2350 has menu for this later on
         print("%s.build.chip=%s" % (name, chip))
         print("%s.build.toolchain=%s" % (name, chaintuple))
+        print("%s.build.toolchainpkg=%s" % (name, "pqt-gcc"))
         print("%s.build.toolchainopts=%s" % (name, chipoptions))
         print("%s.build.uf2family=%s" % (name, "--family rp2040"))
     print("%s.build.variant=%s" % (name, variant))


### PR DESCRIPTION
Released packages have a post-processing step to allow them to work with IDE installed toolchains.  This was not updated for the RISC-V compiler, so R5 compiles fail under the release IDE package.  Update to call proper compiler path.

Fixes #2510