### PR TITLE
Fix SERIAL_HOWMANY for Waveshare boards

### DIFF
--- a/variants/waveshare_rp2040_matrix/pins_arduino.h
+++ b/variants/waveshare_rp2040_matrix/pins_arduino.h
@@ -34,7 +34,7 @@
 #define PIN_WIRE1_SDA  (26u)
 #define PIN_WIRE1_SCL  (27u)
 
-#define SERIAL_HOWMANY (2u)
+#define SERIAL_HOWMANY (3u)
 #define SPI_HOWMANY    (2u)
 #define WIRE_HOWMANY   (2u)
 

--- a/variants/waveshare_rp2040_one/pins_arduino.h
+++ b/variants/waveshare_rp2040_one/pins_arduino.h
@@ -58,7 +58,7 @@
 #define PIN_WIRE1_SDA  (26u)
 #define PIN_WIRE1_SCL  (27u)
 
-#define SERIAL_HOWMANY (2u)
+#define SERIAL_HOWMANY (3u)
 #define SPI_HOWMANY    (2u)
 #define WIRE_HOWMANY   (2u)
 

--- a/variants/waveshare_rp2040_pizero/pins_arduino.h
+++ b/variants/waveshare_rp2040_pizero/pins_arduino.h
@@ -29,7 +29,7 @@
 #define PIN_WIRE1_SDA  (26u)
 #define PIN_WIRE1_SCL  (27u)
 
-#define SERIAL_HOWMANY (2u)
+#define SERIAL_HOWMANY (3u)
 #define SPI_HOWMANY    (2u)
 #define WIRE_HOWMANY   (2u)
 

--- a/variants/waveshare_rp2040_zero/pins_arduino.h
+++ b/variants/waveshare_rp2040_zero/pins_arduino.h
@@ -59,7 +59,7 @@
 #define PIN_WIRE1_SDA  (26u)
 #define PIN_WIRE1_SCL  (27u)
 
-#define SERIAL_HOWMANY (2u)
+#define SERIAL_HOWMANY (3u)
 #define SPI_HOWMANY    (2u)
 #define WIRE_HOWMANY   (2u)
 

--- a/variants/waveshare_rp2350_zero/pins_arduino.h
+++ b/variants/waveshare_rp2350_zero/pins_arduino.h
@@ -58,7 +58,7 @@
 #define PIN_WIRE1_SDA (26u)
 #define PIN_WIRE1_SCL (27u)
 
-#define SERIAL_HOWMANY (2u)
+#define SERIAL_HOWMANY (3u)
 #define SPI_HOWMANY (2u)
 #define WIRE_HOWMANY (2u)
 


### PR DESCRIPTION
Corrected `SERIAL_HOWMANY` to 3 in `pins_arduino.h` for Waveshare RP2040 and RP2350 boards:

- waveshare_rp2040_matrix
- waveshare_rp2040_one
- waveshare_rp2040_pizero
- waveshare_rp2040_zero
- waveshare_rp2350_zero

Earlier, I added RP2350 boards and reused `pins_arduino.h` from RP2040 variants since they are the same, but in my last PR #3110 I realized the USB serial is also counted, so the value needed correction.