### PR TITLE
Build libpico in CI

### DIFF
--- a/.github/workflows/build-libpico.yml
+++ b/.github/workflows/build-libpico.yml
@@ -23,12 +23,17 @@ jobs:
         - name: Install dependencies
           run: |
             sudo apt update
-            sudo apt install cmake make build-essential wget gcc-arm-none-eabi
-            # RISC-V toolchain
-            wget -O "$GITHUB_WORKSPACE/riscv32.tar.gz" "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/4.0.1/x86_64-linux-gnu.riscv32-unknown-elf-8ec9d6f.240929.tar.gz"
-            tar xf "$GITHUB_WORKSPACE/riscv32.tar.gz"
-            echo "$GITHUB_WORKSPACE/riscv32-unknown-elf/bin" >> "$GITHUB_PATH"
-            # ARM toolchain taken from Ubuntu repository
+            sudo apt install cmake make build-essential wget
+            # Automatically get correct toolchain
+            cd tools && python3 get.py && cd ..
+            # add to PATH
+            echo "$GITHUB_WORKSPACE/system/riscv32-unknown-elf/bin" >> "$GITHUB_PATH"
+            echo "$GITHUB_WORKSPACE/system/arm-none-eabi/bin" >> "$GITHUB_PATH"
+        - name: Patch Pico-SDK (Fix Assembly for newer GCC)
+          run: |
+            cd pico-sdk
+            wget https://patch-diff.githubusercontent.com/raw/raspberrypi/pico-sdk/pull/2000.patch
+            patch -p1 < 2000.patch
         - name: Build libpico
           run: |
             cd tools/libpico

--- a/.github/workflows/build-libpico.yml
+++ b/.github/workflows/build-libpico.yml
@@ -5,7 +5,7 @@ name: libpico Builder
 on:
   pull_request:
     paths:
-        - tools/libpico/**  
+      - tools/libpico/**  
   workflow_dispatch:
   push:
     paths:
@@ -29,6 +29,7 @@ jobs:
             # add to PATH
             echo "$GITHUB_WORKSPACE/system/riscv32-unknown-elf/bin" >> "$GITHUB_PATH"
             echo "$GITHUB_WORKSPACE/system/arm-none-eabi/bin" >> "$GITHUB_PATH"
+        # Needed until we switch to Pico-SDK 2.0.1.
         - name: Patch Pico-SDK (Fix Assembly for newer GCC)
           run: |
             cd pico-sdk

--- a/.github/workflows/build-libpico.yml
+++ b/.github/workflows/build-libpico.yml
@@ -1,0 +1,42 @@
+# Run whenever it is manually triggered, a pull request or a push is done that modifes the libpico configuration 
+
+name: libpico Builder
+
+on:
+  pull_request:
+    paths:
+        - tools/libpico/**  
+  workflow_dispatch:
+  push:
+    paths:
+      - tools/libpico/**
+jobs:
+    build-libpico:
+        name: Build libpico precompiled libraries
+        runs-on: ubuntu-latest
+        steps:
+        - uses: actions/checkout@v4
+          with:
+            submodules: false
+        - name: Get submodules for pico-sdk
+          run: cd pico-sdk && git submodule update --init --recursive
+        - name: Install dependencies
+          run: |
+            sudo apt update
+            sudo apt install cmake make build-essential wget gcc-arm-none-eabi
+            # RISC-V toolchain
+            wget -O "$GITHUB_WORKSPACE/riscv32.tar.gz" "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/4.0.1/x86_64-linux-gnu.riscv32-unknown-elf-8ec9d6f.240929.tar.gz"
+            tar xf "$GITHUB_WORKSPACE/riscv32.tar.gz"
+            echo "$GITHUB_WORKSPACE/riscv32-unknown-elf/bin" >> "$GITHUB_PATH"
+            # ARM toolchain taken from Ubuntu repository
+        - name: Build libpico
+          run: |
+            cd tools/libpico
+            ./make-libpico.sh
+        - uses: actions/upload-artifact@v4
+          with:
+            name: libpico
+            path: |
+              tools/libpico/build-rp2040/*.a
+              tools/libpico/build-rp2350/*.a
+              tools/libpico/build-rp2350-riscv/*.a


### PR DESCRIPTION
For logs and artefacts see https://github.com/maxgerhardt/arduino-pico/actions/workflows/build-libpico.yml

Motivation: Build the `libpico*.a` files in CI, so that:
* builds are reproducable (we don't have to rely on users compiling those libraries, if they're using different compilers, may introduce subtle bugs)
* easy to adapt featureset of pico-sdk (e.g.; activate `CYW43_PIO_CLOCK_DIV_DYNAMIC` per https://github.com/earlephilhower/arduino-pico/discussions/2590)
* users have a starting point to also build it / check it locally if they want to.
  * eliminates some pain points as e.g. encountered in https://github.com/earlephilhower/arduino-pico/discussions/2549  
* auto-triggers when Pico-SDK config is changed

Open points of discussion:
* What compiler versions to use exactly?
  * For ARM I used the one built into `ubuntu-latest`, which can compile the SDK files normally
  * if I want to use arm-none-eabi-gcc from https://github.com/earlephilhower/pico-quick-toolchain/releases/download/4.0.1/x86_64-linux-gnu.arm-none-eabi-8ec9d6f.240929.tar.gz, I run into https://github.com/raspberrypi/pico-sdk/pull/2000, the SDK is not compilable
  * For RISC-V I used `https://github.com/earlephilhower/pico-quick-toolchain/releases/download/4.0.1/x86_64-linux-gnu.riscv32-unknown-elf-8ec9d6f.240929.tar.gz`
  * Optimally we want to use our custom toolchain for both builds?
* Renaming of output files?
  * the build generates e.g.  `build-rp2040/libpico-rp2040.a` in the ZIP file
  * but this repo has it as `lib/rp2040/libpico.a`, no CPU prefix

Artefact output: `libpico.zip`
![grafik](https://github.com/user-attachments/assets/d8f3fdb6-a8eb-43ed-9667-ff444c0172f6)
![grafik](https://github.com/user-attachments/assets/b81d35f2-e62d-4093-9bf1-a5c5e895e534)

Just for reference, non working with ARM toolchain from pico-quick-toolchain
```yaml
            # ARM toolchain
            wget -O "$GITHUB_WORKSPACE/arm.tar.gz" "https://github.com/earlephilhower/pico-quick-toolchain/releases/download/4.0.1/x86_64-linux-gnu.arm-none-eabi-8ec9d6f.240929.tar.gz"
            tar xf "$GITHUB_WORKSPACE/arm.tar.gz"
            echo "$GITHUB_WORKSPACE/arm-none-eabi/bin" >> "$GITHUB_PATH"
```