### PR TITLE
Don't reset pulse width on servo detach

### DIFF
--- a/libraries/Servo/src/Servo.cpp
+++ b/libraries/Servo/src/Servo.cpp
@@ -117,7 +117,6 @@ void Servo::detach() {
         pio_sm_set_enabled(_pio, _smIdx, false);
         pio_sm_unclaim(_pio, _smIdx);
         _attached = false;
-        _valueUs = DEFAULT_NEUTRAL_PULSE_WIDTH;
     }
 }
 


### PR DESCRIPTION
Thanks to @Koryphon for noting it.

Standard Arduino doesn't reset the Servo position on a detach, so for compatibility we shouldn't either.

Fixes #3195