### PR TITLE
Don't set SDFAT_FILE_TYPE, default is OK

### DIFF
--- a/libraries/BTstackLib/examples/LEPeripheral/LEPeripheral.ino
+++ b/libraries/BTstackLib/examples/LEPeripheral/LEPeripheral.ino
@@ -82,7 +82,7 @@ void deviceDisconnectedCallback(BLEDevice * device) {
    @text In BTstack, the Read Callback is first called to query the size of the
    Characteristic Value, before it is called to provide the data.
    Both times, the size has to be returned. The data is only stored in the provided
-   buffer, if the buffer argeument is not NULL.
+   buffer, if the buffer argument is not NULL.
    If more than one dynamic Characteristics is used, the value handle is used
    to distinguish them.
 */

--- a/libraries/LEAmDNS/src/LEAmDNS_Transfer.cpp
+++ b/libraries/LEAmDNS/src/LEAmDNS_Transfer.cpp
@@ -161,7 +161,7 @@ bool MDNSResponder::_prepareMDNSMessage(MDNSResponder::stcMDNSSendParameter& p_r
     // Prepare header; count answers
     stcMDNS_MsgHeader msgHeader(p_rSendParameter.m_u16ID, p_rSendParameter.m_bResponse, 0,
                                 p_rSendParameter.m_bAuthorative);
-    // If this is a response, the answers are anwers,
+    // If this is a response, the answers are answers,
     // else this is a query or probe and the answers go into auth section
     uint16_t& ru16Answers
         = (p_rSendParameter.m_bResponse ? msgHeader.m_u16ANCount : msgHeader.m_u16NSCount);

--- a/platform.txt
+++ b/platform.txt
@@ -114,7 +114,7 @@ build.espwifitype=
 build.debugscript=picoprobe_cmsis_dap.tcl
 build.picodebugflags=
 build.variantdefines=
-build.sdfatdefines=-DFILE_COPY_CONSTRUCTOR_SELECT=FILE_COPY_CONSTRUCTOR_PUBLIC -DUSE_UTF8_LONG_NAMES=1 -DSDFAT_FILE_TYPE=3 -DDISABLE_FS_H_WARNING=1
+build.sdfatdefines=-DFILE_COPY_CONSTRUCTOR_SELECT=FILE_COPY_CONSTRUCTOR_PUBLIC -DUSE_UTF8_LONG_NAMES=1 -DDISABLE_FS_H_WARNING=1
 
 # Allow Pico boards to be auto-discovered by the IDE
 #discovery.rp2040.pattern={runtime.tools.pqt-python3.path}/python3 -I "{runtime.platform.path}/tools/pluggable_discovery.py"

--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -229,7 +229,6 @@ env.Append(
         # SdFat definitions required for SDFS
         ("FILE_COPY_CONSTRUCTOR_SELECT", "FILE_COPY_CONSTRUCTOR_PUBLIC"),
         ("USE_UTF8_LONG_NAMES", "1"),
-        ("SDFAT_FILE_TYPE", "3"),
         ("DISABLE_FS_H_WARNING", "1")
     ],
 

--- a/variants/challenger_2040_wifi/ChallengerWiFi.cpp
+++ b/variants/challenger_2040_wifi/ChallengerWiFi.cpp
@@ -55,7 +55,7 @@ void Challenger2040WiFiClass::flashReset() { // Prepare ESP for flashing
 // after a sw or hw reset have been performed to ensure that the AT
 // interpreter is up and running.
 bool Challenger2040WiFiClass::waitForReady() {
-    int timeout = 20;                         // Aprox max 2 sec
+    int timeout = 20;                         // Approx max 2 sec
 
     _serial->setTimeout(100);
     String rdy = _serial->readStringUntil('\n');

--- a/variants/challenger_2040_wifi6_ble/ChallengerWiFi.cpp
+++ b/variants/challenger_2040_wifi6_ble/ChallengerWiFi.cpp
@@ -62,7 +62,7 @@ void Challenger2040WiFiClass::flashReset() { // Prepare ESP for flashing
 // after a sw or hw reset have been performed to ensure that the AT
 // interpreter is up and running.
 bool Challenger2040WiFiClass::waitForReady() {
-    int timeout = 20;                         // Aprox max 2 sec
+    int timeout = 20;                         // Approx max 2 sec
 
     _serial->setTimeout(100);
     String rdy = _serial->readStringUntil('\n');

--- a/variants/challenger_2040_wifi_ble/ChallengerWiFi.cpp
+++ b/variants/challenger_2040_wifi_ble/ChallengerWiFi.cpp
@@ -55,7 +55,7 @@ void Challenger2040WiFiClass::flashReset() { // Prepare ESP for flashing
 // after a sw or hw reset have been performed to ensure that the AT
 // interpreter is up and running.
 bool Challenger2040WiFiClass::waitForReady() {
-    int timeout = 20;                         // Aprox max 2 sec
+    int timeout = 20;                         // Approx max 2 sec
 
     _serial->setTimeout(100);
     String rdy = _serial->readStringUntil('\n');

--- a/variants/challenger_2350_wifi6_ble5/ChallengerWiFi.cpp
+++ b/variants/challenger_2350_wifi6_ble5/ChallengerWiFi.cpp
@@ -55,7 +55,7 @@ void Challenger2040WiFiClass::flashReset() { // Prepare ESP for flashing
 // after a sw or hw reset have been performed to ensure that the AT
 // interpreter is up and running.
 bool Challenger2040WiFiClass::waitForReady() {
-    int timeout = 20;                         // Aprox max 2 sec
+    int timeout = 20;                         // Approx max 2 sec
 
     _serial->setTimeout(100);
     String rdy = _serial->readStringUntil('\n');

--- a/variants/challenger_nb_2040_wifi/ChallengerWiFi.cpp
+++ b/variants/challenger_nb_2040_wifi/ChallengerWiFi.cpp
@@ -55,7 +55,7 @@ void Challenger2040WiFiClass::flashReset() { // Prepare ESP for flashing
 // after a sw or hw reset have been performed to ensure that the AT
 // interpreter is up and running.
 bool Challenger2040WiFiClass::waitForReady() {
-    int timeout = 20;                         // Aprox max 2 sec
+    int timeout = 20;                         // Approx max 2 sec
 
     _serial->setTimeout(100);
     String rdy = _serial->readStringUntil('\n');

--- a/variants/connectivity_2040_lte_wifi_ble/Connectivity.cpp
+++ b/variants/connectivity_2040_lte_wifi_ble/Connectivity.cpp
@@ -195,7 +195,7 @@ void iLabsConnectivityClass::flashEspReset() { // Prepare ESP for flashing
 // after a sw or hw reset have been performed to ensure that the AT
 // interpreter is up and running.
 bool iLabsConnectivityClass::waitForEspReady() {
-    int timeout = 20;                         // Aprox max 2 sec
+    int timeout = 20;                         // Approx max 2 sec
 
     _espSerial->setTimeout(100);
     String rdy = _espSerial->readStringUntil('\n');

--- a/variants/ilabs_rpico32/Ilabs2040WiFiClass.cpp
+++ b/variants/ilabs_rpico32/Ilabs2040WiFiClass.cpp
@@ -53,7 +53,7 @@ void Ilabs2040WiFiClass::flashReset() { // Prepare ESP8285 for flashing
 // after a sw or hw reset have been performed to ensure that the AT
 // interpreter is up and running.
 bool Ilabs2040WiFiClass::waitForReady() {
-    int timeout = 20;                     // Aprox max 2 sec
+    int timeout = 20;                     // Approx max 2 sec
 
     ESP_SERIAL_PORT.begin(DEFAULT_ESP8285_BAUDRATE);
     ESP_SERIAL_PORT.setTimeout(100);


### PR DESCRIPTION
Fixes #2772

No need to set SDFAT_FILE_TYPE=3 as that is the defaulr value with upstream SdFat.  Remove it from platform.txt and platform.io build.