### PR TITLE
Convert to SDK RP2350A/B determination

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -36083,9 +36083,9 @@ generic_rp2350.menu.freq.276.build.f_cpu=276000000L
 generic_rp2350.menu.freq.300=300 MHz (Overclock)
 generic_rp2350.menu.freq.300.build.f_cpu=300000000L
 generic_rp2350.menu.variantchip.RP2350A=RP2350A
-generic_rp2350.menu.variantchip.RP2350A.build.variantdefines=-DPICO_RP2350A=1
+generic_rp2350.menu.variantchip.RP2350A.build.variantdefines=-D__PICO_RP2350A=1
 generic_rp2350.menu.variantchip.RP2530B=RP2530B
-generic_rp2350.menu.variantchip.RP2530B.build.variantdefines=-DPICO_RP2350A=0
+generic_rp2350.menu.variantchip.RP2530B.build.variantdefines=-D__PICO_RP2350A=0
 generic_rp2350.menu.psramcs.GPIOnone=None
 generic_rp2350.menu.psramcs.GPIOnone.build.psram_cs=
 generic_rp2350.menu.psramcs.GPIO0=GPIO 0

--- a/boards.txt
+++ b/boards.txt
@@ -36085,7 +36085,7 @@ generic_rp2350.menu.freq.300.build.f_cpu=300000000L
 generic_rp2350.menu.variantchip.RP2350A=RP2350A
 generic_rp2350.menu.variantchip.RP2350A.build.variantdefines=-DPICO_RP2350A=1
 generic_rp2350.menu.variantchip.RP2530B=RP2530B
-generic_rp2350.menu.variantchip.RP2530B.build.variantdefines=-DPICO_RP2350B=1
+generic_rp2350.menu.variantchip.RP2530B.build.variantdefines=-DPICO_RP2350A=0
 generic_rp2350.menu.psramcs.GPIOnone=None
 generic_rp2350.menu.psramcs.GPIOnone.build.psram_cs=
 generic_rp2350.menu.psramcs.GPIO0=GPIO 0

--- a/cores/rp2040/Arduino.h
+++ b/cores/rp2040/Arduino.h
@@ -27,6 +27,7 @@
 #include "RP2040Version.h"
 #include "api/ArduinoAPI.h"
 #include "api/itoa.h" // ARM toolchain doesn't provide itoa etc, provide them
+#include <pico.h>
 #include <pins_arduino.h>
 #include <hardware/gpio.h> // Required for the port*Register macros
 #include "debug_internal.h"

--- a/cores/rp2040/Arduino.h
+++ b/cores/rp2040/Arduino.h
@@ -41,7 +41,7 @@
 #error Invalid RP2350 definition.  Need to set PICO_RP2350A=0/1 for A/B variant
 #endif
 #if defined(PICO_RP2350B)
-#error Do not defile PICO_RP2350B.  Use PICO_RP2350A=0 to indicate RP2350B.  See the SDK for more details
+#error Do not define PICO_RP2350B.  Use PICO_RP2350A=0 to indicate RP2350B.  See the SDK for more details
 #endif
 
 // Try and make the best of the old Arduino abs() macro.  When in C++, use

--- a/cores/rp2040/Arduino.h
+++ b/cores/rp2040/Arduino.h
@@ -28,6 +28,7 @@
 #include "api/ArduinoAPI.h"
 #include "api/itoa.h" // ARM toolchain doesn't provide itoa etc, provide them
 #include <pico.h>
+#undef PICO_RP2350A // Set in the RP2350 SDK boards file, overridden in the variant pins_arduino.h
 #include <pins_arduino.h>
 #include <hardware/gpio.h> // Required for the port*Register macros
 #include "debug_internal.h"

--- a/cores/rp2040/Arduino.h
+++ b/cores/rp2040/Arduino.h
@@ -31,6 +31,17 @@
 #include <hardware/gpio.h> // Required for the port*Register macros
 #include "debug_internal.h"
 
+// Chip sanity checking.  SDK uses interesting way of separating 2350A from 2350B, see https://github.com/raspberrypi/pico-sdk/issues/2364
+#if (!defined(PICO_RP2040) && !defined(PICO_RP2350)) || defined(PICO_RP2040) && defined(PICO_RP2350)
+#error Invalid core definition. Either PICO_RP2040 or PICO_RP2350 must be defined.
+#endif
+#if defined(PICO_RP2350) && !defined(PICO_RP2350A)
+#error Invalid RP2350 definition.  Need to set PICO_RP2350A=0/1 for A/B variant
+#endif
+#if defined(PICO_RP2350B)
+#error Do not defile PICO_RP2350B.  Use PICO_RP2350A=0 to indicate RP2350B.  See the SDK for more details
+#endif
+
 // Try and make the best of the old Arduino abs() macro.  When in C++, use
 // the sane std::abs() call, but for C code use their macro since stdlib abs()
 // is int but their macro "works" for everything (with potential side effects)

