### PR TITLE
Fixes Issue 2584: delays LRCK to falling edge of BCK in I2S input

### DIFF
--- a/libraries/I2S/src/pio_i2s.pio
+++ b/libraries/I2S/src/pio_i2s.pio
@@ -162,13 +162,13 @@ right1:
 left1:
     in pins, 1       side 0b01
     jmp x--, left1   side 0b00
-    in pins, 1       side 0b11 ; Last bit of left has WCLK change per I2S spec
-
+    in pins, 1       side 0b01 ; 2584 LRCK stays low until BCLK goes low
+                               ; Last bit of left has WCLK change per I2S spec
     mov x, y         side 0b10
 right1:
     in pins, 1       side 0b11
     jmp x--, right1  side 0b10
-    in pins, 1       side 0b01 ; Last bit of right also has WCLK change
+    in pins, 1       side 0b11 ; 2584 LRCK stays high until BCLK goes low
     ; Loop back to beginning...
 
 

--- a/libraries/I2S/src/pio_i2s.pio
+++ b/libraries/I2S/src/pio_i2s.pio
@@ -184,13 +184,13 @@ right1:
 left1:
     in pins, 1       side 0b10
     jmp x--, left1   side 0b00
-    in pins, 1       side 0b11 ; Last bit of left has WCLK change per I2S spec
+    in pins, 1       side 0b10 ;2584 LRCK stays low until BCLK goes low
 
     mov x, y         side 0b01
 right1:
     in pins, 1       side 0b11
     jmp x--, right1  side 0b01
-    in pins, 1       side 0b10 ; Last bit of right also has WCLK change
+    in pins, 1       side 0b11 ; 2584 LRCK stays high until BCLK goes low
     ; Loop back to beginning...
 
 

--- a/libraries/I2S/src/pio_i2s.pio.h
+++ b/libraries/I2S/src/pio_i2s.pio.h
@@ -286,11 +286,11 @@ static const uint16_t pio_i2s_in_program_instructions[] = {
     0xa022, //  0: mov    x, y            side 0
     0x4801, //  1: in     pins, 1         side 1
     0x0041, //  2: jmp    x--, 1          side 0
-    0x4801, //  3: in     pins, 1         side 3
+    0x4801, //  3: in     pins, 1         side 1
     0xb022, //  4: mov    x, y            side 2
     0x5801, //  5: in     pins, 1         side 3
     0x1045, //  6: jmp    x--, 5          side 2
-    0x5801, //  7: in     pins, 1         side 1
+    0x5801, //  7: in     pins, 1         side 3
     //     .wrap
 };
 
@@ -326,11 +326,11 @@ static const uint16_t pio_i2s_in_swap_program_instructions[] = {
     0xa022, //  0: mov    x, y            side 0
     0x5001, //  1: in     pins, 1         side 2
     0x0041, //  2: jmp    x--, 1          side 0
-    0x5801, //  3: in     pins, 1         side 3
+    0x5001, //  3: in     pins, 1         side 2
     0xa822, //  4: mov    x, y            side 1
     0x5801, //  5: in     pins, 1         side 3
     0x0845, //  6: jmp    x--, 5          side 1
-    0x5001, //  7: in     pins, 1         side 2
+    0x5801, //  7: in     pins, 1         side 3
     //     .wrap
 };
 

--- a/libraries/I2S/src/pio_i2s.pio.h
+++ b/libraries/I2S/src/pio_i2s.pio.h
@@ -286,11 +286,11 @@ static const uint16_t pio_i2s_in_program_instructions[] = {
     0xa022, //  0: mov    x, y            side 0
     0x4801, //  1: in     pins, 1         side 1
     0x0041, //  2: jmp    x--, 1          side 0
-    0x5801, //  3: in     pins, 1         side 3
+    0x4801, //  3: in     pins, 1         side 3
     0xb022, //  4: mov    x, y            side 2
     0x5801, //  5: in     pins, 1         side 3
     0x1045, //  6: jmp    x--, 5          side 2
-    0x4801, //  7: in     pins, 1         side 1
+    0x5801, //  7: in     pins, 1         side 1
     //     .wrap
 };
 


### PR DESCRIPTION
2 changes in pio_i2s.pio (stamped 2584) to delay the transitions on LRCK until the falling edge of BCK.  Only for input mode.  TI ADCs usually prefer that timing.