### PR TITLE
Force DHCP request on WiFiMulti ::run connection

### DIFF
--- a/libraries/WiFi/src/WiFiMulti.cpp
+++ b/libraries/WiFi/src/WiFiMulti.cpp
@@ -109,6 +109,9 @@ uint8_t WiFiMulti::run(uint32_t to) {
                j->bssid[0], j->bssid[1], j->bssid[2], j->bssid[3], j->bssid[4], j->bssid[5], j->rssi);
     }
 
+    // Force DHCP request
+    WiFi.config(IPAddress(0, 0, 0, 0));
+
     // Attempt to connect to each (will be in order of decreasing RSSI)
     for (auto j = _scanList.begin(); j != _scanList.end(); j++) {
         DEBUGV("[WIFIMULTI] Connecting to: SSID: '%s' -- BSSID: '%02X%02X%02X%02X%02X%02X' -- RSSI: %d\n", j->ssid,


### PR DESCRIPTION
The IP address is not cleared (even if it is DHCP acquired) between ::begins on the Ethernet classes by design (#1866).  But it is possible that the WiFi networks being polled by WiFiMulti are different network configurations, so force a DHCP request explicitly before (re)connecting).

Fixes #2974