### PR TITLE
Rewrite SerialPIO receive path, ensure proper edge

### DIFF
--- a/cores/rp2040/pio_uart.pio
+++ b/cores/rp2040/pio_uart.pio
@@ -73,7 +73,7 @@ static inline void pio_tx_program_init(PIO pio, uint sm, uint offset, uint pin_t
 ; IN pin 0 and JMP pin are both mapped to the GPIO used as UART RX.
 
 start:
-    set x, 18           ; Preload bit counter...ovewritten by the app
+    set x, 18           ; Preload bit counter...overwritten by the app
     wait 0 pin 0        ; Stall until start bit is asserted
 
    ; Delay until 1/2 way into the bit time

--- a/cores/rp2040/pio_uart.pio
+++ b/cores/rp2040/pio_uart.pio
@@ -73,20 +73,25 @@ static inline void pio_tx_program_init(PIO pio, uint sm, uint offset, uint pin_t
 ; IN pin 0 and JMP pin are both mapped to the GPIO used as UART RX.
 
 start:
-    set x, 18           ; Preload bit counter...we'll shift in the start bit and stop bit, and each bit will be double-recorded (to be fixed by RP2040 code)
+    set x, 18           ; Preload bit counter...ovewritten by the app
     wait 0 pin 0        ; Stall until start bit is asserted
 
-bitloop:
    ; Delay until 1/2 way into the bit time
     mov y, osr
-wait_half:
-    jmp y-- wait_half
+wait_mid_start:
+    jmp y-- wait_mid_start
 
-    ; Read in the bit
-    in pins, 1          ; Shift data bit into ISR
-    jmp x-- bitloop     ; Loop all bits
-    
-    push                ; Stuff it and wait for next start
+bitloop:
+    mov y, osr
+bitloop1:
+    jmp y-- bitloop1
+    mov y, osr
+bitloop2:
+    jmp y-- bitloop2
+
+    in pins, 1
+    jmp x-- bitloop
+    push
 
 % c-sdk {
 static inline void pio_rx_program_init(PIO pio, uint sm, uint offset, uint pin) {

--- a/cores/rp2040/pio_uart.pio.h
+++ b/cores/rp2040/pio_uart.pio.h
@@ -71,7 +71,7 @@ static inline void pio_tx_program_init(PIO pio, uint sm, uint offset, uint pin_t
 // ------ //
 
 #define pio_rx_wrap_target 0
-#define pio_rx_wrap 6
+#define pio_rx_wrap 10
 #define pio_rx_pio_version 0
 
 static const uint16_t pio_rx_program_instructions[] = {
@@ -80,16 +80,20 @@ static const uint16_t pio_rx_program_instructions[] = {
     0x2020, //  1: wait   0 pin, 0
     0xa047, //  2: mov    y, osr
     0x0083, //  3: jmp    y--, 3
-    0x4001, //  4: in     pins, 1
-    0x0042, //  5: jmp    x--, 2
-    0x8020, //  6: push   block
+    0xa047, //  4: mov    y, osr
+    0x0085, //  5: jmp    y--, 5
+    0xa047, //  6: mov    y, osr
+    0x0087, //  7: jmp    y--, 7
+    0x4001, //  8: in     pins, 1
+    0x0044, //  9: jmp    x--, 4
+    0x8020, // 10: push   block
     //     .wrap
 };
 
 #if !PICO_NO_HARDWARE
 static const struct pio_program pio_rx_program = {
     .instructions = pio_rx_program_instructions,
-    .length = 7,
+    .length = 11,
     .origin = -1,
     .pio_version = 0,
 #if PICO_PIO_VERSION > 0


### PR DESCRIPTION
The SerialPIO(SoftwareSerial) receive path was convoluted and required a lot of work on the host to get the actual data out.  It also wasn't always sampling on the proper edge leading to errors whenever clocks or hold times shifted slightly.

Rewrite the SerialPIO RX path fo explicitily wait for start bit, pause 1/2 bit time, then idle for a full bit time for all bits. Takes more PIO instruction memory but works flawlessly even with mismatched clocks.

Tested with a loopback from HW UART to SW UART with a 5% clock mismatch @ 19200 baud without reception errors, whereas the original code would fail with less than a 0.5% variation.

Fixes #2928

````
#include <SoftwareSerial.h>
SoftwareSerial s(15, -1);
void setup() {
  Serial1.setTX(0);
  Serial1.begin(19200 + 1920/2, SERIAL_8N1);
  s.begin(19200, SERIAL_8N1);
}

void loop() {
  Serial.println("---");
  Serial1.write("Had we but world enough and time", 32);
  uint32_t now = millis();
  while (millis() - now < 500) {
    while (s.available()) {
      auto c = s.read();
      Serial.printf("%02x '%c'\n", c, c);
    }
  }
}
````