### PR TITLE
Use localtime_r for multicore safety

### DIFF
--- a/libraries/FatFS/src/FatFS.cpp
+++ b/libraries/FatFS/src/FatFS.cpp
@@ -294,17 +294,18 @@ DWORD get_fattime() {
     } else {
         now = time(nullptr);
     }
-    struct tm *stm = localtime(&now);
-    if (stm->tm_year < 80) {
+    struct tm stm;
+    localtime_r(&now, &stm);
+    if (stm.tm_year < 80) {
         // FAT can't report years before 1980
-        stm->tm_year = 80;
+        stm.tm_year = 80;
     }
-    return (DWORD)(stm->tm_year - 80) << 25 |
-           (DWORD)(stm->tm_mon + 1) << 21 |
-           (DWORD)stm->tm_mday << 16 |
-           (DWORD)stm->tm_hour << 11 |
-           (DWORD)stm->tm_min << 5 |
-           (DWORD)stm->tm_sec >> 1;
+    return (DWORD)(stm.tm_year - 80) << 25 |
+           (DWORD)(stm.tm_mon + 1) << 21 |
+           (DWORD)stm.tm_mday << 16 |
+           (DWORD)stm.tm_hour << 11 |
+           (DWORD)stm.tm_min << 5 |
+           (DWORD)stm.tm_sec >> 1;
 }
 
 }

--- a/libraries/FatFSUSB/examples/Listfiles-USB/Listfiles-USB.ino
+++ b/libraries/FatFSUSB/examples/Listfiles-USB/Listfiles-USB.ino
@@ -90,8 +90,9 @@ void printDirectory(String dirName, int numTabs) {
       Serial.print("\t\t");
       Serial.print(dir.fileSize(), DEC);
       time_t cr = dir.fileCreationTime();
-      struct tm* tmstruct = localtime(&cr);
-      Serial.printf("\t%d-%02d-%02d %02d:%02d:%02d\n", (tmstruct->tm_year) + 1900, (tmstruct->tm_mon) + 1, tmstruct->tm_mday, tmstruct->tm_hour, tmstruct->tm_min, tmstruct->tm_sec);
+      struct tm tmstruct;
+      localtime_r(&cr, &tmstruct);
+      Serial.printf("\t%d-%02d-%02d %02d:%02d:%02d\n", (tmstruct.tm_year) + 1900, (tmstruct.tm_mon) + 1, tmstruct.tm_mday, tmstruct.tm_hour, tmstruct.tm_min, tmstruct.tm_sec);
     }
   }
 }

--- a/libraries/SD/examples/CardInfo/CardInfo.ino
+++ b/libraries/SD/examples/CardInfo/CardInfo.ino
@@ -180,10 +180,11 @@ void printDirectory(File dir, int numTabs) {
       Serial.print(entry.size(), DEC);
       time_t cr = entry.getCreationTime();
       time_t lw = entry.getLastWrite();
-      struct tm* tmstruct = localtime(&cr);
-      Serial.printf("\tCREATION: %d-%02d-%02d %02d:%02d:%02d", (tmstruct->tm_year) + 1900, (tmstruct->tm_mon) + 1, tmstruct->tm_mday, tmstruct->tm_hour, tmstruct->tm_min, tmstruct->tm_sec);
-      tmstruct = localtime(&lw);
-      Serial.printf("\tLAST WRITE: %d-%02d-%02d %02d:%02d:%02d\n", (tmstruct->tm_year) + 1900, (tmstruct->tm_mon) + 1, tmstruct->tm_mday, tmstruct->tm_hour, tmstruct->tm_min, tmstruct->tm_sec);
+      struct tm tmstruct;
+      localtime_r(&cr, &tmstruct);
+      Serial.printf("\tCREATION: %d-%02d-%02d %02d:%02d:%02d", (tmstruct.tm_year) + 1900, (tmstruct.tm_mon) + 1, tmstruct.tm_mday, tmstruct.tm_hour, tmstruct.tm_min, tmstruct.tm_sec);
+      localtime_r(&lw, &tmstruct);
+      Serial.printf("\tLAST WRITE: %d-%02d-%02d %02d:%02d:%02d\n", (tmstruct.tm_year) + 1900, (tmstruct.tm_mon) + 1, tmstruct.tm_mday, tmstruct.tm_hour, tmstruct.tm_min, tmstruct.tm_sec);
     }
     entry.close();
   }

