### PR TITLE
Ensure connectBLE doesn't return before HCI conn

### DIFF
--- a/libraries/BluetoothHCI/src/BluetoothHCI.h
+++ b/libraries/BluetoothHCI/src/BluetoothHCI.h
@@ -49,6 +49,10 @@ public:
 
     void scanFree(); // Free allocated scan buffers
 
+    bool connected() {
+        return _hciConn != HCI_CON_HANDLE_INVALID;
+    }
+
     friend class BluetoothHIDMaster;
 
 protected:


### PR DESCRIPTION
gap_connect() is async, so we need to pause until either it connects or we timeout so that we can ger an accurate connection state.

Fixes #3221 (again)