### PR TITLE
rp2040.enableDoubleResetBootloader only on RP2040

### DIFF
--- a/cores/rp2040/RP2040Support.cpp
+++ b/cores/rp2040/RP2040Support.cpp
@@ -18,6 +18,8 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#ifdef PICO_RP2040
+
 #include <Arduino.h>
 #include <hardware/structs/psm.h>
 
@@ -31,3 +33,5 @@ void RP2040::enableDoubleResetBootloader() {
         boot_double_tap_check();
     }
 }
+
+#endif

--- a/cores/rp2040/RP2040Support.h
+++ b/cores/rp2040/RP2040Support.h
@@ -351,7 +351,9 @@ public:
         }
     }
 
+#ifdef PICO_RP2040
     static void enableDoubleResetBootloader();
+#endif
 
     void wdt_begin(uint32_t delay_ms) {
         watchdog_enable(delay_ms, 1);

--- a/docs/rp2040.rst
+++ b/docs/rp2040.rst
@@ -95,8 +95,8 @@ doing any WiFi calls.
 Bootloader
 ----------
 
-void rp2040.enableDoubleResetBootloader()
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+void rp2040.enableDoubleResetBootloader()  (Pico/RP2040 only)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Add a call anywhere in the sketch to ``rp2040.enableDoubleResetBootloader()`` and
 the core will check for a double-tap on reset, and if found will start the USB
 bootloader.


### PR DESCRIPTION
The RP2350 boot ROM seems to randomize memory on a HW reset, including both CPU stacks where we normally stuff the "reset to bootloader" flag. Update the docs and source to remove rp2040.enableDoubleResetBootloader() on RP2350-based boards.

Fixes #2606