--- a/cores/rp2040/SerialUART.cpp
+++ b/cores/rp2040/SerialUART.cpp
@@ -32,7 +32,7 @@ extern void serialEvent1() __attribute__((weak));
 extern void serialEvent2() __attribute__((weak));
 
 bool SerialUART::setRX(pin_size_t pin) {
-#if defined(PICO_RP2350B)
+#if defined(PICO_RP2350) && !PICO_RP2350A // RP2350B
     constexpr uint64_t valid[2] = { __bitset({1, 3, 13, 15, 17, 19, 29, 31, 33, 35, 45, 47}) /* UART0 */,
                                     __bitset({5, 7, 9, 11, 21, 23, 25, 27, 37, 39, 41, 43})  /* UART1 */
                                   };
@@ -64,7 +64,7 @@ bool SerialUART::setRX(pin_size_t pin) {
 }
 
 bool SerialUART::setTX(pin_size_t pin) {
-#if defined(PICO_RP2350B)
+#if defined(PICO_RP2350) && !PICO_RP2350A // RP2350B
     constexpr uint64_t valid[2] = { __bitset({0, 2, 12, 14, 16, 18, 28, 30, 32, 34, 44, 46}) /* UART0 */,
                                     __bitset({4, 6, 8, 10, 20, 22, 24, 26, 36, 38, 40, 42})  /* UART1 */
                                   };
@@ -95,7 +95,7 @@ bool SerialUART::setTX(pin_size_t pin) {
 }
 
 bool SerialUART::setRTS(pin_size_t pin) {
-#ifdef PICO_RP2350B
+#if defined(PICO_RP2350) && !PICO_RP2350A // RP2350B
     constexpr uint64_t valid[2] = { __bitset({3, 15, 19, 31, 35, 47}) /* UART0 */,
                                     __bitset({7, 11, 23, 27, 39, 43})  /* UART1 */
                                   };
@@ -122,7 +122,7 @@ bool SerialUART::setRTS(pin_size_t pin) {
 }
 
 bool SerialUART::setCTS(pin_size_t pin) {
-#ifdef PICO_RP2350B
+#if defined(PICO_RP2350) && !PICO_RP2350A // RP2350B
     constexpr uint64_t valid[2] = { __bitset({2, 14, 18, 30, 34, 46}) /* UART0 */,
                                     __bitset({6, 10, 22, 26, 38, 42})  /* UART1 */
                                   };
@@ -182,7 +182,7 @@ static void _uart1IRQ();
 // Does the selected TX/RX need UART_AUX function (rp2350)
 static gpio_function_t __gpioFunction(int pin) {
     switch (pin) {
-#if defined(PICO_RP2350) || defined(PICO_RP2350B)
+#if defined(PICO_RP2350) && !PICO_RP2350A
     case 2:
     case 3:
     case 6:

--- a/libraries/ADCInput/src/ADCInput.cpp
+++ b/libraries/ADCInput/src/ADCInput.cpp
@@ -49,7 +49,7 @@ bool ADCInput::setBuffers(size_t buffers, size_t bufferWords) {
 
 int ADCInput::_mask(pin_size_t p) {
     switch (p) {
-#if !defined(PICO_RP2350B)
+#if defined(PICO_RP2350) && !PICO_RP2350A // RP2350B
     case 26: return 1;
     case 27: return 2;
     case 28: return 4;
@@ -106,7 +106,7 @@ bool ADCInput::begin() {
     // Set up the GPIOs to go to ADC
     adc_init();
     int cnt = 0;
-#if !defined(PICO_RP2350B)
+#if defined(PICO_RP2350) && !PICO_RP2350A // RP2350B
     int startpin = 26;
     int maxpin = 29;
 #else

--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -263,7 +263,7 @@ void SPIClassRP2040::abortAsync() {
 
 
 bool SPIClassRP2040::setRX(pin_size_t pin) {
-#ifdef PICO_RP2350B
+#if defined(PICO_RP2350) && !PICO_RP2350A // RP2350B
     constexpr uint64_t valid[2] = { __bitset({0, 4, 16, 20, 32, 26}) /* SPI0 */,
                                     __bitset({8, 12, 24, 28, 40, 44})  /* SPI1 */
                                   };
@@ -290,7 +290,7 @@ bool SPIClassRP2040::setRX(pin_size_t pin) {
 }
 
 bool SPIClassRP2040::setCS(pin_size_t pin) {
-#ifdef PICO_RP2350B
+#if defined(PICO_RP2350) && !PICO_RP2350A // RP2350B
     constexpr uint64_t valid[2] = { __bitset({1, 5, 17, 21, 33, 37}) /* SPI0 */,
                                     __bitset({9, 13, 25, 29, 41, 45})  /* SPI1 */
                                   };
@@ -317,7 +317,7 @@ bool SPIClassRP2040::setCS(pin_size_t pin) {
 }
 
 bool SPIClassRP2040::setSCK(pin_size_t pin) {
-#ifdef PICO_RP2350B
+#if defined(PICO_RP2350) && !PICO_RP2350A // RP2350B
     constexpr uint64_t valid[2] = { __bitset({2, 6, 18, 22, 34, 38}) /* SPI0 */,
                                     __bitset({10, 14, 26, 30, 42, 46})  /* SPI1 */
                                   };
@@ -344,7 +344,7 @@ bool SPIClassRP2040::setSCK(pin_size_t pin) {
 }
 
 bool SPIClassRP2040::setTX(pin_size_t pin) {
-#ifdef PICO_RP2350B
+#if defined(PICO_RP2350) && !PICO_RP2350A // RP2350B
     constexpr uint64_t valid[2] = { __bitset({3, 7, 19, 23, 35, 39}) /* SPI0 */,
                                     __bitset({11, 15, 27, 31, 43, 47})  /* SPI1 */
                                   };

--- a/libraries/SPI/src/SPIHelper.h
+++ b/libraries/SPI/src/SPIHelper.h
@@ -98,7 +98,7 @@ public:
         return (reverseByte(w & 0xff) << 8) | (reverseByte(w >> 8));
     }
 
-#ifdef PICO_RP2350B
+#if defined(PICO_RP2350) && !PICO_RP2350A // RP2350B
     static constexpr int GPIOIRQREGS = 6;
 #else
     static constexpr int GPIOIRQREGS = 4;

--- a/libraries/SPISlave/src/SPISlave.cpp
+++ b/libraries/SPISlave/src/SPISlave.cpp
@@ -79,7 +79,7 @@ inline spi_cpha_t SPISlaveClass::cpha(SPISettings _spis) {
 }
 
 bool SPISlaveClass::setRX(pin_size_t pin) {
-#ifdef PICO_RP2350B
+#if defined(PICO_RP2350) && !PICO_RP2350A // RP2350B
     constexpr uint64_t valid[2] = { __bitset({0, 4, 16, 20, 32, 26}) /* SPI0 */,
                                     __bitset({8, 12, 24, 28, 40, 44})  /* SPI1 */
                                   };
@@ -106,7 +106,7 @@ bool SPISlaveClass::setRX(pin_size_t pin) {
 }
 
 bool SPISlaveClass::setCS(pin_size_t pin) {
-#ifdef PICO_RP2350B
+#if defined(PICO_RP2350) && !PICO_RP2350A // RP2350B
     constexpr uint64_t valid[2] = { __bitset({1, 5, 17, 21, 33, 37}) /* SPI0 */,
                                     __bitset({9, 13, 25, 29, 41, 45})  /* SPI1 */
                                   };
@@ -133,7 +133,7 @@ bool SPISlaveClass::setCS(pin_size_t pin) {
 }
 
 bool SPISlaveClass::setSCK(pin_size_t pin) {
-#ifdef PICO_RP2350B
+#if defined(PICO_RP2350) && !PICO_RP2350A // RP2350B
     constexpr uint64_t valid[2] = { __bitset({2, 6, 18, 22, 34, 38}) /* SPI0 */,
                                     __bitset({10, 14, 26, 30, 42, 46})  /* SPI1 */
                                   };
@@ -160,7 +160,7 @@ bool SPISlaveClass::setSCK(pin_size_t pin) {
 }
 
 bool SPISlaveClass::setTX(pin_size_t pin) {
-#ifdef PICO_RP2350B
+#if defined(PICO_RP2350) && !PICO_RP2350A // RP2350B
     constexpr uint64_t valid[2] = { __bitset({3, 7, 19, 23, 35, 39}) /* SPI0 */,
                                     __bitset({11, 15, 27, 31, 43, 47})  /* SPI1 */
                                   };

--- a/libraries/Wire/src/Wire.cpp
+++ b/libraries/Wire/src/Wire.cpp
@@ -49,7 +49,7 @@ TwoWire::TwoWire(i2c_inst_t *i2c, pin_size_t sda, pin_size_t scl) {
 }
 
 bool TwoWire::setSDA(pin_size_t pin) {
-#ifdef PICO_RP2350B
+#if defined(PICO_RP2350) && !PICO_RP2350A // RP2350B
     constexpr uint64_t valid[2] = { __bitset({0, 4, 8, 12, 16, 20, 24, 28, 32, 36, 40, 44}) /* I2C0 */,
                                     __bitset({2, 6, 10, 14, 18, 22, 26, 30, 34, 38, 42, 46})  /* I2C1 */
                                   };
@@ -76,7 +76,7 @@ bool TwoWire::setSDA(pin_size_t pin) {
 }
 
 bool TwoWire::setSCL(pin_size_t pin) {
-#ifdef PICO_RP2350B
+#if defined(PICO_RP2350) && !PICO_RP2350A // RP2350B
     constexpr uint64_t valid[2] = { __bitset({1, 5, 9, 13, 17, 21, 25, 29, 33, 37, 41, 45}) /* I2C0 */,
                                     __bitset({3, 7, 11, 15, 19, 23, 27, 31, 35, 39, 43, 47})  /* I2C1 */
                                   };

--- a/libraries/lwIP_Ethernet/src/LwipEthernet.cpp
+++ b/libraries/lwIP_Ethernet/src/LwipEthernet.cpp
@@ -75,7 +75,7 @@ void __removeEthernetPacketHandler(int id) {
 }
 
 #define GPIOSTACKSIZE 8
-#ifdef PICO_RP2350B
+#if defined(PICO_RP2350) && !PICO_RP2350A // RP2350B
 #define GPIOIRQREGS 6
 #define GPIOIRQREGSINIT 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff, 0xffffffff
 #else

--- a/tools/makeboards.py
+++ b/tools/makeboards.py
@@ -85,7 +85,7 @@ def BuildPSRAMFreq(name):
         print("%s.menu.psramfreq.freq%d.build.psram_freq=-DRP2350_PSRAM_MAX_SCK_HZ=%d" % (name, s, s * 1000000))
 
 def BuildRP2350Variant(name):
-    for l in [ ("RP2350A", "-DPICO_RP2350A=1"), ("RP2530B", "-DPICO_RP2350A=0") ]:
+    for l in [ ("RP2350A", "-D__PICO_RP2350A=1"), ("RP2530B", "-D__PICO_RP2350A=0") ]:
         print("%s.menu.variantchip.%s=%s" % (name, l[0], l[0]))
         print("%s.menu.variantchip.%s.build.variantdefines=%s" % (name, l[0], l[1]))
 

--- a/tools/makeboards.py
+++ b/tools/makeboards.py
@@ -85,7 +85,7 @@ def BuildPSRAMFreq(name):
         print("%s.menu.psramfreq.freq%d.build.psram_freq=-DRP2350_PSRAM_MAX_SCK_HZ=%d" % (name, s, s * 1000000))
 
 def BuildRP2350Variant(name):
-    for l in [ ("RP2350A", "-DPICO_RP2350A=1"), ("RP2530B", "-DPICO_RP2350B=1") ]:
+    for l in [ ("RP2350A", "-DPICO_RP2350A=1"), ("RP2530B", "-DPICO_RP2350A=0") ]:
         print("%s.menu.variantchip.%s=%s" % (name, l[0], l[0]))
         print("%s.menu.variantchip.%s.build.variantdefines=%s" % (name, l[0], l[1]))
 

--- a/variants/adafruit_feather_rp2350_hstx/pins_arduino.h
+++ b/variants/adafruit_feather_rp2350_hstx/pins_arduino.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#undef PICO_RP2350A
 #define PICO_RP2350A 1
 
 // LEDs

--- a/variants/adafruit_feather_rp2350_hstx/pins_arduino.h
+++ b/variants/adafruit_feather_rp2350_hstx/pins_arduino.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#undef PICO_RP2350A
+#define PICO_RP2350A 1
+
 // LEDs
 #define PIN_LED        (7u)
 

--- a/variants/adafruit_metro_rp2350/pins_arduino.h
+++ b/variants/adafruit_metro_rp2350/pins_arduino.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#undef PICO_RP2350A
 #define PICO_RP2350A 0 // RP2350B
 
 // LEDs

--- a/variants/adafruit_metro_rp2350/pins_arduino.h
+++ b/variants/adafruit_metro_rp2350/pins_arduino.h
@@ -1,4 +1,6 @@
 #pragma once
+
+#undef PICO_RP2350A
 #define PICO_RP2350A 0 // RP2350B
 
 // LEDs

--- a/variants/adafruit_metro_rp2350/pins_arduino.h
+++ b/variants/adafruit_metro_rp2350/pins_arduino.h
@@ -1,5 +1,5 @@
 #pragma once
-#define PICO_RP2350B 1
+#define PICO_RP2350A 0 // RP2350B
 
 // LEDs
 #define PIN_LED        (23u)

--- a/variants/challenger_2350_bconnect/pins_arduino.h
+++ b/variants/challenger_2350_bconnect/pins_arduino.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#undef PICO_RP2350A
+#define PICO_RP2350A 1
+
 #define PINS_COUNT          (30u)
 #define NUM_DIGITAL_PINS    (30u)
 #define NUM_ANALOG_INPUTS   (4u)

--- a/variants/challenger_2350_bconnect/pins_arduino.h
+++ b/variants/challenger_2350_bconnect/pins_arduino.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#undef PICO_RP2350A
 #define PICO_RP2350A 1
 
 #define PINS_COUNT          (30u)

--- a/variants/challenger_2350_wifi6_ble5/pins_arduino.h
+++ b/variants/challenger_2350_wifi6_ble5/pins_arduino.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#undef PICO_RP2350A
+#define PICO_RP2350A 1
+
 #define PINS_COUNT          (30u)
 #define NUM_DIGITAL_PINS    (30u)
 #define NUM_ANALOG_INPUTS   (4u)

--- a/variants/challenger_2350_wifi6_ble5/pins_arduino.h
+++ b/variants/challenger_2350_wifi6_ble5/pins_arduino.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#undef PICO_RP2350A
 #define PICO_RP2350A 1
 
 #define PINS_COUNT          (30u)

--- a/variants/cytron_iriv_io_controller/pins_arduino.h
+++ b/variants/cytron_iriv_io_controller/pins_arduino.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#undef PICO_RP2350A
+#define PICO_RP2350A 1
+
 // LEDs
 #define PIN_LED         (29u)
 

--- a/variants/cytron_iriv_io_controller/pins_arduino.h
+++ b/variants/cytron_iriv_io_controller/pins_arduino.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#undef PICO_RP2350A
 #define PICO_RP2350A 1
 
 // LEDs

--- a/variants/cytron_motion_2350_pro/pins_arduino.h
+++ b/variants/cytron_motion_2350_pro/pins_arduino.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#undef PICO_RP2350A
 #define PICO_RP2350A 1
 
 // LEDs

--- a/variants/cytron_motion_2350_pro/pins_arduino.h
+++ b/variants/cytron_motion_2350_pro/pins_arduino.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#undef PICO_RP2350A
+#define PICO_RP2350A 1
+
 // LEDs
 #define PIN_LED             (2u)
 

--- a/variants/datanoisetv_picoadk_v2/pins_arduino.h
+++ b/variants/datanoisetv_picoadk_v2/pins_arduino.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#undef PICO_RP2350A
+#define PICO_RP2350A 1
+
 // DatanoiseTV PicoADK v2 - Audio Development Kit with RP2350A
 // https://github.com/DatanoiseTV/PicoDSP-Hardware
 

--- a/variants/datanoisetv_picoadk_v2/pins_arduino.h
+++ b/variants/datanoisetv_picoadk_v2/pins_arduino.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#undef PICO_RP2350A
 #define PICO_RP2350A 1
 
 // DatanoiseTV PicoADK v2 - Audio Development Kit with RP2350A

--- a/variants/generic/common.h
+++ b/variants/generic/common.h
@@ -164,7 +164,7 @@ static const uint8_t D29 = __PIN_D29;
 static const uint8_t D29 = (29u);
 #endif
 
-#if !defined(PICO_RP2350B)
+#if defined(PICO_RP2040) || (defined(PICO_RP2350) && PICO_RP2350A)
 
 #ifdef __PIN_A0
 static const uint8_t A0 = __PIN_A0;
@@ -190,7 +190,7 @@ static const uint8_t A3 = __PIN_A3;
 static const uint8_t A3 = (29u);
 #endif
 
-#elif defined(PICO_RP2350B)
+#elif defined(PICO_RP2350) && !PICO_RP2350A // RP2350B
 
 #ifdef __PIN_D30
 static const uint8_t D30 = __PIN_D30;

--- a/variants/generic_rp2350/pins_arduino.h
+++ b/variants/generic_rp2350/pins_arduino.h
@@ -3,7 +3,6 @@
 // Pin definitions taken from:
 //    https://datasheets.raspberrypi.org/pico/pico-datasheet.pdf
 
-#undef PICO_RP2350A
 #define PICO_RP2350A __PICO_RP2350A
 
 // LEDs

--- a/variants/generic_rp2350/pins_arduino.h
+++ b/variants/generic_rp2350/pins_arduino.h
@@ -3,6 +3,8 @@
 // Pin definitions taken from:
 //    https://datasheets.raspberrypi.org/pico/pico-datasheet.pdf
 
+#undef PICO_RP2350A
+#define PICO_RP2350A __PICO_RP2350A
 
 // LEDs
 #define PIN_LED        (25u)

--- a/variants/jumperless_v5/pins_arduino.h
+++ b/variants/jumperless_v5/pins_arduino.h
@@ -3,7 +3,6 @@
 // Pin definitions taken from:
 //    https://github.com/Architeuthis-Flux/JumperlessV5/tree/main/Hardware/Jumperless23V50
 
-#undef PICO_RP2350A
 #define PICO_RP2350A   0 // RP2350B
 
 // LEDs

--- a/variants/jumperless_v5/pins_arduino.h
+++ b/variants/jumperless_v5/pins_arduino.h
@@ -3,6 +3,7 @@
 // Pin definitions taken from:
 //    https://github.com/Architeuthis-Flux/JumperlessV5/tree/main/Hardware/Jumperless23V50
 
+#undef PICO_RP2350A
 #define PICO_RP2350A   0 // RP2350B
 
 // LEDs

--- a/variants/jumperless_v5/pins_arduino.h
+++ b/variants/jumperless_v5/pins_arduino.h
@@ -3,7 +3,7 @@
 // Pin definitions taken from:
 //    https://github.com/Architeuthis-Flux/JumperlessV5/tree/main/Hardware/Jumperless23V50
 
-#define PICO_RP2350B   1
+#define PICO_RP2350A   0 // RP2350B
 
 // LEDs
 #define PIN_LED        (17u)

--- a/variants/olimex_pico2xl/pins_arduino.h
+++ b/variants/olimex_pico2xl/pins_arduino.h
@@ -1,4 +1,3 @@
 #pragma once
-#undef PICO_RP2350A
 #define PICO_RP2350A 0 // RP2350B
 #include "../rpipico2/pins_arduino.h"

--- a/variants/olimex_pico2xl/pins_arduino.h
+++ b/variants/olimex_pico2xl/pins_arduino.h
@@ -1,3 +1,3 @@
 #pragma once
-#define PICO_RP2350B 1
+#define PICO_RP2350A 0 // RP2350B
 #include "../rpipico2/pins_arduino.h"

--- a/variants/olimex_pico2xl/pins_arduino.h
+++ b/variants/olimex_pico2xl/pins_arduino.h
@@ -1,3 +1,4 @@
 #pragma once
+#undef PICO_RP2350A
 #define PICO_RP2350A 0 // RP2350B
 #include "../rpipico2/pins_arduino.h"

--- a/variants/olimex_pico2xxl/pins_arduino.h
+++ b/variants/olimex_pico2xxl/pins_arduino.h
@@ -1,5 +1,4 @@
 #pragma once
-#undef PICO_RP2350A
 #define PICO_RP2350A 0 // RP2350B
 #define RP2350_PSRAM_CS 8
 #include "../rpipico2/pins_arduino.h"

--- a/variants/olimex_pico2xxl/pins_arduino.h
+++ b/variants/olimex_pico2xxl/pins_arduino.h
@@ -1,4 +1,5 @@
 #pragma once
+#undef PICO_RP2350A
 #define PICO_RP2350A 0 // RP2350B
 #define RP2350_PSRAM_CS 8
 #include "../rpipico2/pins_arduino.h"

--- a/variants/olimex_pico2xxl/pins_arduino.h
+++ b/variants/olimex_pico2xxl/pins_arduino.h
@@ -1,4 +1,4 @@
 #pragma once
-#define PICO_RP2350B 1
+#define PICO_RP2350A 0 // RP2350B
 #define RP2350_PSRAM_CS 8
 #include "../rpipico2/pins_arduino.h"

--- a/variants/pimoroni_pga2350/pins_arduino.h
+++ b/variants/pimoroni_pga2350/pins_arduino.h
@@ -2,7 +2,6 @@
 
 // Enables external PSRAM
 #define RP2350_PSRAM_CS    47
-#undef PICO_RP2350A
 #define PICO_RP2350A 0 // RP2350B
 
 // This is a bare board with no real predefined pins, so use generic

--- a/variants/pimoroni_pga2350/pins_arduino.h
+++ b/variants/pimoroni_pga2350/pins_arduino.h
@@ -2,7 +2,7 @@
 
 // Enables external PSRAM
 #define RP2350_PSRAM_CS    47
-#define PICO_RP2350B 1
+#define PICO_RP2350A 0 // RP2350B
 
 // This is a bare board with no real predefined pins, so use generic
 #include "../generic/pins_arduino.h"

--- a/variants/pimoroni_pga2350/pins_arduino.h
+++ b/variants/pimoroni_pga2350/pins_arduino.h
@@ -2,6 +2,7 @@
 
 // Enables external PSRAM
 #define RP2350_PSRAM_CS    47
+#undef PICO_RP2350A
 #define PICO_RP2350A 0 // RP2350B
 
 // This is a bare board with no real predefined pins, so use generic

--- a/variants/pimoroni_pico_plus_2/pins_arduino.h
+++ b/variants/pimoroni_pico_plus_2/pins_arduino.h
@@ -49,7 +49,7 @@
 #define RP2350_PSRAM_CS         (47u)
 #define RP2350_PSRAM_MAX_SCK_HZ (109*1000*1000)
 
-#define PICO_RP2350B 1
+#define PICO_RP2350A 0 // RP2350B
 
 /* Pins mappings for marked pins on the board */
 static const uint8_t D0 = (0u);

--- a/variants/pimoroni_pico_plus_2/pins_arduino.h
+++ b/variants/pimoroni_pico_plus_2/pins_arduino.h
@@ -49,7 +49,6 @@
 #define RP2350_PSRAM_CS         (47u)
 #define RP2350_PSRAM_MAX_SCK_HZ (109*1000*1000)
 
-#undef PICO_RP2350A
 #define PICO_RP2350A 0 // RP2350B
 
 /* Pins mappings for marked pins on the board */

--- a/variants/pimoroni_pico_plus_2/pins_arduino.h
+++ b/variants/pimoroni_pico_plus_2/pins_arduino.h
@@ -49,6 +49,7 @@
 #define RP2350_PSRAM_CS         (47u)
 #define RP2350_PSRAM_MAX_SCK_HZ (109*1000*1000)
 
+#undef PICO_RP2350A
 #define PICO_RP2350A 0 // RP2350B
 
 /* Pins mappings for marked pins on the board */

--- a/variants/pimoroni_pico_plus_2w/pins_arduino.h
+++ b/variants/pimoroni_pico_plus_2w/pins_arduino.h
@@ -51,7 +51,6 @@
 #define RP2350_PSRAM_CS         (47u)
 #define RP2350_PSRAM_MAX_SCK_HZ (109*1000*1000)
 
-#undef PICO_RP2350A
 #define PICO_RP2350A 0 // RP2530B
 
 /* Pins mappings for marked pins on the board */

--- a/variants/pimoroni_pico_plus_2w/pins_arduino.h
+++ b/variants/pimoroni_pico_plus_2w/pins_arduino.h
@@ -51,6 +51,7 @@
 #define RP2350_PSRAM_CS         (47u)
 #define RP2350_PSRAM_MAX_SCK_HZ (109*1000*1000)
 
+#undef PICO_RP2350A
 #define PICO_RP2350A 0 // RP2530B
 
 /* Pins mappings for marked pins on the board */

--- a/variants/pimoroni_pico_plus_2w/pins_arduino.h
+++ b/variants/pimoroni_pico_plus_2w/pins_arduino.h
@@ -51,7 +51,7 @@
 #define RP2350_PSRAM_CS         (47u)
 #define RP2350_PSRAM_MAX_SCK_HZ (109*1000*1000)
 
-#define PICO_RP2350B 1
+#define PICO_RP2350A 0 // RP2530B
 
 /* Pins mappings for marked pins on the board */
 static const uint8_t D0 = (0u);

--- a/variants/pimoroni_plasma2350/pins_arduino.h
+++ b/variants/pimoroni_plasma2350/pins_arduino.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#undef PICO_RP2350A
+#define PICO_RP2350A 1
+
 // Pin definitions taken from:
 // https://github.com/rp-rs/rp-hal-boards/blob/main/boards/pimoroni-plasma-2040/src/lib.rs
 

--- a/variants/pimoroni_plasma2350/pins_arduino.h
+++ b/variants/pimoroni_plasma2350/pins_arduino.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#undef PICO_RP2350A
 #define PICO_RP2350A 1
 
 // Pin definitions taken from:

--- a/variants/pimoroni_tiny2350/pins_arduino.h
+++ b/variants/pimoroni_tiny2350/pins_arduino.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#undef PICO_RP2350A
+#define PICO_RP2350A 1
+
 // This is a bare board with few predefined pins, so based on generic
 
 // Pin definitions taken from:

--- a/variants/pimoroni_tiny2350/pins_arduino.h
+++ b/variants/pimoroni_tiny2350/pins_arduino.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#undef PICO_RP2350A
 #define PICO_RP2350A 1
 
 // This is a bare board with few predefined pins, so based on generic

--- a/variants/rpipico2/pins_arduino.h
+++ b/variants/rpipico2/pins_arduino.h
@@ -3,6 +3,8 @@
 // Pin definitions taken from:
 //    https://datasheets.raspberrypi.org/pico/pico-datasheet.pdf
 
+#undef PICO_RP2350A
+#define PICO_RP2350A 1
 
 // LEDs
 #define PIN_LED        (25u)

--- a/variants/rpipico2/pins_arduino.h
+++ b/variants/rpipico2/pins_arduino.h
@@ -3,7 +3,6 @@
 // Pin definitions taken from:
 //    https://datasheets.raspberrypi.org/pico/pico-datasheet.pdf
 
-#undef PICO_RP2350A
 #define PICO_RP2350A 1
 
 // LEDs

--- a/variants/rpipico2w/pins_arduino.h
+++ b/variants/rpipico2w/pins_arduino.h
@@ -5,7 +5,6 @@
 // Pin definitions taken from:
 //    https://datasheets.raspberrypi.org/pico/pico-datasheet.pdf
 
-#undef PICO_RP2350A
 #define PICO_RP2350A 1
 
 // LEDs

--- a/variants/rpipico2w/pins_arduino.h
+++ b/variants/rpipico2w/pins_arduino.h
@@ -5,6 +5,8 @@
 // Pin definitions taken from:
 //    https://datasheets.raspberrypi.org/pico/pico-datasheet.pdf
 
+#undef PICO_RP2350A
+#define PICO_RP2350A 1
 
 // LEDs
 #define PIN_LED        (64u)

--- a/variants/seeed_xiao_rp2350/pins_arduino.h
+++ b/variants/seeed_xiao_rp2350/pins_arduino.h
@@ -1,4 +1,8 @@
 #pragma once
+
+#undef PICO_RP2350A
+#define PICO_RP2350A 1
+
 // Pin definitions taken from:
 //    https://www.seeedstudio.com/Seeed-XIAO-RP2350-p-5944.html
 

--- a/variants/seeed_xiao_rp2350/pins_arduino.h
+++ b/variants/seeed_xiao_rp2350/pins_arduino.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#undef PICO_RP2350A
 #define PICO_RP2350A 1
 
 // Pin definitions taken from:

--- a/variants/solderparty_rp2350_stamp/pins_arduino.h
+++ b/variants/solderparty_rp2350_stamp/pins_arduino.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#undef PICO_RP2350A
+#define PICO_RP2350A 1
+
 // Pin definitions taken from:
 //    https://rp2xxx-stamp-carrier-xl.solder.party/
 

--- a/variants/solderparty_rp2350_stamp/pins_arduino.h
+++ b/variants/solderparty_rp2350_stamp/pins_arduino.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#undef PICO_RP2350A
 #define PICO_RP2350A 1
 
 // Pin definitions taken from:

--- a/variants/solderparty_rp2350_stamp_xl/pins_arduino.h
+++ b/variants/solderparty_rp2350_stamp_xl/pins_arduino.h
@@ -3,7 +3,7 @@
 // Pin definitions taken from:
 //    https://rp2xxx-stamp-carrier-xl.solder.party/
 
-#define PICO_RP2350B   1
+#define PICO_RP2350A 0 // RP2350B
 
 // LEDs
 #define PIN_LED        (3u)

--- a/variants/solderparty_rp2350_stamp_xl/pins_arduino.h
+++ b/variants/solderparty_rp2350_stamp_xl/pins_arduino.h
@@ -3,7 +3,6 @@
 // Pin definitions taken from:
 //    https://rp2xxx-stamp-carrier-xl.solder.party/
 
-#undef PICO_RP2350A
 #define PICO_RP2350A 0 // RP2350B
 
 // LEDs

--- a/variants/solderparty_rp2350_stamp_xl/pins_arduino.h
+++ b/variants/solderparty_rp2350_stamp_xl/pins_arduino.h
@@ -3,6 +3,7 @@
 // Pin definitions taken from:
 //    https://rp2xxx-stamp-carrier-xl.solder.party/
 
+#undef PICO_RP2350A
 #define PICO_RP2350A 0 // RP2350B
 
 // LEDs

--- a/variants/sparkfun_iotnode_lorawanrp2350/pins_arduino.h
+++ b/variants/sparkfun_iotnode_lorawanrp2350/pins_arduino.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#undef PICO_RP2350A
 #define PICO_RP2350A 1
 
 // LEDs

--- a/variants/sparkfun_iotnode_lorawanrp2350/pins_arduino.h
+++ b/variants/sparkfun_iotnode_lorawanrp2350/pins_arduino.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#undef PICO_RP2350A
+#define PICO_RP2350A 1
+
 // LEDs
 #define PIN_LED (25u)
 

--- a/variants/sparkfun_iotredboard_rp2350/pins_arduino.h
+++ b/variants/sparkfun_iotredboard_rp2350/pins_arduino.h
@@ -3,6 +3,7 @@
 #include <stdint.h>
 #include <cyw43_wrappers.h>
 
+#undef PICO_RP2350A
 #define PICO_RP2350A 0 // RP2350B
 
 #define PINS_COUNT          (48u)

--- a/variants/sparkfun_iotredboard_rp2350/pins_arduino.h
+++ b/variants/sparkfun_iotredboard_rp2350/pins_arduino.h
@@ -3,8 +3,7 @@
 #include <stdint.h>
 #include <cyw43_wrappers.h>
 
-#define PICO_RP2350B 1
-#define PICO_RP2350A 0
+#define PICO_RP2350A 0 // RP2350B
 
 #define PINS_COUNT          (48u)
 #define NUM_DIGITAL_PINS    (48u)

--- a/variants/sparkfun_iotredboard_rp2350/pins_arduino.h
+++ b/variants/sparkfun_iotredboard_rp2350/pins_arduino.h
@@ -1,9 +1,7 @@
-#pragma once
 
 #include <stdint.h>
 #include <cyw43_wrappers.h>
 
-#undef PICO_RP2350A
 #define PICO_RP2350A 0 // RP2350B
 
 #define PINS_COUNT          (48u)

--- a/variants/sparkfun_promicrorp2350/pins_arduino.h
+++ b/variants/sparkfun_promicrorp2350/pins_arduino.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#undef PICO_RP2350A
 #define PICO_RP2350A 1
 
 // Taken from schematic at https://cdn.sparkfun.com/assets/e/2/7/6/b/ProMicroRP2040_Graphical_Datasheet.pdf

--- a/variants/sparkfun_promicrorp2350/pins_arduino.h
+++ b/variants/sparkfun_promicrorp2350/pins_arduino.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#undef PICO_RP2350A
+#define PICO_RP2350A 1
+
 // Taken from schematic at https://cdn.sparkfun.com/assets/e/2/7/6/b/ProMicroRP2040_Graphical_Datasheet.pdf
 
 // LEDs

--- a/variants/sparkfun_thingplusrp2350/pins_arduino.h
+++ b/variants/sparkfun_thingplusrp2350/pins_arduino.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#undef PICO_RP2350A
 #define PICO_RP2350A 1
 
 #include <cyw43_wrappers.h>

--- a/variants/sparkfun_thingplusrp2350/pins_arduino.h
+++ b/variants/sparkfun_thingplusrp2350/pins_arduino.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#undef PICO_RP2350A
+#define PICO_RP2350A 1
+
 #include <cyw43_wrappers.h>
 
 // LEDs

--- a/variants/sparkfun_xrp_controller/pins_arduino.h
+++ b/variants/sparkfun_xrp_controller/pins_arduino.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#undef PICO_RP2350A
 #define PICO_RP2350A 0 // RP2350B
 
 #include <cyw43_wrappers.h>

--- a/variants/sparkfun_xrp_controller/pins_arduino.h
+++ b/variants/sparkfun_xrp_controller/pins_arduino.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#undef PICO_RP2350A
 #define PICO_RP2350A 0 // RP2350B
 
 #include <cyw43_wrappers.h>

--- a/variants/sparkfun_xrp_controller/pins_arduino.h
+++ b/variants/sparkfun_xrp_controller/pins_arduino.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#define PICO_RP2350A 0
+#define PICO_RP2350A 0 // RP2350B
 
 #include <cyw43_wrappers.h>
 

--- a/variants/wiznet_5100s_evb_pico2/pins_arduino.h
+++ b/variants/wiznet_5100s_evb_pico2/pins_arduino.h
@@ -1,3 +1,2 @@
-#undef PICO_RP2350A
 #define PICO_RP2350A 1
 #include "../generic/pins_arduino.h"

--- a/variants/wiznet_5100s_evb_pico2/pins_arduino.h
+++ b/variants/wiznet_5100s_evb_pico2/pins_arduino.h
@@ -1,1 +1,3 @@
+#undef PICO_RP2350A
+#define PICO_RP2350A 1
 #include "../generic/pins_arduino.h"

--- a/variants/wiznet_5500_evb_pico2/pins_arduino.h
+++ b/variants/wiznet_5500_evb_pico2/pins_arduino.h
@@ -1,3 +1,2 @@
-#undef PICO_RP2350A
 #define PICO_RP2350A 1
 #include "../generic/pins_arduino.h"

--- a/variants/wiznet_5500_evb_pico2/pins_arduino.h
+++ b/variants/wiznet_5500_evb_pico2/pins_arduino.h
@@ -1,1 +1,3 @@
+#undef PICO_RP2350A
+#define PICO_RP2350A 1
 #include "../generic/pins_arduino.h"


### PR DESCRIPTION
Fixes #2878

The SDK uses `defined(PICO_RP2350) && !PICO_RP2350A` to indicate an RP2350B chip, not the define PICO_RP2350B.

Match the SDK's usage by converting from `defined(PICO_RP2350B)` to `defined(PICO_RP2350) && !PICO_RP2350A` and update the chip variants accordingly.