### PR TITLE
Properly wrap AudioBufferManager block writes

### DIFF
--- a/libraries/AudioBufferManager/src/AudioBufferManager.cpp
+++ b/libraries/AudioBufferManager/src/AudioBufferManager.cpp
@@ -209,6 +209,7 @@ size_t AudioBufferManager::write(const uint32_t *v, size_t words, bool sync) {
         size_t availToWriteThisBuff = _wordsPerBuffer - _userOff;
         size_t toWrite = std::min(availToWriteThisBuff, words);
         memcpy(&((*p)->buff[_userOff]), v, toWrite * sizeof(uint32_t));
+        v += toWrite;
         written += toWrite;
         _userOff += toWrite;
         words -= toWrite;


### PR DESCRIPTION
The memcpy-version of the ABM::write updated the destination and count but neglected to move the source forward.  If a block write crossed a frame boundary then the 2nd frame would repeat the data from the first half of the buffer.

Fix by incrementing the source pointer by the same amount as was written.