### PR TITLE
Overclock to 153.6 MHz (instead of 147.6 MHz) for I²S 48 kHz sample rate

### DIFF
--- a/docs/i2s.rst
+++ b/docs/i2s.rst
@@ -71,7 +71,7 @@ sample rate on-the-fly.
 bool setSysClk(int samplerate) 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Changes the PICO system clock to optimise for the desired samplerate. 
-The clock changes to 147.6 MHz for samplerates that are a multiple of 8 kHz, and 135.6 MHz for multiples of 11.025 kHz.
+The clock changes to 153.6 MHz for samplerates that are a multiple of 8 kHz, and 135.6 MHz for multiples of 11.025 kHz.
 Note that using ``setSysClk()`` may affect the timing of other sysclk-dependent functions.
 Should be called before any I2S functions and any other sysclk dependent initialisations.
 

--- a/libraries/I2S/src/I2S.cpp
+++ b/libraries/I2S/src/I2S.cpp
@@ -123,12 +123,10 @@ bool I2S::setFrequency(int newFreq) {
 
 bool I2S::setSysClk(int samplerate) { // optimise sys_clk for desired samplerate
     if (samplerate % 11025 == 0) {
-        set_sys_clock_khz(I2SSYSCLK_44_1, false); // 147.6 unsuccessful - no I2S no USB
-        return true;
+        return set_sys_clock_khz(I2SSYSCLK_44_1, false);
     }
     if (samplerate % 8000 == 0) {
-        set_sys_clock_khz(I2SSYSCLK_8, false);
-        return true;
+        return set_sys_clock_khz(I2SSYSCLK_8, false);
     }
     return false;
 }

--- a/libraries/I2S/src/I2S.h
+++ b/libraries/I2S/src/I2S.h
@@ -163,5 +163,5 @@ private:
     int _sm, _smMCLK;
 
     static const int I2SSYSCLK_44_1 = 135600; // 44.1, 88.2 kHz sample rates
-    static const int I2SSYSCLK_8 = 147600;  // 8k, 16, 32, 48, 96, 192 kHz
+    static const int I2SSYSCLK_8 = 153600;  // 8k, 16, 32, 48, 96, 192 kHz
 };

--- a/tools/makeboards.py
+++ b/tools/makeboards.py
@@ -39,7 +39,7 @@ def BuildDebugLevel(name):
 
 def BuildFreq(name, defmhz):
     out = 0
-    for f in [ defmhz, 50, 100, 120, 125, 128, 133, 150, 175, 200, 225, 240, 250, 275, 300]:
+    for f in [ defmhz, 50, 100, 120, 125, 128, 133, 150, 153.6, 175, 200, 225, 240, 250, 275, 300]:
         warn = ""
         if f > defmhz: warn = " (Overclock)"
         if (out == 1) and (f == defmhz):

--- a/tools/makeboards.py
+++ b/tools/makeboards.py
@@ -39,7 +39,7 @@ def BuildDebugLevel(name):
 
 def BuildFreq(name, defmhz):
     out = 0
-    for f in [ defmhz, 50, 100, 120, 125, 128, 133, 150, 153.6, 175, 200, 225, 240, 250, 275, 300]:
+    for f in [ defmhz, 50, 100, 120, 125, 128, 133, 150, 175, 200, 225, 240, 250, 275, 300]:
         warn = ""
         if f > defmhz: warn = " (Overclock)"
         if (out == 1) and (f == defmhz):


### PR DESCRIPTION
Increasing `clk_sys` by another 6 MHz would allow for exact 96 kHz and 192 kHz sampling rates (apart from the ±30 ppm of Pico's 12 MHz crystal itself).