### PR TITLE
add DVI pin mapping to pins_arduino.h

### DIFF
--- a/variants/pimoroni_pico_plus_2/pins_arduino.h
+++ b/variants/pimoroni_pico_plus_2/pins_arduino.h
@@ -51,6 +51,16 @@
 
 #define PICO_RP2350A 0 // RP2350B
 
+// DVI connector
+#define PIN_CKN (15u)
+#define PIN_CKP (14u)
+#define PIN_D0N (13u)
+#define PIN_D0P (12u)
+#define PIN_D1N (19u)
+#define PIN_D1P (18u)
+#define PIN_D2N (17u)
+#define PIN_D2P (16u)
+
 /* Pins mappings for marked pins on the board */
 static const uint8_t D0 = (0u);
 static const uint8_t D1 = (1u);


### PR DESCRIPTION
I use the Adafruit library https://github.com/adafruit/Adafruit-DVI-HSTX, which implements DVI over HSTX.
You need the correct pin mapping for tzhe HSTX pins to use this library. Adafruit HSTX boards define this mapping.
I would like to add this to the Pimoroni Pico Plus 2, so that you can use the Adafruit library out of the box without headaches how to map the HSTX pins.