### PR TITLE
BREAKING: PWMAudio availableForWrite report bytes

### DIFF
--- a/libraries/PWMAudio/src/PWMAudio.cpp
+++ b/libraries/PWMAudio/src/PWMAudio.cpp
@@ -219,7 +219,7 @@ int PWMAudio::availableForWrite() {
     if (!_running) {
         return 0;
     }
-    return _arb->available();
+    return _arb->available() * 4; // ARB reports in 32b words
 }
 
 size_t PWMAudio::write(int16_t val, bool sync) {


### PR DESCRIPTION
availableForWrite should always report bytes free, but PWMAudio was returning number of ARB words (i.e. 1/4 the actual space).