### PR TITLE
Fix wrong cyw43 pin array for Soldered Electronics NULA RP2350 board

### DIFF
--- a/variants/soldered_nula_rp2350/init.cpp
+++ b/variants/soldered_nula_rp2350/init.cpp
@@ -22,7 +22,7 @@
 #include "pico/cyw43_driver.h"
 
 extern "C" void initVariant() {
-    static uint cyw43_pin_array[CYW43_PIN_INDEX_WL_COUNT] = {24, 38, 38, 38, 37, 36};
+    static uint cyw43_pin_array[CYW43_PIN_INDEX_WL_COUNT] = {23, 24, 24, 24, 29, 25};
     cyw43_set_pins_wl(cyw43_pin_array);
     init_cyw43_wifi();
 }


### PR DESCRIPTION
When creating the board variant for the Soldered Electronics NULA RP2350 board, the incorrect cyw43 pin array for the RF module was defined by mistake. My apologies.