### PR TITLE
Document setting the PSRAM size for PlatformIO

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -322,6 +322,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install --upgrade platformio
         pio pkg install --global --platform https://github.com/maxgerhardt/platform-raspberrypi.git
+        pio pkg update --global --platform https://github.com/maxgerhardt/platform-raspberrypi.git
         pio pkg install --global --tool symlink://.
         cp -f /home/runner/work/arduino-pico/arduino-pico/tools/json/*.json /home/runner/.platformio/platforms/raspberrypi/boards/.
     - name: Build Every Variant

--- a/docs/platformio.rst
+++ b/docs/platformio.rst
@@ -169,6 +169,8 @@ To learn more about PSRAM usage, see: :doc:`RP2350 PSRAM Support <psram>`
     board_upload.psram_length = 1048576
     ; PSRAM size: 2MB
     board_upload.psram_length = 2097152
+    ; PSRAM size: 4MB
+    board_upload.psram_length = 4194304
 
 CPU Speed
 ---------

--- a/docs/platformio.rst
+++ b/docs/platformio.rst
@@ -161,7 +161,7 @@ PSRAM size
 
 For RP2350 based boards, this controls how much PSRAM the firmware will think it has available in bytes, mapped at starting address 0x11000000.
 
-To learn about PSRAM usage, see: :doc:`RP2350 PSRAM Support <psram>` 
+To learn more about PSRAM usage, see: :doc:`RP2350 PSRAM Support <psram>` 
 
 .. code:: ini
 

--- a/docs/platformio.rst
+++ b/docs/platformio.rst
@@ -156,6 +156,20 @@ platform <https://github.com/maxgerhardt/platform-raspberrypi/blob/77e0d3a29d1db
     ; Flash Size: 2MB (Sketch: 0.5MB, FS:1.5MB)
     board_build.filesystem_size = 1.5m
 
+PSRAM size
+----------
+
+For RP2350 based boards, this controls how much PSRAM the firmware will think it has available in bytes, mapped at starting address 0x11000000.
+
+To learn about PSRAM usage, see: :doc:`RP2350 PSRAM Support <psram>` 
+
+.. code:: ini
+
+    ; PSRAM size: 1MB
+    board_upload.psram_length = 1048576
+    ; PSRAM size: 2MB
+    board_upload.psram_length = 2097152
+
 CPU Speed
 ---------
 


### PR DESCRIPTION
Was still missing in the docs.