### PR TITLE
Add buffer read to `AudioBufferManager` and `I2S`.

### DIFF
--- a/docs/i2s.rst
+++ b/docs/i2s.rst
@@ -164,7 +164,7 @@ size_t write(const uint8_t \*buffer, size_t size)
 Transfers number of bytes from an application buffer to the I2S output buffer.
 Be aware that ``size`` is in *bytes** and not samples.  Size must be a multiple
 of **4 bytes**.  Will not block, so check the return value to find out how
-many bytes were actually written.
+many 32-bit words were actually written.
 
 int availableForWrite()
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -180,6 +180,13 @@ int peek()
 ~~~~~~~~~~
 Returns the next sample to be read from the I2S buffer (without actually
 removing it).
+
+size_t read(const uint8_t \*buffer, size_t size)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Transfers number of bytes from the I2S input buffer to an application buffer.
+Be aware that ``size`` is in *bytes** and not samples.  Size must be a multiple
+of **4 bytes**.  Will not block, so check the return value to find out how
+many 32-bit words were actually read.
 
 void onTransmit(void (\*fn)(void))
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/i2s.rst
+++ b/docs/i2s.rst
@@ -181,7 +181,7 @@ int peek()
 Returns the next sample to be read from the I2S buffer (without actually
 removing it).
 
-size_t read(const uint8_t \*buffer, size_t size)
+size_t read(uint8_t \*buffer, size_t size)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Transfers number of bytes from the I2S input buffer to an application buffer.
 Be aware that ``size`` is in *bytes** and not samples.  Size must be a multiple

--- a/libraries/AudioBufferManager/src/AudioBufferManager.cpp
+++ b/libraries/AudioBufferManager/src/AudioBufferManager.cpp
@@ -244,7 +244,7 @@ bool AudioBufferManager::read(uint32_t *v, bool sync) {
     return true;
 }
 
