### PR TITLE
Rescan if first one fails in HIDMaster examples

### DIFF
--- a/libraries/BluetoothHIDMaster/examples/KeyboardPiano/KeyboardPiano.ino
+++ b/libraries/BluetoothHIDMaster/examples/KeyboardPiano/KeyboardPiano.ino
@@ -206,8 +206,10 @@ void setup() {
 
   hid.begin();
 
-  hid.connectAny();
-  // or hid.connectMouse();
+  do {
+    hid.connectAny();
+    // or hid.connectMouse();
+  } while (!hid.connected());
 }
 
 void loop() {

--- a/libraries/BluetoothHIDMaster/examples/KeyboardPianoBLE/KeyboardPianoBLE.ino
+++ b/libraries/BluetoothHIDMaster/examples/KeyboardPianoBLE/KeyboardPianoBLE.ino
@@ -206,7 +206,9 @@ void setup() {
 
   hid.begin(true);
 
-  hid.connectBLE();
+  do {
+    hid.connectBLE();
+  } while (!hid.connected());
 }
 
 void loop() {


### PR DESCRIPTION
Sometimes the BT or BLE announcement doesn't show up during an initial scan window.

Loop in the KeyboardPiano examples so that scans will be repeated until something actually links up.

Fixes #3074