### PR TITLE
Add optional callback parameters for I2S/PWMAudio

### DIFF
--- a/libraries/AudioBufferManager/src/AudioBufferManager.h
+++ b/libraries/AudioBufferManager/src/AudioBufferManager.h
@@ -29,6 +29,7 @@ public:
     ~AudioBufferManager();
 
     void setCallback(void (*fn)());
+    void setCallback(void (*fn)(void *), void *cbData);
 
     bool begin(int dreq, volatile void *pioFIFOAddr);
 
@@ -93,7 +94,11 @@ private:
     bool _isOutput;
 
     int _channelDMA[2];
+
+    bool _useData;
     void (*_callback)();
+    void (*_callbackCB)(void *);
+    void *_callbackData;
 
     bool _overunderflow;
 

--- a/libraries/I2S/src/I2S.h
+++ b/libraries/I2S/src/I2S.h
@@ -110,7 +110,9 @@ public:
     // Note that these callback are called from **INTERRUPT CONTEXT** and hence
     // should be in RAM, not FLASH, and should be quick to execute.
     void onTransmit(void(*)(void));
+    void onTransmit(void(*)(void *), void *);
     void onReceive(void(*)(void));
+    void onReceive(void(*)(void *), void *);
 
 private:
     pin_size_t _pinBCLK;
@@ -142,6 +144,9 @@ private:
     int _isHolding = 0;
 
     void (*_cb)();
+    void (*_cbd)(void *);
+    void *_cbdata;
+
     void MCLKbegin();
 
     AudioBufferManager *_arb;

--- a/libraries/PWMAudio/src/PWMAudio.cpp
+++ b/libraries/PWMAudio/src/PWMAudio.cpp
@@ -112,6 +112,14 @@ void PWMAudio::onTransmit(void(*fn)(void)) {
     }
 }
 
+void PWMAudio::onTransmit(void(*fn)(void *), void *cbData) {
+    _cbd = fn;
+    _cbdata = cbData;
+    if (_running) {
+        _arb->setCallback(_cbd, _cbdata);
+    }
+}
+
 bool PWMAudio::begin() {
     if (_running) {
         return false;
@@ -155,7 +163,11 @@ bool PWMAudio::begin() {
         return false;
     }
 
-    _arb->setCallback(_cb);
+    if (_cbd) {
+        _arb->setCallback(_cbd, _cbdata);
+    } else {
+        _arb->setCallback(_cb);
+    }
 
     return true;
 }

--- a/libraries/PWMAudio/src/PWMAudio.h
+++ b/libraries/PWMAudio/src/PWMAudio.h
@@ -73,6 +73,15 @@ public:
     // Note that these callback are called from **INTERRUPT CONTEXT** and hence
     // should be in RAM, not FLASH, and should be quick to execute.
     void onTransmit(void(*)(void));
+    void onTransmit(void(*)(void *), void *data);
+
+    bool getUnderflow() {
+        if (!_running) {
+            return false;
+        } else {
+            return _arb->getOverUnderflow();
+        }
+    }
 
 private:
     pin_size_t _pin;
@@ -94,6 +103,8 @@ private:
     uint32_t _holdWord;
 
     void (*_cb)();
+    void (*_cbd)(void *);
+    void *_cbdata;
 
     AudioBufferManager *_arb;
 


### PR DESCRIPTION
Like GPIO interrupts, allow the user to pass in a callback data pointer.