### PR TITLE
fix: Wire::writeReadAsync always malloc'ing DMA buffer

### DIFF
--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -507,7 +507,7 @@ bool TwoWire::writeReadAsync(uint8_t address, const void *wbuffer, size_t wbytes
     abortAsync();
 
     // Create or enlarge dma command buffer, we need one entry for every i2c byte we want to write/read
-    const size_t bufLen = (wbytes + rbytes) * 2;
+    const size_t bufLen = (wbytes + rbytes) * sizeof(uint16_t);
     if (_dmaSendBufferLen < bufLen) {
         if (_dmaSendBuffer) {
             free(_dmaSendBuffer);
@@ -518,6 +518,7 @@ bool TwoWire::writeReadAsync(uint8_t address, const void *wbuffer, size_t wbytes
         if (!_dmaSendBuffer) {
             return false;
         }
+        _dmaSendBufferLen = bufLen;
     }
 
     // Fill the dma command buffer


### PR DESCRIPTION
The async implementation of I2C (Wire) seems to allocate the DMA buffer for every call because the check, whether the current buffer is large enough (`if (_dmaSendBufferLen < bufLen) {`) is always `true` because `_dmaSendBufferLen` is never actually set anywhere. 


Simple fix: added a line after successful `malloc` that sets the `_dmaSendBufferLen = bufLen`. 

PS: Shouldn't we use `new uint16_t[bufLen]` here, since we're in a C++ object? It probably maps to `malloc` but it would at least avoid one cast.