### PR TITLE
Use doorbell on RP2350 to freeze the cores

### DIFF
--- a/cores/rp2040/RP2040Support.cpp
+++ b/cores/rp2040/RP2040Support.cpp
@@ -35,7 +35,10 @@ void RP2040::enableDoubleResetBootloader() {
         boot_double_tap_check();
     }
 }
+#endif
 
+#ifdef PICO_RP2350
+uint8_t _MFIFO::_doorbell = 0;
 #endif
 
 #ifdef __PROFILE

--- a/docs/multicore.rst
+++ b/docs/multicore.rst
@@ -99,6 +99,11 @@ use the following functions to access a software-managed, multicore safe
 FIFO.  There are two FIFOs, one written to by core 0 and read by core 1, and
 the other written to by core 1 and read by core 0.
 
+On the RP2350, the hardware FIFO is available for use using the SDK APIs
+or the calls below (which just wrap the SDK APIs very lightly).  This is
+because the idle/resume calls above are implemented using a hardware doorbell
+on the RP2350, not the hardware FIFO.
+
 You can (and probably should) use shared memory (such as ``volatile`` globals)
 or other normal multiprocessor communication algorithms to transfer data or
 work between cores, but for simple tasks these FIFO routines can suffice.


### PR DESCRIPTION
Free up the hardware FIFO by using the new hardware doorbell registers present on the RP2350.