### PR TITLE
Fix getStackPointer() to work in RISC-V and ARM mode

### DIFF
--- a/cores/rp2040/RP2040Support.h
+++ b/cores/rp2040/RP2040Support.h
@@ -289,7 +289,11 @@ public:
 
     inline uint32_t getStackPointer() {
         uint32_t *sp;
+#if defined(__riscv)
+        asm volatile("mv %0, sp" : "=r"(sp));
+#else
         asm volatile("mov %0, sp" : "=r"(sp));
+#endif
         return (uint32_t)sp;
     }
 


### PR DESCRIPTION
Fixes #2525.

Tested on RISC-V with a debugger to match.

"mv" instruction to move one register's content into another register, see https://projectf.io/posts/riscv-cheat-sheet/#misc-instructions. 

![grafik](https://github.com/user-attachments/assets/3db88234-182d-4600-898d-60094471cc6e)
