### PR TITLE
Workaround PSRAM cache invalid'n by reading flash

### DIFF
--- a/cores/rp2040/flash_wrapper.cpp
+++ b/cores/rp2040/flash_wrapper.cpp
@@ -31,7 +31,7 @@ static void __no_inline_not_in_flash_func(flushcache)() {
     //    *cache = 0;
     //}
     uint32_t sum = 0; // Ignored, just to ensure not optimized out
-    for (volatile uint32_t *flash = (volatile uint32_t *)0x11000000; flash < (volatile uint32_t *)(0x11000000 + 48*1024*4); flash++) {
+    for (volatile uint32_t *flash = (volatile uint32_t *)0x11000000; flash < (volatile uint32_t *)(0x11000000 + 48 * 1024 * 4); flash++) {
         sum += *flash;
     }
     __wastedsum += sum;

--- a/cores/rp2040/flash_wrapper.cpp
+++ b/cores/rp2040/flash_wrapper.cpp
@@ -24,7 +24,7 @@
 #include <hardware/structs/qmi.h>
 #endif
 
-#if defined(RP2350_PSRAM_CS)
+#if defined(PICO_RP2350) && defined(RP2350_PSRAM_CS)
 static volatile uint32_t __wastedsum = 0;
 static void __no_inline_not_in_flash_func(flushcache)() {
     //for (volatile uint8_t* cache = (volatile uint8_t*)0x18000001; cache < (volatile uint8_t*)(0x18000001 + 2048 * 8); cache += 8) {
@@ -36,11 +36,12 @@ static void __no_inline_not_in_flash_func(flushcache)() {
     }
     __wastedsum += sum;
 }
-#else
-static uint32_t flushcache() {
-    return 0;
+#elif defined(PICO_RP2350)
+static void __no_inline_not_in_flash_func(flushcache)() {
+    // Null
 }
 #endif
+
 
 extern "C" {
     extern void __real_flash_range_erase(uint32_t flash_offs, size_t count);

--- a/cores/rp2040/flash_wrapper.cpp
+++ b/cores/rp2040/flash_wrapper.cpp
@@ -25,16 +25,13 @@
 #endif
 
 #if defined(PICO_RP2350) && defined(RP2350_PSRAM_CS)
-static volatile uint32_t __wastedsum = 0;
 static void __no_inline_not_in_flash_func(flushcache)() {
-    //for (volatile uint8_t* cache = (volatile uint8_t*)0x18000001; cache < (volatile uint8_t*)(0x18000001 + 2048 * 8); cache += 8) {
-    //    *cache = 0;
-    //}
-    uint32_t sum = 0; // Ignored, just to ensure not optimized out
-    for (volatile uint32_t *flash = (volatile uint32_t *)0x11000000; flash < (volatile uint32_t *)(0x11000000 + 48 * 1024 * 4); flash++) {
-        sum += *flash;
+    for (volatile uint8_t* cache = (volatile uint8_t*)0x18000001; cache < (volatile uint8_t*)(0x18000001 + 2048 * 8); cache += 8) {
+        *cache = 0;
+        __compiler_memory_barrier();
+        *(cache - 1) = 0;
+        __compiler_memory_barrier();
     }
-    __wastedsum += sum;
 }
 #elif defined(PICO_RP2350)
 static void __no_inline_not_in_flash_func(flushcache)() {


### PR DESCRIPTION
Fixes #2537

While waiting for a working direct cache flush routine, try and force the cache to evict all PSRAM values by reading a bunch of flash addresses (which share the XIP cache).  This hurts performance when PSRAM is not used, but is required for correctness until we have a working XIP flush.