### PR TITLE
Mark all boards as picosdk compatible in PlatformIO board definition

### DIFF
--- a/tools/json/0xcb_helios.json
+++ b/tools/json/0xcb_helios.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Helios",
     "upload": {

--- a/tools/json/DudesCab.json
+++ b/tools/json/DudesCab.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "DudesCab",
     "upload": {

--- a/tools/json/MyRP_bot.json
+++ b/tools/json/MyRP_bot.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "RP2040",
     "upload": {

--- a/tools/json/adafruit_feather.json
+++ b/tools/json/adafruit_feather.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Feather RP2040",
     "upload": {

--- a/tools/json/adafruit_feather_adalogger.json
+++ b/tools/json/adafruit_feather_adalogger.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Feather RP2040 Adalogger",
     "upload": {

--- a/tools/json/adafruit_feather_can.json
+++ b/tools/json/adafruit_feather_can.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Feather RP2040 CAN",
     "upload": {

--- a/tools/json/adafruit_feather_dvi.json
+++ b/tools/json/adafruit_feather_dvi.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Feather RP2040 DVI",
     "upload": {

--- a/tools/json/adafruit_feather_prop_maker.json
+++ b/tools/json/adafruit_feather_prop_maker.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Feather RP2040 Prop-Maker",
     "upload": {

--- a/tools/json/adafruit_feather_rfm.json
+++ b/tools/json/adafruit_feather_rfm.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Feather RP2040 RFM",
     "upload": {

--- a/tools/json/adafruit_feather_rp2350_adalogger.json
+++ b/tools/json/adafruit_feather_rp2350_adalogger.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2350.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Feather RP2350 Adalogger",
     "upload": {

--- a/tools/json/adafruit_feather_rp2350_hstx.json
+++ b/tools/json/adafruit_feather_rp2350_hstx.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2350.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Feather RP2350 HSTX",
     "upload": {

--- a/tools/json/adafruit_feather_scorpio.json
+++ b/tools/json/adafruit_feather_scorpio.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Feather RP2040 SCORPIO",
     "upload": {

--- a/tools/json/adafruit_feather_thinkink.json
+++ b/tools/json/adafruit_feather_thinkink.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Feather RP2040 ThinkINK",
     "upload": {

--- a/tools/json/adafruit_feather_usb_host.json
+++ b/tools/json/adafruit_feather_usb_host.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Feather RP2040 USB Host",
     "upload": {

--- a/tools/json/adafruit_floppsy.json
+++ b/tools/json/adafruit_floppsy.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Floppsy",
     "upload": {

--- a/tools/json/adafruit_fruitjam.json
+++ b/tools/json/adafruit_fruitjam.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2350.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Fruit Jam RP2350",
     "upload": {

--- a/tools/json/adafruit_itsybitsy.json
+++ b/tools/json/adafruit_itsybitsy.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "ItsyBitsy RP2040",
     "upload": {

--- a/tools/json/adafruit_kb2040.json
+++ b/tools/json/adafruit_kb2040.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "KB2040",
     "upload": {

--- a/tools/json/adafruit_macropad2040.json
+++ b/tools/json/adafruit_macropad2040.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "MacroPad RP2040",
     "upload": {

--- a/tools/json/adafruit_metro.json
+++ b/tools/json/adafruit_metro.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Metro RP2040",
     "upload": {

--- a/tools/json/adafruit_metro_rp2350.json
+++ b/tools/json/adafruit_metro_rp2350.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2350.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Metro RP2350",
     "upload": {

--- a/tools/json/adafruit_qtpy.json
+++ b/tools/json/adafruit_qtpy.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "QT Py RP2040",
     "upload": {

--- a/tools/json/adafruit_stemmafriend.json
+++ b/tools/json/adafruit_stemmafriend.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "STEMMA Friend RP2040",
     "upload": {

--- a/tools/json/adafruit_trinkeyrp2040qt.json
+++ b/tools/json/adafruit_trinkeyrp2040qt.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Trinkey RP2040 QT",
     "upload": {

--- a/tools/json/akana_r1.json
+++ b/tools/json/akana_r1.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Akana R1",
     "upload": {

--- a/tools/json/amken_bunny.json
+++ b/tools/json/amken_bunny.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "BunnyBoard",
     "upload": {

--- a/tools/json/amken_revelop.json
+++ b/tools/json/amken_revelop.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Revelop",
     "upload": {

--- a/tools/json/amken_revelop_es.json
+++ b/tools/json/amken_revelop_es.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Revelop eS",
     "upload": {

--- a/tools/json/amken_revelop_plus.json
+++ b/tools/json/amken_revelop_plus.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Revelop Plus",
     "upload": {

--- a/tools/json/arduino_nano_connect.json
+++ b/tools/json/arduino_nano_connect.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Nano RP2040 Connect",
     "upload": {

--- a/tools/json/artronshop_rp2_nano.json
+++ b/tools/json/artronshop_rp2_nano.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "RP2 Nano",
     "upload": {

--- a/tools/json/breadstick_raspberry.json
+++ b/tools/json/breadstick_raspberry.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Raspberry",
     "upload": {

--- a/tools/json/bridgetek_idm2040_43a.json
+++ b/tools/json/bridgetek_idm2040_43a.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "IDM2040-43A",
     "upload": {

--- a/tools/json/bridgetek_idm2040_7a.json
+++ b/tools/json/bridgetek_idm2040_7a.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "IDM2040-7A",
     "upload": {

--- a/tools/json/challenger_2040_lora.json
+++ b/tools/json/challenger_2040_lora.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Challenger 2040 LoRa",
     "upload": {

--- a/tools/json/challenger_2040_lte.json
+++ b/tools/json/challenger_2040_lte.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Challenger 2040 LTE",
     "upload": {

--- a/tools/json/challenger_2040_nfc.json
+++ b/tools/json/challenger_2040_nfc.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Challenger 2040 NFC",
     "upload": {

--- a/tools/json/challenger_2040_sdrtc.json
+++ b/tools/json/challenger_2040_sdrtc.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Challenger 2040 SD/RTC",
     "upload": {

--- a/tools/json/challenger_2040_subghz.json
+++ b/tools/json/challenger_2040_subghz.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Challenger 2040 SubGHz",
     "upload": {

--- a/tools/json/challenger_2040_uwb.json
+++ b/tools/json/challenger_2040_uwb.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Challenger 2040 UWB",
     "upload": {

--- a/tools/json/challenger_2040_wifi.json
+++ b/tools/json/challenger_2040_wifi.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Challenger 2040 WiFi",
     "upload": {

--- a/tools/json/challenger_2040_wifi6_ble.json
+++ b/tools/json/challenger_2040_wifi6_ble.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Challenger 2040 WiFi6/BLE",
     "upload": {

--- a/tools/json/challenger_2040_wifi_ble.json
+++ b/tools/json/challenger_2040_wifi_ble.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Challenger 2040 WiFi/BLE",
     "upload": {

--- a/tools/json/challenger_2350_bconnect.json
+++ b/tools/json/challenger_2350_bconnect.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2350.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Challenger 2350 BConnect",
     "upload": {

--- a/tools/json/challenger_2350_wifi6_ble5.json
+++ b/tools/json/challenger_2350_wifi6_ble5.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2350.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Challenger 2350 WiFi/BLE",
     "upload": {

--- a/tools/json/challenger_nb_2040_wifi.json
+++ b/tools/json/challenger_nb_2040_wifi.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Challenger NB 2040 WiFi",
     "upload": {

--- a/tools/json/connectivity_2040_lte_wifi_ble.json
+++ b/tools/json/connectivity_2040_lte_wifi_ble.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Connectivity 2040 LTE/WiFi/BLE",
     "upload": {

--- a/tools/json/cytron_iriv_io_controller.json
+++ b/tools/json/cytron_iriv_io_controller.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2350.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "IRIV IO Controller",
     "upload": {

--- a/tools/json/cytron_maker_nano_rp2040.json
+++ b/tools/json/cytron_maker_nano_rp2040.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Maker Nano RP2040",
     "upload": {

--- a/tools/json/cytron_maker_pi_rp2040.json
+++ b/tools/json/cytron_maker_pi_rp2040.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Maker Pi RP2040",
     "upload": {

--- a/tools/json/cytron_maker_uno_rp2040.json
+++ b/tools/json/cytron_maker_uno_rp2040.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Maker Uno RP2040",
     "upload": {

--- a/tools/json/cytron_motion_2350_pro.json
+++ b/tools/json/cytron_motion_2350_pro.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2350.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Motion 2350 Pro",
     "upload": {

--- a/tools/json/datanoisetv_picoadk.json
+++ b/tools/json/datanoisetv_picoadk.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "PicoADK",
     "upload": {

--- a/tools/json/datanoisetv_picoadk_v2.json
+++ b/tools/json/datanoisetv_picoadk_v2.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2350.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "PicoADK v2",
     "upload": {

--- a/tools/json/degz_suibo.json
+++ b/tools/json/degz_suibo.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Suibo RP2040",
     "upload": {

--- a/tools/json/dfrobot_beetle_rp2040.json
+++ b/tools/json/dfrobot_beetle_rp2040.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Beetle RP2040",
     "upload": {

--- a/tools/json/electroniccats_huntercat_nfc.json
+++ b/tools/json/electroniccats_huntercat_nfc.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "HunterCat NFC RP2040",
     "upload": {

--- a/tools/json/evn_alpha.json
+++ b/tools/json/evn_alpha.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Alpha",
     "upload": {

--- a/tools/json/extelec_rc2040.json
+++ b/tools/json/extelec_rc2040.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "RC2040",
     "upload": {

--- a/tools/json/flyboard2040_core.json
+++ b/tools/json/flyboard2040_core.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "FlyBoard2040Core",
     "upload": {

--- a/tools/json/generic.json
+++ b/tools/json/generic.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "RP2040",
     "upload": {

--- a/tools/json/generic_rp2350.json
+++ b/tools/json/generic_rp2350.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2350.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "RP2350",
     "upload": {

--- a/tools/json/groundstudio_marble_pico.json
+++ b/tools/json/groundstudio_marble_pico.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Marble Pico",
     "upload": {

--- a/tools/json/ilabs_rpico32.json
+++ b/tools/json/ilabs_rpico32.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "RPICO32",
     "upload": {

--- a/tools/json/jumperless_v1.json
+++ b/tools/json/jumperless_v1.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Jumperless",
     "upload": {

--- a/tools/json/jumperless_v5.json
+++ b/tools/json/jumperless_v5.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2350.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Jumperless V5",
     "upload": {

--- a/tools/json/melopero_cookie_rp2040.json
+++ b/tools/json/melopero_cookie_rp2040.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Cookie RP2040",
     "upload": {

--- a/tools/json/melopero_shake_rp2040.json
+++ b/tools/json/melopero_shake_rp2040.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Shake RP2040",
     "upload": {

--- a/tools/json/mksthr36.json
+++ b/tools/json/mksthr36.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "MKS THR36",
     "upload": {

--- a/tools/json/mksthr42.json
+++ b/tools/json/mksthr42.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "MKS THR42",
     "upload": {

--- a/tools/json/nekosystems_bl2040_mini.json
+++ b/tools/json/nekosystems_bl2040_mini.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "BL2040 Mini",
     "upload": {

--- a/tools/json/newsan_archi.json
+++ b/tools/json/newsan_archi.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Archi",
     "upload": {

--- a/tools/json/nullbits_bit_c_pro.json
+++ b/tools/json/nullbits_bit_c_pro.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Bit-C PRO",
     "upload": {

--- a/tools/json/olimex_pico2xl.json
+++ b/tools/json/olimex_pico2xl.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2350.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Pico2XL",
     "upload": {

--- a/tools/json/olimex_pico2xxl.json
+++ b/tools/json/olimex_pico2xxl.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2350.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Pico2XXL",
     "upload": {

--- a/tools/json/olimex_rp2040pico30.json
+++ b/tools/json/olimex_rp2040pico30.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "RP2040-Pico30",
     "upload": {

--- a/tools/json/pimoroni_pga2040.json
+++ b/tools/json/pimoroni_pga2040.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "PGA2040",
     "upload": {

--- a/tools/json/pimoroni_pga2350.json
+++ b/tools/json/pimoroni_pga2350.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2350.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "PGA2350",
     "upload": {

--- a/tools/json/pimoroni_pico_plus_2.json
+++ b/tools/json/pimoroni_pico_plus_2.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2350.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "PicoPlus2",
     "upload": {

--- a/tools/json/pimoroni_pico_plus_2w.json
+++ b/tools/json/pimoroni_pico_plus_2w.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2350.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "PicoPlus2W",
     "upload": {

--- a/tools/json/pimoroni_plasma2040.json
+++ b/tools/json/pimoroni_plasma2040.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Plasma2040",
     "upload": {

--- a/tools/json/pimoroni_plasma2350.json
+++ b/tools/json/pimoroni_plasma2350.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2350.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Plasma2350",
     "upload": {

--- a/tools/json/pimoroni_servo2040.json
+++ b/tools/json/pimoroni_servo2040.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Servo2040",
     "upload": {

--- a/tools/json/pimoroni_tiny2040.json
+++ b/tools/json/pimoroni_tiny2040.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Tiny2040",
     "upload": {

--- a/tools/json/pimoroni_tiny2350.json
+++ b/tools/json/pimoroni_tiny2350.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2350.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Tiny2350",
     "upload": {

--- a/tools/json/pintronix_pinmax.json
+++ b/tools/json/pintronix_pinmax.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "PinMax",
     "upload": {

--- a/tools/json/rakwireless_rak11300.json
+++ b/tools/json/rakwireless_rak11300.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "RAK11300",
     "upload": {

--- a/tools/json/redscorp_rp2040_eins.json
+++ b/tools/json/redscorp_rp2040_eins.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "RP2040-Eins",
     "upload": {

--- a/tools/json/redscorp_rp2040_promini.json
+++ b/tools/json/redscorp_rp2040_promini.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "RP2040-ProMini",
     "upload": {

--- a/tools/json/rpipico.json
+++ b/tools/json/rpipico.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Pico",
     "upload": {

--- a/tools/json/rpipico2.json
+++ b/tools/json/rpipico2.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2350.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Pico 2",
     "upload": {

--- a/tools/json/rpipico2w.json
+++ b/tools/json/rpipico2w.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2350.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Pico 2W",
     "upload": {

--- a/tools/json/rpipicow.json
+++ b/tools/json/rpipicow.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Pico W",
     "upload": {

--- a/tools/json/sea_picro.json
+++ b/tools/json/sea_picro.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Sea-Picro",
     "upload": {

--- a/tools/json/seeed_indicator_rp2040.json
+++ b/tools/json/seeed_indicator_rp2040.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "INDICATOR RP2040",
     "upload": {

--- a/tools/json/seeed_xiao_rp2040.json
+++ b/tools/json/seeed_xiao_rp2040.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "XIAO RP2040",
     "upload": {

--- a/tools/json/seeed_xiao_rp2350.json
+++ b/tools/json/seeed_xiao_rp2350.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2350.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "XIAO RP2350",
     "upload": {

--- a/tools/json/silicognition_rp2040_shim.json
+++ b/tools/json/silicognition_rp2040_shim.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "RP2040-Shim",
     "upload": {

--- a/tools/json/solderparty_rp2040_stamp.json
+++ b/tools/json/solderparty_rp2040_stamp.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "RP2040 Stamp",
     "upload": {

--- a/tools/json/solderparty_rp2350_stamp.json
+++ b/tools/json/solderparty_rp2350_stamp.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2350.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "RP2350 Stamp",
     "upload": {

--- a/tools/json/solderparty_rp2350_stamp_xl.json
+++ b/tools/json/solderparty_rp2350_stamp_xl.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2350.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "RP2350 Stamp XL",
     "upload": {

--- a/tools/json/sparkfun_iotnode_lorawanrp2350.json
+++ b/tools/json/sparkfun_iotnode_lorawanrp2350.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2350.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "IoT Node LoRaWAN",
     "upload": {

--- a/tools/json/sparkfun_iotredboard_rp2350.json
+++ b/tools/json/sparkfun_iotredboard_rp2350.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2350.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "IoT RedBoard RP2350",
     "upload": {

--- a/tools/json/sparkfun_micromodrp2040.json
+++ b/tools/json/sparkfun_micromodrp2040.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "MicroMod RP2040",
     "upload": {

--- a/tools/json/sparkfun_promicrorp2040.json
+++ b/tools/json/sparkfun_promicrorp2040.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "ProMicro RP2040",
     "upload": {

--- a/tools/json/sparkfun_promicrorp2350.json
+++ b/tools/json/sparkfun_promicrorp2350.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2350.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "ProMicro RP2350",
     "upload": {

--- a/tools/json/sparkfun_thingplusrp2040.json
+++ b/tools/json/sparkfun_thingplusrp2040.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Thing Plus RP2040",
     "upload": {

--- a/tools/json/sparkfun_thingplusrp2350.json
+++ b/tools/json/sparkfun_thingplusrp2350.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2350.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Thing Plus RP2350",
     "upload": {

--- a/tools/json/sparkfun_xrp_controller.json
+++ b/tools/json/sparkfun_xrp_controller.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2350.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "XRP Controller",
     "upload": {

--- a/tools/json/sparkfun_xrp_controller_beta.json
+++ b/tools/json/sparkfun_xrp_controller_beta.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "XRP Controller (Beta)",
     "upload": {

--- a/tools/json/upesy_rp2040_devkit.json
+++ b/tools/json/upesy_rp2040_devkit.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "RP2040 DevKit",
     "upload": {

--- a/tools/json/vccgnd_yd_rp2040.json
+++ b/tools/json/vccgnd_yd_rp2040.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "YD RP2040",
     "upload": {

--- a/tools/json/viyalab_mizu.json
+++ b/tools/json/viyalab_mizu.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "Mizu RP2040",
     "upload": {

--- a/tools/json/waveshare_rp2040_lcd_0_96.json
+++ b/tools/json/waveshare_rp2040_lcd_0_96.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "RP2040 LCD 0.96",
     "upload": {

--- a/tools/json/waveshare_rp2040_lcd_1_28.json
+++ b/tools/json/waveshare_rp2040_lcd_1_28.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "RP2040 LCD 1.28",
     "upload": {

--- a/tools/json/waveshare_rp2040_matrix.json
+++ b/tools/json/waveshare_rp2040_matrix.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "RP2040 Matrix",
     "upload": {

--- a/tools/json/waveshare_rp2040_one.json
+++ b/tools/json/waveshare_rp2040_one.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "RP2040 One",
     "upload": {

--- a/tools/json/waveshare_rp2040_pizero.json
+++ b/tools/json/waveshare_rp2040_pizero.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "RP2040 PiZero",
     "upload": {

--- a/tools/json/waveshare_rp2040_plus_16mb.json
+++ b/tools/json/waveshare_rp2040_plus_16mb.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "RP2040 Plus 16MB",
     "upload": {

--- a/tools/json/waveshare_rp2040_plus_4mb.json
+++ b/tools/json/waveshare_rp2040_plus_4mb.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "RP2040 Plus 4MB",
     "upload": {

--- a/tools/json/waveshare_rp2040_zero.json
+++ b/tools/json/waveshare_rp2040_zero.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "RP2040 Zero",
     "upload": {

--- a/tools/json/wiznet_5100s_evb_pico.json
+++ b/tools/json/wiznet_5100s_evb_pico.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "W5100S-EVB-Pico",
     "upload": {

--- a/tools/json/wiznet_5100s_evb_pico2.json
+++ b/tools/json/wiznet_5100s_evb_pico2.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2350.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "W5100S-EVB-Pico2",
     "upload": {

--- a/tools/json/wiznet_5500_evb_pico.json
+++ b/tools/json/wiznet_5500_evb_pico.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "W5500-EVB-Pico",
     "upload": {

--- a/tools/json/wiznet_5500_evb_pico2.json
+++ b/tools/json/wiznet_5500_evb_pico2.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2350.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "W5500-EVB-Pico2",
     "upload": {

--- a/tools/json/wiznet_55rp20_evb_pico.json
+++ b/tools/json/wiznet_55rp20_evb_pico.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "W55RP20-EVB-Pico",
     "upload": {

--- a/tools/json/wiznet_wizfi360_evb_pico.json
+++ b/tools/json/wiznet_wizfi360_evb_pico.json
@@ -30,7 +30,8 @@
         "svd_path": "rp2040.svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": "WizFi360-EVB-Pico",
     "upload": {

--- a/tools/makeboards.py
+++ b/tools/makeboards.py
@@ -451,7 +451,8 @@ def MakeBoardJSON(name, chip, vendor_name, product_name, vid, pid, pwr, boarddef
         "svd_path": chip + ".svd"
     },
     "frameworks": [
-        "arduino"
+        "arduino",
+        "picosdk"
     ],
     "name": product_name,
     "upload": {


### PR DESCRIPTION
As the work continues in platform-raspberrypi to be able to compile native `framework = picosdk` firmwares, it has come to a point where I want every board to be in general marked as "Pico-SDK framework compatible".

I have specificially tested the [examples/picosdk-blink](https://github.com/maxgerhardt/platform-raspberrypi/blob/develop/examples/picosdk-blink/platformio.ini) example in the `pico2` environment with the Pimoroni Tiny2350 board to be working.

Since I mostly copy-paste the board JSON definitions from here into the PlatformIO platform, it's best to change the generator script here instead of making a second-pass on the generated files.

At a later point in time, I will update this again, adding the `build.picosdk.board_header` information in the board files as needed, which links them to their Pico-SDK board header file name (e.g. `pico.h`, `pimoroni_tiny2350.h`, ..)