### PR TITLE
Send DHCP request on ::begin even if lease exist

### DIFF
--- a/libraries/lwIP_Ethernet/src/LwipIntfDev.h
+++ b/libraries/lwIP_Ethernet/src/LwipIntfDev.h
@@ -186,6 +186,7 @@ protected:
     SPIClass& _spiUnit;
     SPISettings _spiSettings = SPISettings(4000000, MSBFIRST, SPI_MODE0);
     netif _netif;
+    bool _isDHCP = true;
 
     uint16_t _mtu;
     int8_t   _intrPin;
@@ -281,6 +282,8 @@ bool LwipIntfDev<RawDev>::config(const IPAddress& localIP, const IPAddress& gate
         DEBUGV("LwipIntfDev: use config() then begin()\n");
         return false;
     }
+
+    _isDHCP = (localIP.v4() == 0);
 
     IPAddress realGateway, realNetmask, realDns1;
     if (!ipAddressReorder(localIP, gateway, netmask, dns1, realGateway, realNetmask, realDns1)) {
@@ -389,7 +392,7 @@ bool LwipIntfDev<RawDev>::begin(const uint8_t* macAddress, const uint16_t mtu) {
         _phID = __addEthernetPacketHandler([this] { this->handlePackets(); });
     }
 
-    if (localIP().v4() == 0) {
+    if (_isDHCP) {
         // IP not set, starting DHCP
         _netif.flags |= NETIF_FLAG_UP;
         switch (dhcp_start(&_netif)) {


### PR DESCRIPTION
When a link comes up, we were only sending a DHCP request if the existing netif's ipaddress was 0.  When a DHCP lease is acquired at first that IP is changed to the given address, and if we do another ::begin we wouldn't dhcp_start to send a new request and use the old one (until its lease expired).

In the case of network changing (i.e. WiFiMulti on different nets or moving an Ethernet cable to another router) that old address would not be valid.

Track if an IP address has been manually set and use that to determine if DHCP needs to be re-requested instead of looking at the old netif's ipaddress.

Fixes #2974