### PR TITLE
BREAKING: USB PID will vary depending on devices

### DIFF
--- a/cores/rp2040/RP2040USB.cpp
+++ b/cores/rp2040/RP2040USB.cpp
@@ -108,13 +108,13 @@ const uint8_t *tud_descriptor_device_cb(void) {
     }
     // Need a multi-endpoint config which will require changing the PID to help Windows not barf
     if (__USBInstallKeyboard) {
-        usbd_desc_device.idProduct |= 0x8000;
+        usbd_desc_device.idProduct ^= 0x8000;
     }
     if (__USBInstallMouse || __USBInstallAbsoluteMouse) {
-        usbd_desc_device.idProduct |= 0x4000;
+        usbd_desc_device.idProduct ^= 0x4000;
     }
     if (__USBInstallJoystick) {
-        usbd_desc_device.idProduct |= 0x0100;
+        usbd_desc_device.idProduct ^= 0x0100;
     }
     if (__USBInstallMassStorage) {
         usbd_desc_device.idProduct ^= 0x2000;


### PR DESCRIPTION
The USB PID was already being changed depending on the devices installed in the app.  This was needed because Windows has issues with the same VID:PID exporting different HID devices (i.e. it would not recognize changed ones properly).

Unfortunately the change was to set a bit to 1 in the PID, but if the bit was already 1 then no change would occur.

Now, actually XOR the bitmap of device exports to ensure the VID:PID of a sketch with only Serial will differ from one with Serial and Keyboard, for example.