### PR TITLE
Handle SPISlave with no output data ever written

### DIFF
--- a/libraries/SPISlave/src/SPISlave.cpp
+++ b/libraries/SPISlave/src/SPISlave.cpp
@@ -167,14 +167,14 @@ void SPISlaveClass::_handleIRQ() {
         _recvCB(buff, cnt);
     }
     // Attempt to send as many bytes to the TX FIFO as we have/are free
-    while (spi_is_writable(_spi)) {
+    do {
         for (; _dataLeft && spi_is_writable(_spi); _dataLeft--) {
             spi_get_hw(_spi)->dr = *(_dataOut++);
         }
         if (!_dataLeft && _sentCB) {
             _sentCB();
         }
-    }
+    } while (spi_is_writable(_spi) & _dataLeft);
     // Disable the TX FIFO IRQ if there is still no data to send or we'd always be stuck in an IRQ
     // Will be re-enabled once user does a setData
     if (!_dataLeft) {


### PR DESCRIPTION
Fixes #3068.  The SPISlave TX-FIFO IRQ would infinitely try to fill the FIFO as soon as IRQs were enabled, but in the case when the app never sent any data this would cause an infinite loop in the IRQ handler.

Now abort if we don't have any data, even if there is space in the FIFO.