### PR TITLE
Update board variants IRIV IO Controller to add pins definition for I2C1.

### DIFF
--- a/variants/cytron_iriv_io_controller/pins_arduino.h
+++ b/variants/cytron_iriv_io_controller/pins_arduino.h
@@ -64,8 +64,13 @@
 #define PIN_SPI0_SS     (21u)
 
 // Wire
-#define PIN_WIRE0_SDA   (16u)
-#define PIN_WIRE0_SCL   (17u)
+#define __WIRE0_DEVICE i2c0
+#define PIN_WIRE0_SDA  (16u)
+#define PIN_WIRE0_SCL  (17u)
+
+#define __WIRE1_DEVICE i2c1
+#define PIN_WIRE1_SDA  (31u)    // Not used.
+#define PIN_WIRE1_SCL  (31u)    // Not used.
 
 
 


### PR DESCRIPTION
Added pin definitions for I2C1, even though it's not used.
Without this, the compilation failed when using the Wire library.