### PR TITLE
Cleanly install PlatformIO platform from scratch

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -268,8 +268,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install --upgrade platformio
+        rm -rf ~/.platformio/platforms/raspberrypi*
         pio pkg install --global --platform https://github.com/maxgerhardt/platform-raspberrypi.git
-        pio pkg update --global --platform https://github.com/maxgerhardt/platform-raspberrypi.git
         pio pkg install --global --tool symlink://.
         cp -f /home/runner/work/arduino-pico/arduino-pico/tools/json/*.json /home/runner/.platformio/platforms/raspberrypi/boards/.
     - name: Build Multicore Example
@@ -325,8 +325,8 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install --upgrade platformio
+        rm -rf ~/.platformio/platforms/raspberrypi*
         pio pkg install --global --platform https://github.com/maxgerhardt/platform-raspberrypi.git
-        pio pkg update --global --platform https://github.com/maxgerhardt/platform-raspberrypi.git
         pio pkg install --global --tool symlink://.
         cp -f /home/runner/work/arduino-pico/arduino-pico/tools/json/*.json /home/runner/.platformio/platforms/raspberrypi/boards/.
     - name: Build Every Variant


### PR DESCRIPTION
Prevents weird update errors stemming from an already installed platform (cached), then updating some files in it manually and then pio pkg updating it.

Should fix issues seen in #2975 and other PRs.