### PR TITLE
Clean up some add'l warnings noted

### DIFF
--- a/cores/rp2040/RP2040Support.h
+++ b/cores/rp2040/RP2040Support.h
@@ -175,7 +175,7 @@ private:
 
 class RP2040;
 extern RP2040 rp2040;
-extern "C" void main1();
+extern void main1();
 extern "C" char __StackLimit;
 extern "C" char __bss_end__;
 extern "C" void setup1() __attribute__((weak));

--- a/cores/rp2040/Tone.cpp
+++ b/cores/rp2040/Tone.cpp
@@ -45,7 +45,7 @@ static inline bool pio_sm_get_enabled(PIO pio, uint sm) {
     return (pio->ctrl & ~(1u << sm)) & (1 << sm);
 }
 
-int64_t _stopTonePIO(alarm_id_t id, void *user_data) {
+static int64_t _stopTonePIO(alarm_id_t id, void *user_data) {
     (void) id;
     Tone *tone = (Tone *)user_data;
     tone->alarm = 0;

--- a/cores/rp2040/WMath.cpp
+++ b/cores/rp2040/WMath.cpp
@@ -18,6 +18,7 @@
 
 #include <stdlib.h>
 #include <stdint.h>
+#include <Arduino.h>
 
 void randomSeed(uint32_t dwSeed) {
     if (dwSeed != 0) {

--- a/cores/rp2040/delay.cpp
+++ b/cores/rp2040/delay.cpp
@@ -18,6 +18,7 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
+#include <Arduino.h>
 #include <pico.h>
 #include <pico/time.h>
 

--- a/cores/rp2040/lwip_wrap.cpp
+++ b/cores/rp2040/lwip_wrap.cpp
@@ -845,6 +845,7 @@ extern "C" {
             return;
         }
 #endif
+        (void) buffer;
         cb(cbData);
         return;
     }

--- a/cores/rp2040/main.cpp
+++ b/cores/rp2040/main.cpp
@@ -18,7 +18,7 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-#include <Arduino.h>
+#include "Arduino.h"
 #include "RP2040USB.h"
 #include <pico/stdlib.h>
 #include <pico/multicore.h>
@@ -55,7 +55,7 @@ bool core1_separate_stack __attribute__((weak)) = false;
 bool core1_disable_systick __attribute__((weak)) = false;
 extern void setup1() __attribute__((weak));
 extern void loop1() __attribute__((weak));
-extern "C" void main1() {
+void __attribute__((__noreturn__)) main1() {
     if (!core1_disable_systick) {
         // Don't install the SYSTICK exception handler. rp2040.getCycleCount will not work properly on core1
         rp2040.begin(1);

--- a/cores/rp2040/wiring_private.cpp
+++ b/cores/rp2040/wiring_private.cpp
@@ -82,7 +82,7 @@ void *_gpioIrqCBParam[__GPIOCNT];
 
 // Only 1 GPIO IRQ callback for all pins, so we need to look at the pin it's for and
 // dispatch to the real callback manually
-void _gpioInterruptDispatcher(uint gpio, uint32_t events) {
+static void _gpioInterruptDispatcher(uint gpio, uint32_t events) {
     (void) events;
     uint64_t mask = 1LL << gpio;
     if (_gpioIrqEnabled & mask) {

--- a/libraries/LittleFS/src/LittleFS.h
+++ b/libraries/LittleFS/src/LittleFS.h
@@ -146,7 +146,7 @@ public:
         if ((rc == 0) && _timeCallback) {
             time_t now = _timeCallback();
             // Add metadata with creation time to the directory marker
-            int rc = lfs_setattr(&_lfs, path, 'c', (const void *)&now, sizeof(now));
+            rc = lfs_setattr(&_lfs, path, 'c', (const void *)&now, sizeof(now));
             if (rc < 0) {
                 DEBUGV("Unable to set creation time on '%s' to %ld\n", path, (long)now);
             }

--- a/libraries/SingleFileDrive/src/SingleFileDrive.cpp
+++ b/libraries/SingleFileDrive/src/SingleFileDrive.cpp
@@ -20,6 +20,7 @@
 #include <SingleFileDrive.h>
 #include <LittleFS.h>
 #include <class/msc/msc.h>
+#include <class/msc/msc_device.h>
 #include <device/usbd.h>
 #include <RP2040USB.h>
 


### PR DESCRIPTION
See https://github.com/earlephilhower/arduino-pico/issues/3134.  Only difference is correct error handling in one LittleFS function call when making a file passes but setting the time attribute somehow fails.