### PR TITLE
Fix warning for FatFS lfn size

### DIFF
--- a/libraries/FatFS/src/FatFS.h
+++ b/libraries/FatFS/src/FatFS.h
@@ -459,7 +459,7 @@ protected:
     FatFSImpl*              _fs;
     std::shared_ptr<DIR>    _dir;
     bool                    _valid;
-    char                    _lfn[64];
+    char                    _lfn[65];
     time_t                  _time;
     time_t                  _creation;
     std::shared_ptr<char>   _dirPath;


### PR DESCRIPTION
`FILINFO.fname` has size 65 to accomodate a 64 character file name and the null byte. `_lfn` is defined with size 64 which could truncate the null byte if the file name is exactly 64 characters long.

```
In file included from framework-arduinopico\libraries\FatFS\src\FatFS.cpp:25:
framework-arduinopico\libraries\FatFS\src\FatFS.h: In member function 'virtual bool fatfs::FatFSDirImpl::next()':
framework-arduinopico\libraries\FatFS\src\FatFS.h:443:24: warning: 'char* strncpy(char*, const char*, size_t)' output may be truncated copying 64 bytes from a string 
of length 64 [-Wstringop-truncation]
  443 |                 strncpy(_lfn, fno.fname, sizeof(_lfn));
      |                 ~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```