### PR TITLE
Edited the interrupt dispatcher to not block for too long on interrupt

### DIFF
--- a/cores/rp2040/wiring_private.cpp
+++ b/cores/rp2040/wiring_private.cpp
@@ -94,10 +94,11 @@ void _gpioInterruptDispatcher(uint gpio, uint32_t events) {
         CoreMutex m(&_irqMutex);
         if (m) {
             auto irq = _map.find(gpio);
-            if (irq == _map.end()) return;
+            if (irq == _map.end()) {
+                return;
+            }
             cb = &irq->second;
-        }
-        else {
+        } else {
             return;
         }
     }


### PR DESCRIPTION
You only need to lock the mutex around the std::map check, not the whole IRQ callback
This is important if you have a time-sensitive interrupt on one of the cores