### PR TITLE
Remove DEBUGV for lfs_file_close

### DIFF
--- a/libraries/LittleFS/src/LittleFS.h
+++ b/libraries/LittleFS/src/LittleFS.h
@@ -465,7 +465,6 @@ public:
         if (_opened && _fd) {
             lfs_file_close(_fs->getFS(), _getFD());
             _opened = false;
-            DEBUGV("lfs_file_close: fd=%p\n", _getFD());
             if (_timeCallback && (_flags & LFS_O_WRONLY)) {
                 // If the file opened with O_CREAT, write the creation time attribute
                 if (_creation) {


### PR DESCRIPTION
All `DEBUGV` statements in littlefs driver are to report error conditions, except for the statement in `lfs_file_close`.
Removed it for consistency and to suppress useless debug logs.

See also #2542 for a discussion on the topic.