### PR TITLE
Force correct PlatformIO LDF mode for WiFi library

### DIFF
--- a/libraries/WiFi/library.json
+++ b/libraries/WiFi/library.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://raw.githubusercontent.com/platformio/platformio-core/develop/platformio/assets/schema/library.json",
+  "name": "WiFi",
+  "version": "1.0.0",
+  "build": {
+    "libLDFMode": "chain+"
+  }
+}


### PR DESCRIPTION
Fixes #3202 

Adding this `library.json` corrects compilation failures when the user choses an explicit LDF mode that has no preprocessor defines checking, although the WiFi lirbary definitely requires it. 

Reproducing with this `platformio.ini`
```ini
[env]
platform = https://github.com/maxgerhardt/platform-raspberrypi.git
board = rpipicow
framework = arduino

[env:no_additional_settings]

[env:chain]
lib_ldf_mode = chain

[env:deep]
lib_ldf_mode = deep

[env:chainplus]
lib_ldf_mode = chain+

[env:deepplus]
lib_ldf_mode = deep+
```

And `src/main.cpp` of
```cpp
#include <Arduino.h>
#include <WiFi.h>

void setup() {
  Serial.begin(115200);
  WiFi.begin("your-SSID", "your-PASSWORD");
}

void loop() {}
```

Leads to these results.

Results with library.json
```
Environment             Status    Duration
----------------------  --------  ------------
no_additional_settings  SUCCESS   00:00:21.318
chain                   SUCCESS   00:00:20.926
deep                    SUCCESS   00:00:21.336
chainplus               SUCCESS   00:00:22.134
deepplus                SUCCESS   00:00:22.348
```
Results without library.json
```
Environment             Status    Duration
----------------------  --------  ------------
no_additional_settings  SUCCESS   00:00:20.382
chain                   FAILED    00:00:12.717
deep                    FAILED    00:00:12.653
chainplus               SUCCESS   00:00:21.010
deepplus                SUCCESS   00:00:20.931
```
So while we add  a tiny bit of overhead in the default case, we are now correct for all other cases as well.