-size_t AudioBufferManager::read(const uint32_t *v, size_t words, bool sync) {
+size_t AudioBufferManager::read(uint32_t *v, size_t words, bool sync) {
     size_t read = 0;
 
     if (!_running || _isOutput) {

--- a/libraries/AudioBufferManager/src/AudioBufferManager.h
+++ b/libraries/AudioBufferManager/src/AudioBufferManager.h
@@ -36,7 +36,7 @@ public:
     bool write(uint32_t v, bool sync = true);
     size_t write(const uint32_t *v, size_t words, bool sync = true);
     bool read(uint32_t *v, bool sync = true);
-    size_t read(const uint32_t *v, size_t words, bool sync = true);
+    size_t read(uint32_t *v, size_t words, bool sync = true);
     void flush();
 
     bool getOverUnderflow();

--- a/libraries/AudioBufferManager/src/AudioBufferManager.h
+++ b/libraries/AudioBufferManager/src/AudioBufferManager.h
@@ -36,6 +36,7 @@ public:
     bool write(uint32_t v, bool sync = true);
     size_t write(const uint32_t *v, size_t words, bool sync = true);
     bool read(uint32_t *v, bool sync = true);
+    size_t read(const uint32_t *v, size_t words, bool sync = true);
     void flush();
 
     bool getOverUnderflow();

--- a/libraries/I2S/examples/I2SLoopback_Buffer/I2SLoopback_Buffer.ino
+++ b/libraries/I2S/examples/I2SLoopback_Buffer/I2SLoopback_Buffer.ino
@@ -1,0 +1,38 @@
+/*
+   I2S bi-directional input and output buffered loopback example
+   Released to the Public Domain by Cooper Dalrymple
+*/
+
+#include <I2S.h>
+
+I2S i2s(INPUT_PULLUP);
+
+#define SIZE 256
+int16_t buffer[SIZE];
+
+void setup() {
+  Serial.begin(115200);
+
+  i2s.setDOUT(0);
+  i2s.setDIN(1);
+  i2s.setBCLK(2); // Note: LRCLK = BCLK + 1
+  i2s.setBitsPerSample(16);
+  i2s.setFrequency(22050);
+  i2s.setBuffers(6, SIZE * sizeof(int16_t) / sizeof(int32_t));
+  i2s.begin();
+
+  size_t count, index;
+  while (1) {
+    count = i2s.read((const uint8_t *)&buffer, SIZE * sizeof(int16_t)) * sizeof(int32_t) / sizeof(int16_t);
+    index = 0;
+    while (index < count) {
+        buffer[index++]; // left
+        buffer[index++]; // right
+    }
+    i2s.write((const uint8_t *)&buffer, count * sizeof(int16_t));
+  }
+}
+
+void loop() {
+  /* Nothing here */
+}

--- a/libraries/I2S/examples/I2SLoopback_Buffer/I2SLoopback_Buffer.ino
+++ b/libraries/I2S/examples/I2SLoopback_Buffer/I2SLoopback_Buffer.ino
@@ -26,8 +26,9 @@ void setup() {
     count = i2s.read((const uint8_t *)&buffer, SIZE * sizeof(int16_t)) * sizeof(uint32_t) / sizeof(int16_t);
     index = 0;
     while (index < count) {
-      buffer[index++]; // left
-      buffer[index++]; // right
+      // Reduce volume by half
+      buffer[index++] >>= 1; // right
+      buffer[index++] >>= 1; // left
     }
     i2s.write((const uint8_t *)&buffer, count * sizeof(int16_t));
   }

--- a/libraries/I2S/examples/I2SLoopback_Buffer/I2SLoopback_Buffer.ino
+++ b/libraries/I2S/examples/I2SLoopback_Buffer/I2SLoopback_Buffer.ino
@@ -23,7 +23,7 @@ void setup() {
 
   size_t count, index;
   while (1) {
-    count = i2s.read((const uint8_t *)&buffer, SIZE * sizeof(int16_t)) * sizeof(uint32_t) / sizeof(int16_t);
+    count = i2s.read((uint8_t *)&buffer, SIZE * sizeof(int16_t)) * sizeof(uint32_t) / sizeof(int16_t);
     index = 0;
     while (index < count) {
       // Reduce volume by half

--- a/libraries/I2S/examples/I2SLoopback_Buffer/I2SLoopback_Buffer.ino
+++ b/libraries/I2S/examples/I2SLoopback_Buffer/I2SLoopback_Buffer.ino
@@ -18,12 +18,12 @@ void setup() {
   i2s.setBCLK(2); // Note: LRCLK = BCLK + 1
   i2s.setBitsPerSample(16);
   i2s.setFrequency(22050);
-  i2s.setBuffers(6, SIZE * sizeof(int16_t) / sizeof(int32_t));
+  i2s.setBuffers(6, SIZE * sizeof(int16_t) / sizeof(uint32_t));
   i2s.begin();
 
   size_t count, index;
   while (1) {
-    count = i2s.read((const uint8_t *)&buffer, SIZE * sizeof(int16_t)) * sizeof(int32_t) / sizeof(int16_t);
+    count = i2s.read((const uint8_t *)&buffer, SIZE * sizeof(int16_t)) * sizeof(uint32_t) / sizeof(int16_t);
     index = 0;
     while (index < count) {
         buffer[index++]; // left

--- a/libraries/I2S/examples/I2SLoopback_Buffer/I2SLoopback_Buffer.ino
+++ b/libraries/I2S/examples/I2SLoopback_Buffer/I2SLoopback_Buffer.ino
@@ -26,8 +26,8 @@ void setup() {
     count = i2s.read((const uint8_t *)&buffer, SIZE * sizeof(int16_t)) * sizeof(uint32_t) / sizeof(int16_t);
     index = 0;
     while (index < count) {
-        buffer[index++]; // left
-        buffer[index++]; // right
+      buffer[index++]; // left
+      buffer[index++]; // right
     }
     i2s.write((const uint8_t *)&buffer, count * sizeof(int16_t));
   }

--- a/libraries/I2S/src/I2S.cpp
+++ b/libraries/I2S/src/I2S.cpp
@@ -559,6 +559,14 @@ bool I2S::read32(int32_t *l, int32_t *r) {
     return true;
 }
 
+size_t I2S::read(const uint8_t *buffer, size_t size) {
+    // We can only read 32-bit chunks here
+    if (size & 0x3 || !_running || !_isInput) {
+        return 0;
+    }
+    return _arbInput->read((const uint32_t *)buffer, size / sizeof(uint32_t), false);
+}
+
 size_t I2S::write(const uint8_t *buffer, size_t size) {
     // We can only write 32-bit chunks here
     if (size & 0x3 || !_running || !_isOutput) {

--- a/libraries/I2S/src/I2S.cpp
+++ b/libraries/I2S/src/I2S.cpp
@@ -559,12 +559,12 @@ bool I2S::read32(int32_t *l, int32_t *r) {
     return true;
 }
 
-size_t I2S::read(const uint8_t *buffer, size_t size) {
+size_t I2S::read(uint8_t *buffer, size_t size) {
     // We can only read 32-bit chunks here
     if (size & 0x3 || !_running || !_isInput) {
         return 0;
     }
-    return _arbInput->read((const uint32_t *)buffer, size / sizeof(uint32_t), false);
+    return _arbInput->read((uint32_t *)buffer, size / sizeof(uint32_t), false);
 }
 
 size_t I2S::write(const uint8_t *buffer, size_t size) {

--- a/libraries/I2S/src/I2S.h
+++ b/libraries/I2S/src/I2S.h
@@ -128,7 +128,7 @@ public:
     bool read32(int32_t *l, int32_t *r);
 
     // Read samples into buffer
-    size_t read(const uint8_t *buffer, size_t size);
+    size_t read(uint8_t *buffer, size_t size);
 
     // Note that these callback are called from **INTERRUPT CONTEXT** and hence
     // should be in RAM, not FLASH, and should be quick to execute.

--- a/libraries/I2S/src/I2S.h
+++ b/libraries/I2S/src/I2S.h
@@ -127,6 +127,9 @@ public:
     bool read24(int32_t *l, int32_t *r); // Note that 24b reads will be left-aligned (see above)
     bool read32(int32_t *l, int32_t *r);
 
+    // Read samples into buffer
+    size_t read(const uint8_t *buffer, size_t size);
+
     // Note that these callback are called from **INTERRUPT CONTEXT** and hence
     // should be in RAM, not FLASH, and should be quick to execute.
     void onTransmit(void(*)(void));


### PR DESCRIPTION
I quickly noticed after our discussion in https://github.com/earlephilhower/arduino-pico/pull/2775 that a buffered read was not available in the I2S library or the AudioBufferManager. I've added the necessary functionality to do this as well as a second loopback example demonstrating how to properly implement it. The documentation has also been updated with this method.

Notes:
- I have noticed performance improvements with this feature properly implemented.
- I've fixed an error in the documentation regarding the return value of `size_t I2S::write(const uint8_t *buffer, size_t size)`. I'm good with having that function and the new `size_t I2S::write(const uint8_t *buffer, size_t size)` return the number of words written. But to match the nature of the `size_t size` argument (size in bytes), the return could be scaled by `sizeof(uint32_t)`.