### PR TITLE
lwIP_Ethernet: rename copied cyw43 mac function

### DIFF
--- a/libraries/lwIP_Ethernet/src/LwipIntfDev.h
+++ b/libraries/lwIP_Ethernet/src/LwipIntfDev.h
@@ -53,15 +53,13 @@
 
 // Dup'd to avoid CYW43 dependency
 // Generate a mac address if one is not set in otp
-extern "C" {
-    static void cyw43_hal_generate_laa_mac(__unused int idx, uint8_t buf[6]) {
-        pico_unique_board_id_t board_id;
-        pico_get_unique_board_id(&board_id);
-        memcpy(buf, &board_id.id[2], 6);
-        buf[0] &= (uint8_t)~0x1; // unicast
-        buf[0] |= 0x2; // locally administered
-    }
-};
+static void _cyw43_hal_generate_laa_mac(__unused int idx, uint8_t buf[6]) {
+    pico_unique_board_id_t board_id;
+    pico_get_unique_board_id(&board_id);
+    memcpy(buf, &board_id.id[2], 6);
+    buf[0] &= (uint8_t)~0x1; // unicast
+    buf[0] |= 0x2; // locally administered
+}
 
 
 
@@ -70,8 +68,6 @@ enum EthernetLinkStatus {
     LinkON,
     LinkOFF
 };
-
-extern "C" void cyw43_hal_generate_laa_mac(__unused int idx, uint8_t buf[6]);
 
 template<class RawDev>
 class LwipIntfDev: public LwipIntf, public RawDev {
@@ -356,7 +352,7 @@ bool LwipIntfDev<RawDev>::begin(const uint8_t* macAddress, const uint16_t mtu) {
 #if 1
         // forge a new mac-address from the esp's wifi sta one
         // I understand this is cheating with an official mac-address
-        cyw43_hal_generate_laa_mac(0, _macAddress);
+        _cyw43_hal_generate_laa_mac(0, _macAddress);
 #else
         // https://serverfault.com/questions/40712/what-range-of-mac-addresses-can-i-safely-use-for-my-virtual-machines
         memset(_macAddress, 0, 6);


### PR DESCRIPTION
Prevent symbol conflicts when including both Wifi.h and cyw43.h

Fixes #2602