### PR TITLE
early out of (un)maskInterrupts() if no GPIO interrupts need to be masked

### DIFF
--- a/libraries/SPI/src/SPIHelper.h
+++ b/libraries/SPI/src/SPIHelper.h
@@ -108,6 +108,7 @@ public:
         @brief Disables any GPIO interrupts registered before an SPI transaction begins
     */
     void maskInterrupts() {
+        if(_usingIRQs.empty()) { return; }
         noInterrupts(); // Avoid possible race conditions if IRQ comes in while main app is in middle of this
         // Disable any IRQs that are being used for SPI
         io_bank0_irq_ctrl_hw_t *irq_ctrl_base = get_core_num() ? &iobank0_hw->proc1_irq_ctrl : &iobank0_hw->proc0_irq_ctrl;
@@ -134,6 +135,7 @@ public:
         @brief Restores GPIO interrupts masks after an SPI transaction completes
     */
     void unmaskInterrupts() {
+        if(_usingIRQs.empty()) { return; }
         noInterrupts(); // Avoid race condition so the GPIO IRQs won't come back until all state is restored
         DEBUGSPI("SPI::endTransaction()\n");
         // Re-enable IRQs

--- a/libraries/SPI/src/SPIHelper.h
+++ b/libraries/SPI/src/SPIHelper.h
@@ -108,7 +108,9 @@ public:
         @brief Disables any GPIO interrupts registered before an SPI transaction begins
     */
     void maskInterrupts() {
-        if(_usingIRQs.empty()) { return; }
+        if (_usingIRQs.empty()) {
+            return;
+        }
         noInterrupts(); // Avoid possible race conditions if IRQ comes in while main app is in middle of this
         // Disable any IRQs that are being used for SPI
         io_bank0_irq_ctrl_hw_t *irq_ctrl_base = get_core_num() ? &iobank0_hw->proc1_irq_ctrl : &iobank0_hw->proc0_irq_ctrl;
@@ -135,7 +137,9 @@ public:
         @brief Restores GPIO interrupts masks after an SPI transaction completes
     */
     void unmaskInterrupts() {
-        if(_usingIRQs.empty()) { return; }
+        if (_usingIRQs.empty()) {
+            return;
+        }
         noInterrupts(); // Avoid race condition so the GPIO IRQs won't come back until all state is restored
         DEBUGSPI("SPI::endTransaction()\n");
         // Re-enable IRQs


### PR DESCRIPTION
My application is designed to generate HSTX data on core0 in interrupts, but also uses hardware SPI for SD card access.

It turns out that the amount of time spent in `maskInterrupts`/`unmaskInterrupts` with interrupts disabled, even with an empty `_usingIRQs`, is too long.

Add a quick check and avoid touching the interrupt disable flag if there's not actually any GPIO interrupt to (un)mask.

@ladyada this fixes the hstx video glitches during SPI SD card access 