--- a/libraries/SD/examples/listfiles/listfiles.ino
+++ b/libraries/SD/examples/listfiles/listfiles.ino
@@ -123,10 +123,11 @@ void printDirectory(File dir, int numTabs) {
       Serial.print(entry.size(), DEC);
       time_t cr = entry.getCreationTime();
       time_t lw = entry.getLastWrite();
-      struct tm* tmstruct = localtime(&cr);
-      Serial.printf("\tCREATION: %d-%02d-%02d %02d:%02d:%02d", (tmstruct->tm_year) + 1900, (tmstruct->tm_mon) + 1, tmstruct->tm_mday, tmstruct->tm_hour, tmstruct->tm_min, tmstruct->tm_sec);
-      tmstruct = localtime(&lw);
-      Serial.printf("\tLAST WRITE: %d-%02d-%02d %02d:%02d:%02d\n", (tmstruct->tm_year) + 1900, (tmstruct->tm_mon) + 1, tmstruct->tm_mday, tmstruct->tm_hour, tmstruct->tm_min, tmstruct->tm_sec);
+      struct tm tmstruct;
+      localtime_r(&cr, &tmstruct);
+      Serial.printf("\tCREATION: %d-%02d-%02d %02d:%02d:%02d", (tmstruct.tm_year) + 1900, (tmstruct.tm_mon) + 1, tmstruct.tm_mday, tmstruct.tm_hour, tmstruct.tm_min, tmstruct.tm_sec);
+      localtime_r(&lw, &tmstruct);
+      Serial.printf("\tLAST WRITE: %d-%02d-%02d %02d:%02d:%02d\n", (tmstruct.tm_year) + 1900, (tmstruct.tm_mon) + 1, tmstruct.tm_mday, tmstruct.tm_hour, tmstruct.tm_min, tmstruct.tm_sec);
     }
     entry.close();
   }

--- a/libraries/SDFS/src/SDFS.h
+++ b/libraries/SDFS/src/SDFS.h
@@ -242,9 +242,10 @@ public:
         } else {
             now = time(nullptr);
         }
-        struct tm *tiempo = localtime(&now);
-        *dosYear = ((tiempo->tm_year - 80) << 9) | ((tiempo->tm_mon + 1) << 5) | tiempo->tm_mday;
-        *dosTime = (tiempo->tm_hour << 11) | (tiempo->tm_min << 5) | tiempo->tm_sec;
+        struct tm tiempo;
+        localtime_r(&now, &tiempo);
+        *dosYear = ((tiempo.tm_year - 80) << 9) | ((tiempo.tm_mon + 1) << 5) | tiempo.tm_mday;
+        *dosTime = (tiempo.tm_hour << 11) | (tiempo.tm_min << 5) | tiempo.tm_sec;
     }
 
 protected:

--- a/libraries/rp2040/examples/Time/Time.ino
+++ b/libraries/rp2040/examples/Time/Time.ino
@@ -21,7 +21,9 @@ void loop() {
   char buff[80];
 
   time(&now);
-  strftime(buff, sizeof(buff), "%c", localtime(&now));
+  struct tm tmstruct;
+  localtime_r(&now, &tmstruct);
+  strftime(buff, sizeof(buff), "%c", &tmstruct);
   Serial.println(buff);
   delay(1000);
 }


### PR DESCRIPTION
The libraries should use multicore safe localtime_r, and update the examples to use it too, since we have 2 cores which could possibly call the unsafe one at the same time.