### PR TITLE
Add real block write for AudioRequestBuffer

### DIFF
--- a/libraries/AudioBufferManager/src/AudioBufferManager.h
+++ b/libraries/AudioBufferManager/src/AudioBufferManager.h
@@ -34,6 +34,7 @@ public:
     bool begin(int dreq, volatile void *pioFIFOAddr);
 
     bool write(uint32_t v, bool sync = true);
+    size_t write(const uint32_t *v, size_t words, bool sync = true);
     bool read(uint32_t *v, bool sync = true);
     void flush();
 

--- a/libraries/I2S/src/I2S.cpp
+++ b/libraries/I2S/src/I2S.cpp
@@ -500,20 +500,7 @@ size_t I2S::write(const uint8_t *buffer, size_t size) {
     if (size & 0x3 || !_running || !_isOutput) {
         return 0;
     }
-
-    size_t writtenSize = 0;
-    uint32_t *p = (uint32_t *)buffer;
-    while (size) {
-        if (!_arb->write(*p, false)) {
-            // Blocked, stop write here
-            return writtenSize;
-        } else {
-            p++;
-            size -= 4;
-            writtenSize += 4;
-        }
-    }
-    return writtenSize;
+    return _arb->write((const uint32_t *)buffer, size / sizeof(uint32_t), false);
 }
 
 int I2S::availableForWrite() {


### PR DESCRIPTION
Optimize AudioRquestBuffer writing when large blocks are available (i.e. I2S writes of full MP3 or AAC frames in BackgroundAudio).  Update I2S to use the new call.  Reduces 1152 calls to arb::write() to a single call/return and optimized memcpy in that case.