### PR TITLE
Bitmask for IRQ stack, save ~112B RAM

### DIFF
--- a/cores/rp2040/wiring_private.cpp
+++ b/cores/rp2040/wiring_private.cpp
@@ -30,7 +30,12 @@
 #define maxIRQs 15
 #endif
 static uint32_t _irqStackTop[2] = { 0, 0 };
+#ifdef __riscv
 static uint32_t _irqStack[2][maxIRQs];
+#else
+// ARM there's only 1 bit valid, so we'll just shift it in and out...
+static uint32_t _irqStack[2];
+#endif
 
 #ifdef __FREERTOS
 static UBaseType_t __savedIrqs[configNUMBER_OF_CORES];
@@ -52,7 +57,13 @@ extern "C" void interrupts() {
         // ERROR
         return;
     }
+#ifdef __riscv
     restore_interrupts(_irqStack[core][--_irqStackTop[core]]);
+#else
+    uint32_t mask = _irqStack[core] & 1;
+    _irqStack[core] >>= 1;
+    restore_interrupts(mask);
+#endif
 }
 
 extern "C" void noInterrupts() {
@@ -71,7 +82,13 @@ extern "C" void noInterrupts() {
         // ERROR
         panic("IRQ stack overflow");
     }
+#ifdef __riscv
     _irqStack[core][_irqStackTop[core]++] = save_and_disable_interrupts();
+#else
+    _irqStack[core] <<= 1;
+    _irqStack[core] |= save_and_disable_interrupts() ? 1 : 0;
+    _irqStackTop[core]++;
+#endif
 }
 
 auto_init_mutex(_irqMutex);


### PR DESCRIPTION
The ARM PRIMASK register only has 1 bit defined, so just save that bit and not the whole 32b returned by save_and_disable_irq().

Reduces memory usage by 120 bytes for all apps.