### PR TITLE
Increase default PWMAudio buffer sizes

### DIFF
--- a/libraries/PWMAudio/src/PWMAudio.cpp
+++ b/libraries/PWMAudio/src/PWMAudio.cpp
@@ -127,7 +127,7 @@ bool PWMAudio::begin() {
     _wasHolding = false;
 
     if (!_bufferWords) {
-        _bufferWords = 16;
+        _bufferWords = 64;
     }
 
     setPWMFrequency(_freq);


### PR DESCRIPTION
Help ensure click-free playback by default. App overide will still be obeyed.