### PR TITLE
Properly clean up on SimpleMDNS::end

### DIFF
--- a/libraries/SimpleMDNS/src/SimpleMDNS.cpp
+++ b/libraries/SimpleMDNS/src/SimpleMDNS.cpp
@@ -83,7 +83,7 @@ void SimpleMDNS::enableArduino(unsigned int port, bool passwd) {
         return;
     }
     SimpleMDNSService *svc = new SimpleMDNSService();
-    svc->_service = "arduino";
+    svc->_service = strdup("arduino");
     svc->_proto = DNSSD_PROTO_TCP;
     svc->_port = port;
     svc->_fn = _arduinoGetTxt;
@@ -140,7 +140,13 @@ void SimpleMDNS::end() {
         __setStateChangeCallback(nullptr);
         __setAddNetifCallback(nullptr);
         __setRemoveNetifCallback(nullptr);
-
+        for (auto svc : _svcMap) {
+            free(svc.second->_service);
+            delete svc.second;
+        }
+        _svcMap.clear();
+        free(_hostname);
+        _arduinoAdded = false;
     }
     _running = false;
 }
@@ -218,7 +224,5 @@ hMDNSTxt SimpleMDNS::addServiceTxt(const hMDNSService p_hService, const char* p_
     return addServiceTxt(p_hService, p_pcKey, (int32_t)p_i8Value);
 }
 
-
-const char *SimpleMDNS::_hostname = nullptr;
 
 SimpleMDNS MDNS;

--- a/libraries/SimpleMDNS/src/SimpleMDNS.h
+++ b/libraries/SimpleMDNS/src/SimpleMDNS.h
@@ -34,7 +34,7 @@ public:
     static void callback(struct mdns_service *service, void *txt_userdata);
     hMDNSTxt add(const char *key, const char *val);
 
-    const char *_service;
+    char *_service;
     uint16_t _proto;
     uint16_t _port;
     service_get_txt_fn_t _fn;
@@ -80,8 +80,8 @@ private:
 
     bool _running = false;
     bool _lwipMSNDInitted = false;
-    static const char *_hostname;
-    std::map<std::string, SimpleMDNSService*> _svcMap;
+    char *_hostname;
+    std::map<const char *, SimpleMDNSService*> _svcMap;
     bool _arduinoAdded = false;
 
     // LwipIntfDev helpers when netifs come up and down, to ensure we set the old services on the new netif


### PR DESCRIPTION
Cleans up a couple memory leaks on a (rare/never seen?) SimpleMDNS::end() and avoid pulling in std::string.