### PR TITLE
Rewrite I2S bidirectional support

### DIFF
--- a/libraries/I2S/src/pio_i2s.pio
+++ b/libraries/I2S/src/pio_i2s.pio
@@ -238,23 +238,23 @@ right1:
 
 ;                           +----- WCLK
 ;                           |+---- BCLK
-    mov x, y         side 0b00 [1]
+    in pins, 1       side 0b01 ; Adjust for input shift
+.wrap_target
+    mov x, y         side 0b01
 left1:
-    out pins, 1      side 0b01
+    out pins, 1      side 0b00 [1]
     in pins, 1       side 0b01
-    jmp x--, left1   side 0b00 [1]
-    out pins, 1      side 0b01
-    in pins, 1       side 0b01 ; 2584 LRCK stays low until BCLK goes low
-                               ; Last bit of left has WCLK change per I2S spec
-    mov x, y         side 0b10 [1]
-right1:
-    out pins, 1      side 0b11
+    jmp x--, left1   side 0b01
+    out pins, 1      side 0b10 [1] ; Last bit of left has WCLK change per I2S spec
     in pins, 1       side 0b11
-    jmp x--, right1  side 0b10 [1]
-    out pins, 1      side 0b11
-    in pins, 1       side 0b11 ; 2584 LRCK stays high until BCLK goes low
-    ; Loop back to beginning...
-
+    mov x, y         side 0b11
+right1:
+    out pins, 1      side 0b10 [1]
+    in pins, 1       side 0b11
+    jmp x--, right1  side 0b11
+    out pins, 1      side 0b00 [1]; Last bit of right also has WCLK change
+    in pins, 1       side 0b01
+.wrap  ; Loop back to beginning...
 
 .program pio_i2s_inout_swap ; Note this is the same as _out, just "in" and not "out"
 .side_set 2   ; 0 = wclk, 1=bclk
@@ -264,22 +264,23 @@ right1:
 
 ;                           +----- BCLK
 ;                           |+---- WCLK
-    mov x, y         side 0b00 [1]
+    in pins, 1       side 0b10 ; Adjust for input shift
+.wrap_target
+    mov x, y         side 0b10
 left1:
-    out pins, 1      side 0b10
+    out pins, 1      side 0b00 [1]
     in pins, 1       side 0b10
-    jmp x--, left1   side 0b00 [1]
-    out pins, 1      side 0b10
-    in pins, 1       side 0b10 ;2584 LRCK stays low until BCLK goes low
-
-    mov x, y         side 0b01 [1]
-right1:
-    out pins, 1      side 0b11
+    jmp x--, left1   side 0b10
+    out pins, 1      side 0b01 [1] ; Last bit of left has WCLK change per I2S spec
     in pins, 1       side 0b11
-    jmp x--, right1  side 0b01 [1]
-    out pins, 1      side 0b11
-    in pins, 1       side 0b11 ; 2584 LRCK stays high until BCLK goes low
-    ; Loop back to beginning...
+    mov x, y         side 0b11
+right1:
+    out pins, 1      side 0b01 [1]
+    in pins, 1       side 0b11
+    jmp x--, right1  side 0b11
+    out pins, 1      side 0b00 [1]; Last bit of right also has WCLK change
+    in pins, 1       side 0b10
+.wrap  ; Loop back to beginning...
 
 
 

