### PR TITLE
Fix overzealous stripping of comments in #3181

### DIFF
--- a/cores/rp2040/lwip_wrap.h
+++ b/cores/rp2040/lwip_wrap.h
@@ -58,11 +58,13 @@ public:
     }
 
     ~LWIPMutex() {
+#if !defined(__FREERTOS)
         if (ethernet_arch_lwip_end) {
             ethernet_arch_lwip_end();
         } else {
             recursive_mutex_exit(&__lwipMutex);
         }
+#endif
     }
 };
 


### PR DESCRIPTION
Lost an ifndef(FREERTOS) in the lwip mutex