### PR TITLE
Fix USB descriptors for multiple interface devices

### DIFF
--- a/cores/rp2040/SerialUSB.h
+++ b/cores/rp2040/SerialUSB.h
@@ -57,11 +57,16 @@ public:
     void tud_cdc_line_state_cb(uint8_t itf, bool dtr, bool rts);
     void tud_cdc_line_coding_cb(uint8_t itf, void const *p_line_coding); // Can't use cdc_line_coding_t const* p_line_coding, TinyUSB and BTStack conflict when we include tusb.h + BTStack.h
 
+    // USB interface descriptor CB
+    void interfaceCB(int itf, uint8_t *dst, int len);
+
 private:
     bool _running = false;
     uint8_t _id;
     uint8_t _epIn;
     uint8_t _epOut;
+    uint8_t _epIn2;
+    uint8_t _strID;
 
     typedef struct {
         unsigned int rebooting : 1;
@@ -73,6 +78,10 @@ private:
     SyntheticState _ss = { 0, 0, 0, 0, 115200};
 
     void checkSerialReset();
+
+    static void _cb(int itf, uint8_t *dst, int len, void *param) {
+        ((SerialUSB *)param)->interfaceCB(itf, dst, len);
+    }
 };
 
 extern SerialUSB Serial;

--- a/libraries/FatFSUSB/src/FatFSUSB.cpp
+++ b/libraries/FatFSUSB/src/FatFSUSB.cpp
@@ -63,7 +63,7 @@ bool FatFSUSBClass::begin() {
     _epIn = USB.registerEndpointIn();
     _epOut = USB.registerEndpointOut();
     static uint8_t msd_desc[] = { TUD_MSC_DESCRIPTOR(1 /* placeholder */, 0, _epOut, _epIn, USBD_MSC_EPSIZE) };
-    _id = USB.registerInterface(2, msd_desc, sizeof(msd_desc), 2, 0);
+    _id = USB.registerInterface(1, USBClass::simpleInterface, msd_desc, sizeof(msd_desc), 2, 0);
     USB.connect();
 
     _started = true;

--- a/libraries/SingleFileDrive/src/SingleFileDrive.cpp
+++ b/libraries/SingleFileDrive/src/SingleFileDrive.cpp
@@ -61,7 +61,7 @@ bool SingleFileDrive::begin(const char *localFile, const char *dosFile) {
     _epIn = USB.registerEndpointIn();
     _epOut = USB.registerEndpointOut();
     static uint8_t msd_desc[] = { TUD_MSC_DESCRIPTOR(1 /* placeholder */, 0, _epOut, _epIn, USBD_MSC_EPSIZE) };
-    _id = USB.registerInterface(2, msd_desc, sizeof(msd_desc), 2, 0);
+    _id = USB.registerInterface(1, USBClass::simpleInterface, msd_desc, sizeof(msd_desc), 2, 0);
     USB.connect();
     _localFile = strdup(localFile);
     _dosFile = strdup(dosFile);


### PR DESCRIPTION
For simple 1-interface devices, there is a fixed position in the USB interface descriptor where the interface lives and we can hardcode an updater in the USB handler.  However, for devices like CDC(Serial) or MIDI there are multiple interfaces and the interface IDs need to be stuffed inside the actual descriptor at different locations.

To allow this, instead of just taking a fixed set of bytes and blindly patching in USB, make all interfaces do their own memcpy from a local version, updated with the new dynamic interface id, via a callback.

Add a simple USBClass callback to handle the normal 1-interface case without add'l code.

Fix MSD (SingleFileDrive, FatFSUSB) to only request the correct, single interface used.