### PR TITLE
Fixed generic PIN_LED and SPI0 Pin assignment on WIZnet W55RP20-EVB-Pico.

### DIFF
--- a/variants/wiznet_55rp20_evb_pico/pins_arduino.h
+++ b/variants/wiznet_55rp20_evb_pico/pins_arduino.h
@@ -16,10 +16,10 @@
 
 // SPI
 // Default SPI0 pins are used internally and are unavailable on this board. To use SPI0 other peripherals must be sacrificed.
-// #define PIN_SPI0_MISO  (16u)
-// #define PIN_SPI0_MOSI  (19u)
-// #define PIN_SPI0_SCK   (18u)
-// #define PIN_SPI0_SS    (17u)
+#define PIN_SPI0_MISO  (2u) // 16u is connected to the buck-boost converted.
+#define PIN_SPI0_MOSI  (3u) // 19u is connected to USERLED, defined as PIN_LED.
+#define PIN_SPI0_SCK   (4u) // 18u is connected to a voltage divider on VBUS.
+#define PIN_SPI0_SS    (5u) // 17u doesn't even show up in the schematics.
 
 #define PIN_SPI1_MISO  (12u)
 #define PIN_SPI1_MOSI  (15u)

--- a/variants/wiznet_55rp20_evb_pico/pins_arduino.h
+++ b/variants/wiznet_55rp20_evb_pico/pins_arduino.h
@@ -1,1 +1,40 @@
-#include "../generic/pins_arduino.h"
+#pragma once
+
+// Pin definitions taken from:
+//    https://datasheets.raspberrypi.org/pico/pico-datasheet.pdf
+
+
+// LEDs
+#define PIN_LED        (19u)
+
+// Serial
+#define PIN_SERIAL1_TX (0u)
+#define PIN_SERIAL1_RX (1u)
+
+#define PIN_SERIAL2_TX (8u)
+#define PIN_SERIAL2_RX (9u)
+
+// SPI
+// Default SPI0 pins are used internally and are unavailable on this board. To use SPI0 other peripherals must be sacrificed.
+// #define PIN_SPI0_MISO  (16u)
+// #define PIN_SPI0_MOSI  (19u)
+// #define PIN_SPI0_SCK   (18u)
+// #define PIN_SPI0_SS    (17u)
+
+#define PIN_SPI1_MISO  (12u)
+#define PIN_SPI1_MOSI  (15u)
+#define PIN_SPI1_SCK   (14u)
+#define PIN_SPI1_SS    (13u)
+
+// Wire
+#define PIN_WIRE0_SDA  (4u)
+#define PIN_WIRE0_SCL  (5u)
+
+#define PIN_WIRE1_SDA  (26u)
+#define PIN_WIRE1_SCL  (27u)
+
+#define SERIAL_HOWMANY (3u)
+#define SPI_HOWMANY    (2u)
+#define WIRE_HOWMANY   (2u)
+
+#include "../generic/common.h"


### PR DESCRIPTION
Assigned GPIO19 to PIN_LED instead of generic 25. GPIO19 is connected to USERLED.
GPIO25 is coincidentally connected to an LED but it has other internal functions.

SPI0 generic pins are unavailable. It's use means sacrificing [other peripherals as per official pinout](https://docs.wiznet.io/Product/ioNIC/W55RP20/w55rp20-evb-pico#hardware-specification).
Assigned GPIO2 to PIN_SPI0_MISO since GPIO16 is connected to the buck-boost converted.
Assigned GPIO3 to PIN_SPI0_MOSI since GPIO19 is now defined as PIN_LED.
Assigned GPIO4 to PIN_SPI0_SCK since GPIO18 is connected to a voltage divider on VBUS.
Assigned GPIO5 to PIN_SPI0_SS since GPIO17 doesn't show up in the schematics.