### PR TITLE
Overhaul SimpleMDNS handling of WiFi::begin/end

### DIFF
--- a/libraries/SimpleMDNS/src/SimpleMDNS.h
+++ b/libraries/SimpleMDNS/src/SimpleMDNS.h
@@ -24,6 +24,7 @@
 #include <string>
 #include <map>
 #include <vector>
+#include <lwip/apps/mdns.h>
 
 typedef void* hMDNSTxt; // Unusable in SimpleMDNS, for signature compatibility only
 
@@ -32,6 +33,13 @@ public:
     SimpleMDNSService();
     static void callback(struct mdns_service *service, void *txt_userdata);
     hMDNSTxt add(const char *key, const char *val);
+
+    const char *_service;
+    uint16_t _proto;
+    uint16_t _port;
+    service_get_txt_fn_t _fn;
+    void *_userdata;
+
 private:
     std::vector<const char *> txt;
 };
@@ -60,8 +68,9 @@ public:
     hMDNSTxt addServiceTxt(const hMDNSService p_hService, const char* p_pcKey, int16_t p_i16Value);
     hMDNSTxt addServiceTxt(const hMDNSService p_hService, const char* p_pcKey, int8_t p_i8Value);
 
-    // No-ops here
     void end();
+
+    // No-ops here
     void update();
 
 private:
@@ -70,9 +79,16 @@ private:
     static void _arduinoGetTxt(struct mdns_service *service, void *txt_userdata);
 
     bool _running = false;
+    bool _lwipMSNDInitted = false;
     static const char *_hostname;
     std::map<std::string, SimpleMDNSService*> _svcMap;
     bool _arduinoAdded = false;
+
+    // LwipIntfDev helpers when netifs come up and down, to ensure we set the old services on the new netif
+    static void _addNetifCB(struct netif *n);
+    static void _removeNetifCB(struct netif *n);
+    void removeNetif(struct netif *n);
+    void addNetif(struct netif *n);
 };
 
 extern SimpleMDNS MDNS;

--- a/libraries/lwIP_Ethernet/src/LwipEthernet.cpp
+++ b/libraries/lwIP_Ethernet/src/LwipEthernet.cpp
@@ -293,3 +293,13 @@ std::function<void(struct netif *)>  _scb;
 void __setStateChangeCallback(std::function<void(struct netif *)> s) {
     _scb = s;
 }
+
+std::function<void(struct netif *)> _addNetifCB;
+void __setAddNetifCallback(std::function<void(struct netif *)> s) {
+    _addNetifCB = s;
+}
+
+std::function<void(struct netif *)> _removeNetifCB;
+void __setRemoveNetifCallback(std::function<void(struct netif *)> s) {
+    _removeNetifCB = s;
+}

--- a/libraries/lwIP_Ethernet/src/LwipEthernet.h
+++ b/libraries/lwIP_Ethernet/src/LwipEthernet.h
@@ -47,3 +47,7 @@ void lwipPollingPeriod(int ms);
 
 // Sets the global netif state change callback
 void __setStateChangeCallback(std::function<void(struct netif *)> s);
+
+// Set callback when a netif is added after bring-up, removed before netif_remove
+void __setAddNetifCallback(std::function<void(struct netif *)> s);
+void __setRemoveNetifCallback(std::function<void(struct netif *)> s);


### PR DESCRIPTION
Fixes #3157

LWIP MDNS was not being removed from a netif when a device ::end was called, resulting in a crash on reconnect when MDNS or things like ArduinoOTA (which uses SimpleMDNS) were used.

They would not crash, however, if the initial WiFi::begin failed, because LWIP MDNS does not automatically add existing services to a "new" netif (i.e. there was no MDNS on the 2nd and following WiFi.begin() calls).

To fix the crash due to null-derefernce, add a way for SimpleMDNS to remove MSND from a netif before it is netif_removed.

To fix the lack of MDNS services after a WiFi reconnect, keep track of the services we've already added and add a call to hook into LwipIntfDev after a new netif has been brought up (link-state at least, if not DHCP).