### PR TITLE
A2DPSink: Remove stubs, fix volume and connect callbacks

### DIFF
--- a/libraries/BluetoothAudio/src/A2DPSink.cpp
+++ b/libraries/BluetoothAudio/src/A2DPSink.cpp
@@ -676,6 +676,8 @@ void A2DPSink::avrcp_target_packet_handler(uint8_t packet_type, uint16_t channel
         volume_percentage = volume * 100 / 127;
         DEBUGV("AVRCP Target    : Volume set to %d%% (%d)\n", volume_percentage, volume);
         _consumer->setVolume(volume);
+        if(_volumeCB)
+          _volumeCB(_volumeData, volume);
         break;
 
     case AVRCP_SUBEVENT_OPERATION:
@@ -773,6 +775,11 @@ void A2DPSink::a2dp_sink_packet_handler(uint8_t packet_type, uint16_t channel, u
         DEBUGV("A2DP  Sink      : Streaming connection is established, address %s, cid 0x%02x, local seid %d\n",
                bd_addr_to_str(a2dp_conn->addr), a2dp_conn->a2dp_cid, a2dp_conn->a2dp_local_seid);
         memcpy(_sourceAddress, a2dp_conn->addr, sizeof(_sourceAddress));
+        
+        _connected = true;
+        if (_connectCB) {
+            _connectCB(_connectData, true);
+        }
         break;
 
     case A2DP_SUBEVENT_STREAM_STARTED:
@@ -784,10 +791,6 @@ void A2DPSink::a2dp_sink_packet_handler(uint8_t packet_type, uint16_t channel, u
         // prepare media processing
         media_processing_init(&a2dp_conn->sbc_configuration);
         // audio stream is started when buffer reaches minimal level
-        _connected = true;
-        if (_connectCB) {
-            _connectCB(_connectData, true);
-        }
         break;
 
     case A2DP_SUBEVENT_STREAM_SUSPENDED:

--- a/libraries/BluetoothAudio/src/A2DPSink.cpp
+++ b/libraries/BluetoothAudio/src/A2DPSink.cpp
@@ -676,8 +676,9 @@ void A2DPSink::avrcp_target_packet_handler(uint8_t packet_type, uint16_t channel
         volume_percentage = volume * 100 / 127;
         DEBUGV("AVRCP Target    : Volume set to %d%% (%d)\n", volume_percentage, volume);
         _consumer->setVolume(volume);
-        if(_volumeCB)
-          _volumeCB(_volumeData, volume);
+        if (_volumeCB) {
+            _volumeCB(_volumeData, volume);
+        }
         break;
 
     case AVRCP_SUBEVENT_OPERATION:
@@ -775,7 +776,7 @@ void A2DPSink::a2dp_sink_packet_handler(uint8_t packet_type, uint16_t channel, u
         DEBUGV("A2DP  Sink      : Streaming connection is established, address %s, cid 0x%02x, local seid %d\n",
                bd_addr_to_str(a2dp_conn->addr), a2dp_conn->a2dp_cid, a2dp_conn->a2dp_local_seid);
         memcpy(_sourceAddress, a2dp_conn->addr, sizeof(_sourceAddress));
-        
+
         _connected = true;
         if (_connectCB) {
             _connectCB(_connectData, true);

--- a/libraries/BluetoothAudio/src/A2DPSink.h
+++ b/libraries/BluetoothAudio/src/A2DPSink.h
@@ -30,40 +30,13 @@
 #include "btstack_resample.h"
 #include "btstack_ring_buffer.h"
 
-class A2DPSink : public Stream {
+class A2DPSink {
 public:
     A2DPSink() {
         _title[0] = 0;
         _artist[0] = 0;
         _album[0] = 0;
         _genre[0] = 0;
-    }
-    virtual int available() override {
-        return 0; // Unreadable, this is output only
-    }
-
-    virtual int read() override {
-        return 0;
-    }
-
-    virtual int peek() override {
-        return 0;
-    }
-
-    virtual void flush() override {
-    }
-    virtual size_t write(const uint8_t *buffer, size_t size) override {
-        (void) buffer;
-        (void) size;
-        return 0;
-    }
-    virtual int availableForWrite() override {
-        return 0;
-    }
-
-    virtual size_t write(uint8_t s) override {
-        (void) s;
-        return 0;
     }
 
     bool setName(const char *name) {
@@ -73,11 +46,6 @@ public:
         free(_name);
         _name = strdup(name);
         return true;
-    }
-
-    void onTransmit(void (*cb)(void *), void *cbData = nullptr) {
-        _transmitCB = cb;
-        _transmitData = cbData;
     }
 
     void onAVRCP(void (*cb)(void *, avrcp_operation_id_t, int), void *cbData = nullptr) {

--- a/libraries/BluetoothAudio/src/A2DPSink.h
+++ b/libraries/BluetoothAudio/src/A2DPSink.h
@@ -205,8 +205,6 @@ private:
     bool _connected = false;
 
     // Callbacks
-    void (*_transmitCB)(void *) = nullptr;
-    void *_transmitData;
     void (*_avrcpCB)(void *, avrcp_operation_id_t, int) = nullptr;
     void *_avrcpData;
     void (*_batteryCB)(void *, avrcp_battery_status_t) = nullptr;


### PR DESCRIPTION
Fixes #2751

Technically a breaking change, since this PR removes Stream subclass, onTransmit method (and associated fields) and changes behavior of onConnect.