### PR TITLE
FreeRTOS LWIP CYW43 wrappers only on CYW43 boards

### DIFF
--- a/cores/rp2040/freertos/freertos-lwip.cpp
+++ b/cores/rp2040/freertos/freertos-lwip.cpp
@@ -384,6 +384,7 @@ static void lwipThread(void *params) {
                 *(r->ret) = __real_ethernet_input(r->p, r->netif);
                 break;
             }
+#if defined(PICO_CYW43_SUPPORTED)
             case __cyw43_wifi_join: {
                 __cyw43_wifi_join_req *r = (__cyw43_wifi_join_req *)w.req;
                 *(r->ret) = __real_cyw43_wifi_join(r->self, r->ssid_len, r->ssid, r->key_len, r->key, r->auth_type, r->bssid, r->channel);
@@ -394,6 +395,7 @@ static void lwipThread(void *params) {
                 *(r->ret) = __real_cyw43_wifi_leave(r->self, r->itf);
                 break;
             }
+#endif
             case __callback: {
                 __callback_req *r = (__callback_req *)w.req;
                 r->cb(r->cbData);

--- a/cores/rp2040/lwip_wrap.cpp
+++ b/cores/rp2040/lwip_wrap.cpp
@@ -832,6 +832,7 @@ extern "C" {
         return __real_ethernet_input(p, netif);
     }
 
+#if defined(PICO_CYW43_SUPPORTED)
     int __real_cyw43_wifi_join(cyw43_t *self, size_t ssid_len, const uint8_t *ssid, size_t key_len, const uint8_t *key, uint32_t auth_type, const uint8_t *bssid, uint32_t channel);
     int __wrap_cyw43_wifi_join(cyw43_t *self, size_t ssid_len, const uint8_t *ssid, size_t key_len, const uint8_t *key, uint32_t auth_type, const uint8_t *bssid, uint32_t channel) {
 #ifdef __FREERTOS
@@ -857,7 +858,7 @@ extern "C" {
 #endif
         return __real_cyw43_wifi_leave(self, itf);
     }
-
+#endif
 
 
     void lwip_callback(void (*cb)(void *), void *cbData, __callback_req *buffer) {

--- a/cores/rp2040/lwip_wrap.h
+++ b/cores/rp2040/lwip_wrap.h
@@ -48,15 +48,6 @@ extern recursive_mutex_t __lwipMutex;
 class LWIPMutex {
 public:
     LWIPMutex() {
-        //        if (ethernet_arch_lwip_gpio_mask)  {
-        //            ethernet_arch_lwip_gpio_mask();
-        //        }
-        //#if defined(ARDUINO_RASPBERRY_PI_PICO_W)
-        //        if (rp2040.isPicoW()) {
-        //            cyw43_arch_lwip_begin();
-        //            return;
-        //        }
-        //#endif
 #if !defined(__FREERTOS)
         if (ethernet_arch_lwip_begin) {
             ethernet_arch_lwip_begin();
@@ -67,24 +58,11 @@ public:
     }
 
     ~LWIPMutex() {
-#if !defined(__FREERTOS)
-        //#if defined(ARDUINO_RASPBERRY_PI_PICO_W)
-        //        if (rp2040.isPicoW()) {
-        //            cyw43_arch_lwip_end();
-        //        } else {
-        //#endif
         if (ethernet_arch_lwip_end) {
             ethernet_arch_lwip_end();
         } else {
             recursive_mutex_exit(&__lwipMutex);
         }
-        //#if defined(ARDUINO_RASPBERRY_PI_PICO_W)
-        //        }
-        //#endif
-#endif
-        //        if (ethernet_arch_lwip_gpio_unmask) {
-        //            ethernet_arch_lwip_gpio_unmask();
-        //        }
     }
 };
 
@@ -167,8 +145,10 @@ typedef enum {
 
     __ethernet_input = 9000,
 
+#if defined(PICO_CYW43_SUPPORTED)
     __cyw43_wifi_join = 9500,
     __cyw43_wifi_leave,
+#endif
 
     __callback = 10000,
 } __lwip_op;
@@ -573,6 +553,7 @@ typedef struct {
     err_t *ret;
 } __ethernet_input_req;
 
+#if defined(PICO_CYW43_SUPPORTED)
 typedef struct {
     cyw43_t *self;
     size_t ssid_len;
@@ -590,6 +571,7 @@ typedef struct {
     int itf;
     int *ret;
 } __cyw43_wifi_leave_req;
+#endif
 
 // Run a callback in the LWIP thread (i.e. for Ethernet device polling and packet reception)
 // When in an interrupt, need to pass in a heap-allocated buffer


### PR DESCRIPTION
Fixes #3180

The FreeRTOS lwip thread needs to not have any calls to the CYW43 functions w/o having an actual CYW43 onboard.  Ifdef them out as needed.