### PR TITLE
Fix minor CodeQL issues which look real

### DIFF
--- a/libraries/LittleFS/src/LittleFS.h
+++ b/libraries/LittleFS/src/LittleFS.h
@@ -389,7 +389,7 @@ public:
     }
 
     int read(uint8_t* buf, size_t size) override {
-        if (!_opened || !_fd | !buf) {
+        if (!_opened || !_fd || !buf) {
             return 0;
         }
         int result = lfs_file_read(_fs->getFS(), _getFD(), (void*) buf, size);

--- a/libraries/SD/src/SD.h
+++ b/libraries/SD/src/SD.h
@@ -187,15 +187,15 @@ private:
         }
         const bool append = (mode & O_APPEND) > 0;
 
-        if (read & !write)           {
+        if (read && !write)           {
             return "r";
-        } else if (!read &  write & !append) {
+        } else if (!read && write && !append) {
             return "w+";
-        } else if (!read &  write &  append) {
+        } else if (!read &&  write &&  append) {
             return "a";
-        } else if (read &  write & !append) {
+        } else if (read &&  write && !append) {
             return "w+";    // may be a bug in FS::mode interpretation, "r+" seems proper
-        } else if (read &  write &  append) {
+        } else if (read &&  write &&  append) {
             return "a+";
         } else                                 {
             return "r";

--- a/tools/platformio-build.py
+++ b/tools/platformio-build.py
@@ -198,7 +198,7 @@ env.Append(
         "-Wl,--undefined=__pre_init_runtime_init_mutex",
         "-Wl,--undefined=__pre_init_runtime_init_default_alarm_pool",
         "-Wl,--undefined=__pre_init_first_per_core_initializer",
-        "-Wl,--undefined=__pre_init_runtime_init_per_core_bootrom_reset"
+        "-Wl,--undefined=__pre_init_runtime_init_per_core_bootrom_reset",
         "-Wl,--undefined=__pre_init_runtime_init_per_core_h3_irq_registers",
         "-Wl,--undefined=__pre_init_runtime_init_per_core_irq_priorities"
     ] + toolopts,

--- a/tools/uf2conv.py
+++ b/tools/uf2conv.py
@@ -253,7 +253,7 @@ def get_drives():
             try:
                 nul = open("nul:", "r")
                 r = subprocess.check_output(["powershell", "-NonInteractive", "-Command",
-                                            "Get-WmiObject -class Win32_LogicalDisk | "
+                                            "Get-WmiObject -class Win32_LogicalDisk | " +
                                             "Format-Table -Property DeviceID, DriveType, Filesystem, VolumeName"],
                                             stdin = nul)
                 nul.close()


### PR DESCRIPTION
CodeQL throws lots of wrong warnings, but did identify a few spots where binary &/| was used in place of boolean &&/|| and some minor Python script issues.