### PR TITLE
Remove debug code which broke static IPs

### DIFF
--- a/libraries/lwIP_Ethernet/src/LwipIntfDev.h
+++ b/libraries/lwIP_Ethernet/src/LwipIntfDev.h
@@ -349,8 +349,6 @@ bool LwipIntfDev<RawDev>::begin(const uint8_t* macAddress, const uint16_t mtu) {
     lwip_init();
     __startEthernetContext();
 
-    memset(&_netif, 0, sizeof(_netif));
-
     if (RawDev::needsSPI()) {
         _spiUnit.begin();
         // Set SPI clocks/etc. per request, doesn't seem to be direct way other than a fake transaction


### PR DESCRIPTION
Fixes #3226

As part of debugging stress-test failures for the CYW43 start/stop, the netif was cleared on begin().  This removes any preset static IPs, breaking the AP mode and STA move w/static IPs.

Remove that debug clear.