### PR TITLE
Split build-all-variants into 4 jobs

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -294,7 +294,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        chunk: [0, 1]
+        chunk: [0, 1, 2, 3]
     steps:
     - uses: actions/checkout@v4
       with:
@@ -335,7 +335,7 @@ jobs:
         cnt=0
         for b in $(cut -f1 -d. /home/runner/work/arduino-pico/arduino-pico/boards.txt | sed 's/#.*//' | sed 's/^menu$//' | sort -u); do
           cnt=$((cnt + 1))
-          rem=$((cnt % 2))
+          rem=$((cnt % 4))
           if [ $rem == ${{ matrix.chunk }} ]; then
             pio ci --board=$b -O "platform_packages=framework-arduinopico@symlink:///home/runner/work/arduino-pico/arduino-pico" libraries/rp2040/examples/Bootsel/Bootsel.ino
           fi


### PR DESCRIPTION
Each job was taking >12 minutes, 2x the other CI times.  Split into 4 jobs for now