--- a/libraries/I2S/src/pio_i2s.pio.h
+++ b/libraries/I2S/src/pio_i2s.pio.h
@@ -433,31 +433,32 @@ static inline pio_sm_config pio_i2s_in_swap_program_get_default_config(uint offs
 // pio_i2s_inout //
 // ------------- //
 
-#define pio_i2s_inout_wrap_target 0
-#define pio_i2s_inout_wrap 11
+#define pio_i2s_inout_wrap_target 1
+#define pio_i2s_inout_wrap 12
 #define pio_i2s_inout_pio_version 0
 
 static const uint16_t pio_i2s_inout_program_instructions[] = {
+    0x4801, //  0: in     pins, 1         side 1
     //     .wrap_target
-    0xa122, //  0: mov    x, y            side 0 [1]
-    0x6801, //  1: out    pins, 1         side 1
-    0x4801, //  2: in     pins, 1         side 1
-    0x0141, //  3: jmp    x--, 1          side 0 [1]
-    0x6801, //  4: out    pins, 1         side 1
-    0x4801, //  5: in     pins, 1         side 1
-    0xb122, //  6: mov    x, y            side 2 [1]
-    0x7801, //  7: out    pins, 1         side 3
-    0x5801, //  8: in     pins, 1         side 3
-    0x1147, //  9: jmp    x--, 7          side 2 [1]
-    0x7801, // 10: out    pins, 1         side 3
-    0x5801, // 11: in     pins, 1         side 3
+    0xa822, //  1: mov    x, y            side 1
+    0x6101, //  2: out    pins, 1         side 0 [1]
+    0x4801, //  3: in     pins, 1         side 1
+    0x0842, //  4: jmp    x--, 2          side 1
+    0x7101, //  5: out    pins, 1         side 2 [1]
+    0x5801, //  6: in     pins, 1         side 3
+    0xb822, //  7: mov    x, y            side 3
+    0x7101, //  8: out    pins, 1         side 2 [1]
+    0x5801, //  9: in     pins, 1         side 3
+    0x1848, // 10: jmp    x--, 8          side 3
+    0x6101, // 11: out    pins, 1         side 0 [1]
+    0x4801, // 12: in     pins, 1         side 1
     //     .wrap
 };
 
 #if !PICO_NO_HARDWARE
 static const struct pio_program pio_i2s_inout_program = {
     .instructions = pio_i2s_inout_program_instructions,
-    .length = 12,
+    .length = 13,
     .origin = -1,
     .pio_version = pio_i2s_inout_pio_version,
 #if PICO_PIO_VERSION > 0
@@ -477,31 +478,32 @@ static inline pio_sm_config pio_i2s_inout_program_get_default_config(uint offset
 // pio_i2s_inout_swap //
 // ------------------ //
 
-#define pio_i2s_inout_swap_wrap_target 0
-#define pio_i2s_inout_swap_wrap 11
+#define pio_i2s_inout_swap_wrap_target 1
+#define pio_i2s_inout_swap_wrap 12
 #define pio_i2s_inout_swap_pio_version 0
 
 static const uint16_t pio_i2s_inout_swap_program_instructions[] = {
+    0x5001, //  0: in     pins, 1         side 2
     //     .wrap_target
-    0xa122, //  0: mov    x, y            side 0 [1]
-    0x7001, //  1: out    pins, 1         side 2
-    0x5001, //  2: in     pins, 1         side 2
-    0x0141, //  3: jmp    x--, 1          side 0 [1]
-    0x7001, //  4: out    pins, 1         side 2
-    0x5001, //  5: in     pins, 1         side 2
-    0xa922, //  6: mov    x, y            side 1 [1]
-    0x7801, //  7: out    pins, 1         side 3
-    0x5801, //  8: in     pins, 1         side 3
-    0x0947, //  9: jmp    x--, 7          side 1 [1]
-    0x7801, // 10: out    pins, 1         side 3
-    0x5801, // 11: in     pins, 1         side 3
+    0xb022, //  1: mov    x, y            side 2
+    0x6101, //  2: out    pins, 1         side 0 [1]
+    0x5001, //  3: in     pins, 1         side 2
+    0x1042, //  4: jmp    x--, 2          side 2
+    0x6901, //  5: out    pins, 1         side 1 [1]
+    0x5801, //  6: in     pins, 1         side 3
+    0xb822, //  7: mov    x, y            side 3
+    0x6901, //  8: out    pins, 1         side 1 [1]
+    0x5801, //  9: in     pins, 1         side 3
+    0x1848, // 10: jmp    x--, 8          side 3
+    0x6101, // 11: out    pins, 1         side 0 [1]
+    0x5001, // 12: in     pins, 1         side 2
     //     .wrap
 };
 
 #if !PICO_NO_HARDWARE
 static const struct pio_program pio_i2s_inout_swap_program = {
     .instructions = pio_i2s_inout_swap_program_instructions,
-    .length = 12,
+    .length = 13,
     .origin = -1,
     .pio_version = pio_i2s_inout_swap_pio_version,
 #if PICO_PIO_VERSION > 0


### PR DESCRIPTION
I2S bidirectional was shifting data out on the wrong clock edge, which would cause failures for setup/hold in some receivers.  Rewrite the sampling to separate writing and reading edges.

Fixes #3116