### PR TITLE
Move Macx86 to MacOS 15

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -205,7 +205,7 @@ jobs:
     name: Mac
     strategy:
       matrix:
-        os: [macOS-13, macOS-14]
+        os: [macOS-15-intel, macOS-14]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
GH is retiring MacOS 13 CI. recommends moving to macos-15-intel