### PR TITLE
SimpleMDNS: let `begin` return a bool

### DIFF
--- a/libraries/SimpleMDNS/src/SimpleMDNS.cpp
+++ b/libraries/SimpleMDNS/src/SimpleMDNS.cpp
@@ -24,9 +24,9 @@
 #include <LwipEthernet.h>
 #include <lwip/apps/mdns.h>
 
-void SimpleMDNS::begin(const char *hostname, unsigned int ttl) {
+bool SimpleMDNS::begin(const char *hostname, unsigned int ttl) {
     if (_running) {
-        return;
+        return false;
     }
     mdns_resp_init();
     struct netif *n = netif_list;
@@ -37,6 +37,8 @@ void SimpleMDNS::begin(const char *hostname, unsigned int ttl) {
     __setStateChangeCallback(_statusCB);
     _hostname = strdup(hostname);
     _running = true;
+    
+    return true;
 }
 
 void SimpleMDNS::enableArduino(unsigned int port, bool passwd) {

--- a/libraries/SimpleMDNS/src/SimpleMDNS.cpp
+++ b/libraries/SimpleMDNS/src/SimpleMDNS.cpp
@@ -37,7 +37,7 @@ bool SimpleMDNS::begin(const char *hostname, unsigned int ttl) {
     __setStateChangeCallback(_statusCB);
     _hostname = strdup(hostname);
     _running = true;
-    
+
     return true;
 }
 

--- a/libraries/SimpleMDNS/src/SimpleMDNS.h
+++ b/libraries/SimpleMDNS/src/SimpleMDNS.h
@@ -25,7 +25,7 @@
 class SimpleMDNS {
 
 public:
-    void begin(const char *hostname, unsigned int ttl = 60);
+    bool begin(const char *hostname, unsigned int ttl = 60);
     void enableArduino(unsigned int port, bool passwd = false);
     void addService(const char *service, const char *proto, unsigned int port);
 


### PR DESCRIPTION
As discussed in #2582, this makes SimpleMDNS an even better drop-in replacement for LEAmDNS.