### PR TITLE
Fix KeyboardBT/BLE, JoystickBT/BLE not xmitting

### DIFF
--- a/libraries/JoystickBLE/src/JoystickBLE.cpp
+++ b/libraries/JoystickBLE/src/JoystickBLE.cpp
@@ -43,6 +43,8 @@ uint8_t *desc_joystickBLE;
 uint16_t desc_joystickBLE_length;
 
 void JoystickBLE_::begin(const char *localName, const char *hidName) {
+    HID_Joystick::begin();
+
     if (!localName) {
         localName = "PicoW BLE Joystick";
     }

--- a/libraries/JoystickBT/src/JoystickBT.cpp
+++ b/libraries/JoystickBT/src/JoystickBT.cpp
@@ -43,6 +43,8 @@ uint8_t *desc_joystickBT;
 uint16_t desc_joystickBT_length;
 
 void JoystickBT_::begin(const char *localName, const char *hidName) {
+    HID_Joystick::begin();
+
     if (!localName) {
         localName = "PicoW BT Joystick";
     }

--- a/libraries/KeyboardBLE/src/KeyboardBLE.cpp
+++ b/libraries/KeyboardBLE/src/KeyboardBLE.cpp
@@ -40,13 +40,14 @@ uint8_t *desc_keyboardBLE;
 uint16_t desc_keyboardBLE_length;
 
 void KeyboardBLE_::begin(const char *localName, const char *hidName, const uint8_t *layout) {
+    HID_Keyboard::begin(layout);
+
     if (!localName) {
         localName = "PicoW BLE Keyboard";
     }
     if (!hidName) {
         hidName = localName;
     }
-    _asciimap = layout;
 
     __SetupHIDreportmap(__BLEInstallMouse, __BLEInstallKeyboard, __BLEInstallJoystick, false, &desc_keyboardBLE_length, &desc_keyboardBLE);
 

--- a/libraries/KeyboardBT/examples/BTKeyboardPassword/BTKeyboardPassword.ino
+++ b/libraries/KeyboardBT/examples/BTKeyboardPassword/BTKeyboardPassword.ino
@@ -14,11 +14,10 @@ void ledCB(bool numlock, bool capslock, bool scrolllock, bool compose, bool kana
 
 void setup() {
   Serial.begin(115200);
-  KeyboardBT.begin("PicoW Password");
   pinMode(LED_BUILTIN, OUTPUT);
   digitalWrite(LED_BUILTIN, LOW);
   KeyboardBT.onLED(ledCB);
-  KeyboardBT.begin();
+  KeyboardBT.begin("PicoW Password");
   delay(5000);
   Serial.printf("Arduino USB Password Typer\n");
   Serial.printf("Press BOOTSEL to enter your super-secure(not!) password\n\n");

--- a/libraries/KeyboardBT/src/KeyboardBT.cpp
+++ b/libraries/KeyboardBT/src/KeyboardBT.cpp
@@ -49,13 +49,16 @@ static void _hidReportCB(uint16_t cid, hid_report_type_t report_type, uint16_t r
 }
 
 void KeyboardBT_::begin(const char *localName, const char *hidName, const uint8_t *layout) {
+    HID_Keyboard::begin(layout);
+
     if (!localName) {
         localName = "PicoW BT Keyboard";
     }
     if (!hidName) {
         hidName = localName;
     }
-    _asciimap = layout;
+
+
     // Required because the hid_report_type_t overlap in BTStack and TUSB
     auto *fcn = (void (*)(short unsigned int, hid_report_type_t_bt, short unsigned int, int, unsigned char*))_hidReportCB;
     hid_device_register_report_data_callback(fcn);

--- a/libraries/MouseBLE/src/MouseBLE.cpp
+++ b/libraries/MouseBLE/src/MouseBLE.cpp
@@ -34,6 +34,8 @@ uint8_t *desc_mouseBLE;
 uint16_t desc_mouseBLE_length;
 
 void MouseBLE_::begin(const char *localName, const char *hidName) {
+    HID_Mouse::begin();
+
     if (!localName) {
         localName = "PicoW BLE Mouse";
     }
@@ -44,7 +46,6 @@ void MouseBLE_::begin(const char *localName, const char *hidName) {
     __SetupHIDreportmap(__BLEInstallMouse, __BLEInstallKeyboard, __BLEInstallJoystick, _absolute, &desc_mouseBLE_length, &desc_mouseBLE);
 
     PicoBluetoothBLEHID.startHID(localName, hidName, __BLEGetAppearance(), desc_mouseBLE, desc_mouseBLE_length);
-    _running = true;
 }
 
 void MouseBLE_::end(void) {

--- a/libraries/MouseBT/src/MouseBT.cpp
+++ b/libraries/MouseBT/src/MouseBT.cpp
@@ -34,6 +34,8 @@ uint8_t *desc_mouseBT;
 uint16_t desc_mouseBT_length;
 
 void MouseBT_::begin(const char *localName, const char *hidName) {
+    HID_Mouse::begin();
+
     if (!localName) {
         localName = "PicoW Mouse 00:00:00:00:00:00";
     }
@@ -44,7 +46,6 @@ void MouseBT_::begin(const char *localName, const char *hidName) {
     __SetupHIDreportmap(__BTInstallMouse, __BTInstallKeyboard, __BTInstallJoystick, _absolute, &desc_mouseBT_length, &desc_mouseBT);
 
     PicoBluetoothHID.startHID(localName, hidName, __BTGetCOD(), 33, desc_mouseBT, desc_mouseBT_length);
-    _running = true;
 }
 
 void MouseBT_::end(void) {


### PR DESCRIPTION
Fixes #3221

The ::begin() for the BT/BLE HID devices shadows the lower-level HID::begin() calls.  This means we need to explicitly call the parent's begin to set things like the _running flag.  Without it, transmission from the BT/BLE device would be stopped by the virtual parent's ::send() since _running wasn't set.