### PR TITLE
BREAKING: ABM::available(ForWrite) return bytes

### DIFF
--- a/libraries/ADCInput/src/ADCInput.cpp
+++ b/libraries/ADCInput/src/ADCInput.cpp
@@ -156,7 +156,7 @@ int ADCInput::available() {
     if (!_running) {
         return 0;
     } else {
-        return _arb->available();
+        return _arb->available() + _isHolding ? sizeof(int16_t) : 0;
     }
 }
 

--- a/libraries/AudioBufferManager/src/AudioBufferManager.cpp
+++ b/libraries/AudioBufferManager/src/AudioBufferManager.cpp
@@ -259,12 +259,12 @@ int AudioBufferManager::available() {
         return 0;
     }
 
-    int avail = _wordsPerBuffer - _userOff; // Currently available in this buffer
+    int avail = (_wordsPerBuffer - _userOff) * sizeof(uint32_t); // Currently available in this buffer
 
     // Each add'l buffer has wpb spaces...
     auto x = p->next;
     while (x) {
-        avail += _wordsPerBuffer;
+        avail += _wordsPerBuffer * sizeof(uint32_t);
         x = x->next;
     }
     return avail;

--- a/libraries/BluetoothAudio/examples/A2DPSource/A2DPSource.ino
+++ b/libraries/BluetoothAudio/examples/A2DPSource/A2DPSource.ino
@@ -80,7 +80,7 @@ void setup() {
 }
 
 void loop() {
-  while ((size_t)a2dp.availableForWrite() > sizeof(pcm)) {
+  while ((size_t)a2dp.availableForWrite() >= sizeof(pcm)) {
     fillPCM();
     a2dp.write((const uint8_t *)pcm, sizeof(pcm));
   }

--- a/libraries/BluetoothAudio/src/A2DPSource.cpp
+++ b/libraries/BluetoothAudio/src/A2DPSource.cpp
@@ -262,7 +262,6 @@ int A2DPSource::availableForWrite() {
     } else {
         avail = _pcmBufferSize - _pcmWriter + _pcmReader - 1;
     }
-    avail /= sizeof(uint32_t); // availableForWrite always 32b sample pairs in this core...
     return avail;
 }
 

--- a/libraries/BluetoothAudio/src/BluetoothAudioConsumerI2S.cpp
+++ b/libraries/BluetoothAudio/src/BluetoothAudioConsumerI2S.cpp
@@ -69,7 +69,7 @@ void BluetoothAudioConsumerI2S::close() {
 }
 
 void BluetoothAudioConsumerI2S::fill() {
-    int num_samples = _i2s->availableForWrite() / 2;
+    int num_samples = _i2s->availableForWrite() / (2 * sizeof(int16_t));
     int16_t buff[32 * 2];
     while (num_samples > 63) {
         _a2dpSink->playback_handler((int16_t *) buff, 32);

--- a/libraries/BluetoothAudio/src/BluetoothAudioConsumerPWM.cpp
+++ b/libraries/BluetoothAudio/src/BluetoothAudioConsumerPWM.cpp
@@ -70,7 +70,7 @@ void BluetoothAudioConsumerPWM::close() {
 }
 
 void BluetoothAudioConsumerPWM::fill() {
-    int num_samples = _pwm->availableForWrite() / 2;
+    int num_samples = _pwm->availableForWrite() / (2 * sizeof(int16_t));
     int16_t buff[32 * 2];
     while (num_samples > 63) {
         _a2dpSink->playback_handler((int16_t *) buff, 32);

--- a/libraries/BluetoothHIDMaster/examples/KeyboardPiano/KeyboardPiano.ino
+++ b/libraries/BluetoothHIDMaster/examples/KeyboardPiano/KeyboardPiano.ino
@@ -46,7 +46,7 @@ void silenceOscillators() {
 
 // PWM callback, generates sum of online oscillators
 void fill() {
-  int num_samples = pwm.availableForWrite() / 2;
+  int num_samples = pwm.availableForWrite() / (2 * sizeof(int16_t));
   int16_t buff[32 * 2];
 
   while (num_samples > 63) {

--- a/libraries/BluetoothHIDMaster/examples/KeyboardPianoBLE/KeyboardPianoBLE.ino
+++ b/libraries/BluetoothHIDMaster/examples/KeyboardPianoBLE/KeyboardPianoBLE.ino
@@ -46,7 +46,7 @@ void silenceOscillators() {
 
 // PWM callback, generates sum of online oscillators
 void fill() {
-  int num_samples = pwm.availableForWrite() / 2;
+  int num_samples = pwm.availableForWrite() / (2 * sizeof(int16_t));
   int16_t buff[32 * 2];
 
   while (num_samples > 63) {

--- a/libraries/I2S/src/I2S.cpp
+++ b/libraries/I2S/src/I2S.cpp
@@ -307,7 +307,6 @@ int I2S::available() {
         return 0;
     } else {
         auto avail = _arb->available();
-        avail *= 4; // 4 samples per 32-bits
         if (_bps < 24 && !_isOutput) {
             avail += _isHolding / 8;
         }

--- a/libraries/PWMAudio/examples/PlayRaw/PlayRaw.ino
+++ b/libraries/PWMAudio/examples/PlayRaw/PlayRaw.ino
@@ -17,7 +17,7 @@ PWMAudio pwm(1);
 unsigned int count = 0;
 
 void cb() {
-  while (pwm.availableForWrite() > sizeof(int16_t)) {
+  while (pwm.availableForWrite() > (int)sizeof(int16_t)) {
     pwm.write(*p++);
     count += 2;
     if (count >= sizeof(out_raw)) {

--- a/libraries/PWMAudio/examples/PlayRaw/PlayRaw.ino
+++ b/libraries/PWMAudio/examples/PlayRaw/PlayRaw.ino
@@ -17,7 +17,7 @@ PWMAudio pwm(1);
 unsigned int count = 0;
 
 void cb() {
-  while (pwm.availableForWrite()) {
+  while (pwm.availableForWrite() > sizeof(int16_t)) {
     pwm.write(*p++);
     count += 2;
     if (count >= sizeof(out_raw)) {

--- a/libraries/PWMAudio/examples/PlayStereo/PlayStereo.ino
+++ b/libraries/PWMAudio/examples/PlayStereo/PlayStereo.ino
@@ -24,7 +24,7 @@ double sineTable[128]; // Precompute sine wave in 128 steps
 
 unsigned int cnt = 0;
 void cb() {
-  while (pwm.availableForWrite() >= 2 * sizeof(int16_t)) {
+  while (pwm.availableForWrite() >= 2 * (int)sizeof(int16_t)) {
     double now = ((double)cnt) / (double)freq;
     int fl = freqL << 7; // Prescale by 128 to avoid FP math later on
     int fr = freqR << 7; // Prescale by 128 to avoid FP math later on

--- a/libraries/PWMAudio/examples/PlayStereo/PlayStereo.ino
+++ b/libraries/PWMAudio/examples/PlayStereo/PlayStereo.ino
@@ -24,7 +24,7 @@ double sineTable[128]; // Precompute sine wave in 128 steps
 
 unsigned int cnt = 0;
 void cb() {
-  while (pwm.availableForWrite()) {
+  while (pwm.availableForWrite() >= 2 * sizeof(int16_t)) {
     double now = ((double)cnt) / (double)freq;
     int fl = freqL << 7; // Prescale by 128 to avoid FP math later on
     int fr = freqR << 7; // Prescale by 128 to avoid FP math later on


### PR DESCRIPTION
The Arduino spec is for available and availableForWrite to return a number of bytes, not uint32_t's.  Libraries and apps using AudioBufferManager were getting number of 32b units available, not bytes (I2S, PWMAudio, BT Audio).