### PR TITLE
Make default SerialBT FIFO 1K

### DIFF
--- a/libraries/SerialBT/src/SerialBT.h
+++ b/libraries/SerialBT/src/SerialBT.h
@@ -79,7 +79,7 @@ private:
     // Lockless, IRQ-handled circular queue
     uint32_t _writer;
     uint32_t _reader;
-    size_t   _fifoSize = 32;
+    size_t   _fifoSize = 1024;
     uint8_t *_queue;
 
     const int RFCOMM_SERVER_CHANNEL = 1;


### PR DESCRIPTION
BT SPP doesn't have backoff and we can receive long messages.  If there's not enough memory to store them then they will be truncated.

Increase the default space to 1K to help avoid this issue.