### PR TITLE
Fix rp2040.getCycleCount() from core1

### DIFF
--- a/cores/rp2040/RP2040Support.h
+++ b/cores/rp2040/RP2040Support.h
@@ -190,8 +190,8 @@ public:
     RP2040()  { /* noop */ }
     ~RP2040() { /* noop */ }
 
-    void begin() {
-        _epoch = 0;
+    void begin(int cpuid) {
+        _epoch[cpuid] = 0;
 #if !defined(__riscv) && !defined(__PROFILE)
         if (!__isFreeRTOS) {
             // Enable SYSTICK exception
@@ -200,11 +200,14 @@ public:
             systick_hw->rvr = 0x00FFFFFF;
         } else {
 #endif
-            int off = 0;
-            _ccountPgm = new PIOProgram(&ccount_program);
-            _ccountPgm->prepare(&_pio, &_sm, &off);
-            ccount_program_init(_pio, _sm, off);
-            pio_sm_set_enabled(_pio, _sm, true);
+            // Only start 1 instance of the PIO SM
+            if (cpuid == 0) {
+                int off = 0;
+                _ccountPgm = new PIOProgram(&ccount_program);
+                _ccountPgm->prepare(&_pio, &_sm, &off);
+                ccount_program_init(_pio, _sm, off);
+                pio_sm_set_enabled(_pio, _sm, true);
+            }
 #if !defined(__riscv) && !defined(__PROFILE)
         }
 #endif
@@ -241,7 +244,7 @@ public:
     /**
         @brief CPU cycle counter epoch (24-bit cycle).  For internal use
     */
-    volatile uint64_t _epoch = 0;
+    volatile uint64_t _epoch[2] = {};
     /**
         @brief Get the count of CPU clock cycles since power on.
 
@@ -258,9 +261,9 @@ public:
             uint32_t epoch;
             uint32_t ctr;
             do {
-                epoch = (uint32_t)_epoch;
+                epoch = (uint32_t)_epoch[sio_hw->cpuid];
                 ctr = systick_hw->cvr;
-            } while (epoch != (uint32_t)_epoch);
+            } while (epoch != (uint32_t)_epoch[sio_hw->cpuid]);
             return epoch + (1 << 24) - ctr; /* CTR counts down from 1<<24-1 */
         } else {
 #endif
@@ -280,9 +283,9 @@ public:
             uint64_t epoch;
             uint64_t ctr;
             do {
-                epoch = _epoch;
+                epoch = _epoch[sio_hw->cpuid];
                 ctr = systick_hw->cvr;
-            } while (epoch != _epoch);
+            } while (epoch != _epoch[sio_hw->cpuid]);
             return epoch + (1LL << 24) - ctr;
         } else {
 #endif
@@ -667,7 +670,7 @@ public:
 
 private:
     static void _SystickHandler() {
-        rp2040._epoch += 1LL << 24;
+        rp2040._epoch[sio_hw->cpuid] += 1LL << 24;
     }
     PIO _pio;
     int _sm;

--- a/cores/rp2040/RP2040Support.h
+++ b/cores/rp2040/RP2040Support.h
@@ -669,7 +669,7 @@ public:
 
 
 private:
-    static void _SystickHandler() {
+    static void __no_inline_not_in_flash_func(_SystickHandler)() {
         rp2040._epoch[sio_hw->cpuid] += 1LL << 24;
     }
     PIO _pio;

--- a/cores/rp2040/main.cpp
+++ b/cores/rp2040/main.cpp
@@ -51,10 +51,14 @@ void initVariant() { }
 
 // Optional 2nd core setup and loop
 bool core1_separate_stack __attribute__((weak)) = false;
+bool core1_disable_systick __attribute__((weak)) = false;
 extern void setup1() __attribute__((weak));
 extern void loop1() __attribute__((weak));
 extern "C" void main1() {
-    rp2040.begin(1);
+    if (!core1_disable_systick) {
+        // Don't install the SYSTICK exception handler. rp2040.getCycleCount will not work properly on core1
+        rp2040.begin(1);
+    }
     rp2040.fifo.registerCore();
     if (setup1) {
         setup1();

--- a/cores/rp2040/main.cpp
+++ b/cores/rp2040/main.cpp
@@ -54,6 +54,7 @@ bool core1_separate_stack __attribute__((weak)) = false;
 extern void setup1() __attribute__((weak));
 extern void loop1() __attribute__((weak));
 extern "C" void main1() {
+    rp2040.begin(1);
     rp2040.fifo.registerCore();
     if (setup1) {
         setup1();
@@ -128,7 +129,7 @@ extern "C" int main() {
         _REENT_INIT_PTR(_impure_ptr1);
     }
 
-    rp2040.begin();
+    rp2040.begin(0);
 
     initVariant();
 

--- a/docs/multicore.rst
+++ b/docs/multicore.rst
@@ -16,6 +16,25 @@ not necessarily simultaneously!).
 See the ``Multicore.ino`` example in the ``rp2040`` example directory for a
 quick introduction.
 
+Core 1 Operation
+----------------
+
+By default, core1 (the second core) has no non-user written code running on it.
+No interrupts, exceptions, or other background processing is done (but the core
+is still subject to hardware stalls due to on-die memory resource conflicts).
+When flash erase or write operations (i.e. ``LittleFS`` or ``EEPROM``) are called
+from core0, core1 **will** be paused.
+
+If ``rp2040.getCycleCount`` is needed to operate on the second core, then a
+periodic (once ever 16M clock cycles) ``SYSTICK`` exception will happen behind
+the scenes.  For extremely time-critical operations this may not be desirable
+and can be disabled by defining a new ``bool`` variable to ``true`` anywhere
+in your sketch:
+
+.. code:: cpp
+
+    bool core1_disable_systick = true;
+
 Stack Sizes
 -----------
 
@@ -67,6 +86,9 @@ void rp2040.restartCore1()
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Hard resets Core1 from Core 0 and restarts its operation from ``setup1()``.
+This can cause unpredictable behavior because globals and the heap
+are shared between cores and not re-initialized with this call.  Use with
+extreme caution.
 
 Communicating Between Cores
 ---------------------------


### PR DESCRIPTION
Fixes #2914

There are 2 systick units, one per core.  Set up and start core1's systick unit and track each core's epoch separately.