### PR TITLE
Move MacX86 runner up to new minimum spec

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -196,7 +196,7 @@ jobs:
     name: Mac
     strategy:
       matrix:
-        os: [macOS-12, macOS-14]
+        os: [macOS-13, macOS-14]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
The MacOS12 runner is dead, so move up to the lowest version still available for CI.