### PR TITLE
BLE HID pairing completed only with HID descriptor

### DIFF
--- a/libraries/BluetoothHIDMaster/src/BluetoothHIDMaster.cpp
+++ b/libraries/BluetoothHIDMaster/src/BluetoothHIDMaster.cpp
@@ -231,12 +231,12 @@ bool BluetoothHIDMaster::connectBLE(const uint8_t *addr, int addrType) {
     // GAP connection running async.  Wait for HCI connect
     uint32_t now = millis();
     while (millis() - now < 5000) {
-        if (_hci.connected()) {
+        if (_hid_host_descriptor_available) {
             break;
         }
         delay(25);
     }
-    if (!_hci.connected()) {
+    if (!_hid_host_descriptor_available) {
         gap_connect_cancel();
         return false;
     }


### PR DESCRIPTION
Related to #3221

Delay the `connectBLE` success until we have a HID descriptor from the BLE remote device.  This takes longer but guarantees we can get those HID messages, and eliminates potential race conditions where the HCI comes up fast but the GATT setup takes its sweet old time.