### PR TITLE
Only start LWIP thread on FreeRTOS if needed

### DIFF
--- a/cores/rp2040/freertos/freertos-main.cpp
+++ b/cores/rp2040/freertos/freertos-main.cpp
@@ -155,8 +155,6 @@ void startFreeRTOS(void) {
     xTaskCreate(IdleThisCore, "IdleCore1", 128, 0, configMAX_PRIORITIES - 1, __idleCoreTask + 1);
     vTaskCoreAffinitySet(__idleCoreTask[1], 1 << 1);
 
-    __startLWIPThread();
-
     // Initialise and run the freeRTOS scheduler. Execution should never return here.
     __freeRTOSinitted = true;
     vTaskStartScheduler();

--- a/cores/rp2040/lwip_wrap.cpp
+++ b/cores/rp2040/lwip_wrap.cpp
@@ -32,6 +32,9 @@
 #include "_xoshiro.h"
 #include "lwip_wrap.h"
 #include <pico/btstack_run_loop_async_context.h>
+#ifdef __FREERTOS
+#include "freertos/freertos-lwip.h"
+#endif
 
 //auto_init_recursive_mutex(__lwipMutex); // Only for case with no Ethernet or PicoW, but still doing LWIP (PPP?)
 recursive_mutex_t __lwipMutex;
@@ -54,6 +57,9 @@ extern "C" {
             recursive_mutex_init(&__lwipMutex);
             _lwip_rng = new XoshiroCpp::Xoshiro256PlusPlus(micros());
             __real_lwip_init();
+#ifdef __FREERTOS
+            __startLWIPThread();
+#endif
         }
     }
 


### PR DESCRIPTION
Fixes #3120

LWIP was being unconditionally started under FreeRTOS, even if the app wasn't using any LWIP calls.  Now start the LWIP thread on the first call to lwip_init, same as we init the RNG.