### PR TITLE
Add support for custom CMake flags and positional target arguments in build script

### DIFF
--- a/tools/libpico/CMakeLists.txt
+++ b/tools/libpico/CMakeLists.txt
@@ -1,5 +1,7 @@
 cmake_minimum_required(VERSION 3.12)
 
+option(LIB_PICO_MULTICORE "Enable multicore support" 0)
+
 set(cpu $ENV{CPU})
 message("Building for CPU ${cpu}")
 
@@ -131,6 +133,7 @@ target_compile_definitions(common-${cpu} INTERFACE
     CYW43_WARN=//
     CYW43_PIO_CLOCK_DIV_DYNAMIC=1
     CYW43_PIN_WL_DYNAMIC=1
+    LIB_PICO_MULTICORE=${LIB_PICO_MULTICORE}
     ${xcd}
 )
 

--- a/tools/libpico/make-libpico.sh
+++ b/tools/libpico/make-libpico.sh
@@ -3,24 +3,40 @@
 set -e # Exit on error
 set -x
 
-export PICO_SDK_PATH="$(cd ../../pico-sdk/; pwd)"
-export PATH="$(cd ../../system/arm-none-eabi/bin; pwd):$PATH"
-export PATH="$(cd ../../system/riscv32-unknown-elf/bin; pwd):$PATH"
-export PATH="$(cd ../../system/picotool; pwd):$PATH"
+PICO_SDK_PATH="$(cd ../../pico-sdk/; pwd)"
+export PICO_SDK_PATH
+PATH="$(cd ../../system/arm-none-eabi/bin; pwd):$PATH"
+PATH="$(cd ../../system/riscv32-unknown-elf/bin; pwd):$PATH"
+PATH="$(cd ../../system/picotool; pwd):$PATH"
+export PATH
 
-rm -rf build-rp2040
-mkdir build-rp2040
-cd build-rp2040
-CPU=rp2040 cmake ..
-make -j
+# Parse arguments
+targets=()
+flags=()
+parse_flags=0
+for arg in "$@"; do
+    if [[ $parse_flags -eq 1 ]]; then
+        flags+=("$arg")
+    elif [[ $arg == "--flags" ]]; then
+        parse_flags=1
+    else
+        targets+=("$arg")
+    fi
+done
 
+build_rp2040() {
+    rm -rf build-rp2040
+    mkdir build-rp2040
+    cd build-rp2040
+    CPU=rp2040 cmake "${flags[@]}" ..
+    make -j
 # The develop branch of the SDK seems to have busted the RP2040 boot2.S files.
 # These don't change and aren't lkikely to get any new additions, so comment out
 # for now and use the prior versions built under earlier SDK.
 #rm -rf boot
 #mkdir boot
 #cd boot
-#mkdir -p pico 
+#mkdir -p pico
 #touch pico/config.h
 #for type in boot2_generic_03h boot2_is25lp080 boot2_w25q080 boot2_w25x10cl; do
 #    for div in 2 4; do
@@ -38,7 +54,7 @@ make -j
 #        arm-none-eabi-gcc -march=armv6-m -mcpu=cortex-m0plus -mthumb -O3 \
 #                          -DNDEBUG -Wl,--build-id=none --specs=nosys.specs -nostartfiles \
 #                          -Wl,--script="$PICO_SDK_PATH/src/rp2040/boot_stage2/boot_stage2.ld" \
-#                          -Wl,-Map=$type.$div.elf.map $type.o -o $type.$div.elf 
+#                          -Wl,-Map=$type.$div.elf.map $type.o -o $type.$div.elf
 #
 #        arm-none-eabi-objdump -h $type.$div.elf >  $type.$div.dis
 #        arm-none-eabi-objdump -d $type.$div.elf >> $type.$div.dis
@@ -51,17 +67,38 @@ make -j
 #done
 #mv *.S ../../../../boot2/rp2040/.
 #cd ../..
+    cd ..
+}
 
-cd ..
-rm -rf build-rp2350
-mkdir build-rp2350
-cd build-rp2350
-CPU=rp2350 cmake ..
-make -j
+build_rp2350() {
+    rm -rf build-rp2350
+    mkdir build-rp2350
+    cd build-rp2350
+    CPU=rp2350 cmake "${flags[@]}" ..
+    make -j
+    cd ..
+}
 
-cd ..
-rm -rf build-rp2350-riscv
-mkdir build-rp2350-riscv
-cd build-rp2350-riscv
-CPU=rp2350-riscv cmake ..
-make -j
+build_rp2350_riscv() {
+    rm -rf build-rp2350-riscv
+    mkdir build-rp2350-riscv
+    cd build-rp2350-riscv
+    CPU=rp2350-riscv cmake "${flags[@]}" ..
+    make -j
+  cd ..
+}
+
+if [[ ${#targets[@]} -eq 0 ]]; then
+    build_rp2040
+    build_rp2350
+    build_rp2350_riscv
+else
+    for t in "${targets[@]}"; do
+        case $t in
+            rp2040) build_rp2040 ;;
+            rp2350) build_rp2350 ;;
+            rp2350-riscv) build_rp2350_riscv ;;
+            *) echo "Unknown target: $t"; exit 1 ;;
+        esac
+    done
+fi


### PR DESCRIPTION
- Refactor `make-libpico.sh` to accept positional arguments for target selection and a `--flags` option to forward custom CMake flags.
- Update environment variable exports for clarity.
- Add `LIB_PICO_MULTICORE` CMake option to `CMakeLists.txt` and propagate it to target compile definitions.
- Preserve backwards compatibility and improve build flexibility for local and CI workflows.

### Example Usage:
```bash
/make-libpico.sh rp2040 --flags -DPICO_STDIO_UART=1 -DPICO_STDIO_USB=0 -DLIB_PICO_MULTICORE=1
```

### Tested:
- Verified that the script works as before with no arguments.
- Confirmed that custom flags are correctly passed to CMake and reflected in the build.

Closes #3058