### PR TITLE
Derive playback objects from common AudioOutputBase

### DIFF
--- a/cores/rp2040/AudioOutputBase.h
+++ b/cores/rp2040/AudioOutputBase.h
@@ -1,0 +1,21 @@
+// Abstract class for audio output devices to allow easy swapping between output devices
+
+#pragma once
+
+#include <Print.h>
+
+class AudioOutputBase : public Print {
+public:
+    virtual ~AudioOutputBase() { }
+    virtual bool setBuffers(size_t buffers, size_t bufferWords, int32_t silenceSample = 0) = 0;
+    virtual bool setBitsPerSample(int bps) = 0;
+    virtual bool setFrequency(int freq) = 0;
+    virtual bool setStereo(bool stereo = true) = 0;
+    virtual bool begin() = 0;
+    virtual bool end() = 0;
+    virtual bool getUnderflow() = 0;
+    virtual void onTransmit(void(*)(void *), void *) = 0;
+    // From Print
+    virtual size_t write(const uint8_t *buffer, size_t size) = 0;
+    virtual int availableForWrite() = 0;
+};

--- a/libraries/BluetoothAudio/src/A2DPSource.cpp
+++ b/libraries/BluetoothAudio/src/A2DPSource.cpp
@@ -220,6 +220,8 @@ void A2DPSource::clearPairing() {
 size_t A2DPSource::write(const uint8_t *buffer, size_t size) {
     BluetoothLock b;
 
+    size = std::min((size_t)availableForWrite(), size);
+
     size_t count = 0;
     size /= 2;
 
@@ -260,6 +262,7 @@ int A2DPSource::availableForWrite() {
     } else {
         avail = _pcmBufferSize - _pcmWriter + _pcmReader - 1;
     }
+    avail /= sizeof(uint32_t); // availableForWrite always 32b sample pairs in this core...
     return avail;
 }
 

--- a/libraries/I2S/src/I2S.cpp
+++ b/libraries/I2S/src/I2S.cpp
@@ -287,7 +287,7 @@ bool I2S::begin() {
     return true;
 }
 
-void I2S::end() {
+bool I2S::end() {
     if (_running) {
         if (_MCLKenabled) {
             pio_sm_set_enabled(_pioMCLK, _smMCLK, false);
@@ -301,6 +301,7 @@ void I2S::end() {
         delete _i2s;
         _i2s = nullptr;
     }
+    return true;
 }
 
 int I2S::available() {

--- a/libraries/I2S/src/I2S.h
+++ b/libraries/I2S/src/I2S.h
@@ -21,9 +21,10 @@
 
 #pragma once
 #include <Arduino.h>
-#include "AudioBufferManager.h"
+#include <AudioBufferManager.h>
+#include <AudioOutputBase.h>
 
-class I2S : public Stream {
+class I2S : public Stream, public AudioOutputBase {
 public:
     I2S(PinMode direction = OUTPUT, pin_size_t bclk = 26, pin_size_t data = 28, pin_size_t mclk = 25);
     virtual ~I2S();
@@ -31,9 +32,12 @@ public:
     bool setBCLK(pin_size_t pin);
     bool setDATA(pin_size_t pin);
     bool setMCLK(pin_size_t pin);
-    bool setBitsPerSample(int bps);
-    bool setBuffers(size_t buffers, size_t bufferWords, int32_t silenceSample = 0);
-    bool setFrequency(int newFreq);
+    virtual bool setBitsPerSample(int bps) override;
+    virtual bool setBuffers(size_t buffers, size_t bufferWords, int32_t silenceSample = 0) override;
+    virtual bool setFrequency(int newFreq) override;
+    virtual bool setStereo(bool stereo = true) override {
+        return stereo;
+    }
     bool setLSBJFormat();
     bool setTDMFormat();
     bool setTDMChannels(int channels);
@@ -46,8 +50,11 @@ public:
         return begin();
     }
 
-    bool begin();
-    void end();
+    virtual bool begin() override;
+    virtual bool end() override;
+    virtual bool getUnderflow() override {
+        return getOverUnderflow();
+    }
 
     // from Stream
     virtual int available() override;

--- a/libraries/PWMAudio/src/PWMAudio.cpp
+++ b/libraries/PWMAudio/src/PWMAudio.cpp
@@ -40,7 +40,8 @@ PWMAudio::~PWMAudio() {
     end();
 }
 
-bool PWMAudio::setBuffers(size_t buffers, size_t bufferWords) {
+bool PWMAudio::setBuffers(size_t buffers, size_t bufferWords, int32_t silence) {
+    (void) silence;
     if (_running || (buffers < 3) || (bufferWords < 8)) {
         return false;
     }
@@ -176,7 +177,7 @@ bool PWMAudio::begin() {
     return true;
 }
 
-void PWMAudio::end() {
+bool PWMAudio::end() {
     if (_running) {
         _running = false;
         pinMode(_pin, OUTPUT);
@@ -189,6 +190,7 @@ void PWMAudio::end() {
         dma_timer_unclaim(_pacer);
         _pacer = -1;
     }
+    return true;
 }
 
 int PWMAudio::available() {

--- a/libraries/PWMAudio/src/PWMAudio.h
+++ b/libraries/PWMAudio/src/PWMAudio.h
@@ -21,20 +21,24 @@
 
 #pragma once
 #include <Arduino.h>
-#include "AudioBufferManager.h"
+#include <AudioOutputBase.h>
+#include <AudioBufferManager.h>
 
-class PWMAudio : public Stream {
+class PWMAudio : public Stream, public AudioOutputBase {
 public:
     PWMAudio(pin_size_t pin = 0, bool stereo = false);
     virtual ~PWMAudio();
 
-    bool setBuffers(size_t buffers, size_t bufferWords);
+    virtual bool setBuffers(size_t buffers, size_t bufferWords, int32_t silenceSample = 0) override;
     /*Sets the frequency of the PWM in hz*/
     bool setPWMFrequency(int newFreq);
     /*Sets the sample rate frequency in hz*/
-    bool setFrequency(int frequency);
+    virtual bool setFrequency(int frequency) override;
     bool setPin(pin_size_t pin);
-    bool setStereo(bool stereo = true);
+    virtual bool setStereo(bool stereo = true) override;
+    virtual bool setBitsPerSample(int bits) override {
+        return bits == 16;
+    }
 
     bool begin(long sampleRate) {
         _sampleRate = sampleRate;
@@ -47,8 +51,8 @@ public:
         return begin();
     }
 
-    bool begin();
-    void end();
+    virtual bool begin() override;
+    virtual bool end() override;
 
     // from Stream
     virtual int available() override;


### PR DESCRIPTION
The audio output objects all have the same general necessary configuration calls.  Abstract them out to a generic AudioOutputBase interface class that they will inherit from.  Simplies letting applications use different output channels.

Should be backwards compatible with existing code.