### PR TITLE
Fix ADCInput clocks for multiple inputs

### DIFF
--- a/libraries/ADCInput/src/ADCInput.cpp
+++ b/libraries/ADCInput/src/ADCInput.cpp
@@ -77,8 +77,9 @@ bool ADCInput::setPins(pin_size_t pin0, pin_size_t pin1, pin_size_t pin2, pin_si
 }
 
 bool ADCInput::setFrequency(int newFreq) {
-    _freq = newFreq * __builtin_popcount(_pinMask); // Want to sample all channels at given frequency
-    adc_set_clkdiv(48000000.0f / _freq - 1.0f);
+    _freq = newFreq;
+    int scaledFreq = newFreq * __builtin_popcount(_pinMask); // Want to sample all channels at given frequency
+    adc_set_clkdiv(48000000.0f / scaledFreq - 1.0f);
     return true;
 }
 


### PR DESCRIPTION
When multiple inputs were active, the frequency was being scaled two times resulting in incorrect sampling speed.  Correct to only scale the calculation and not the stored value (which is used in `begin`).

Fixes #2754