### PR TITLE
Update 1200bps reset sequence for better compat

### DIFF
--- a/cores/rp2040/SerialUSB.cpp
+++ b/cores/rp2040/SerialUSB.cpp
@@ -199,15 +199,10 @@ void SerialUSB::checkSerialReset() {
         __freertos_idle_other_core();
 #endif
         _ss.rebooting = true;
-        // Disable NVIC IRQ, so that we don't get bothered anymore
-        irq_set_enabled(USBCTRL_IRQ, false);
-        // Reset the whole USB hardware block
-        reset_block(RESETS_RESET_USBCTRL_BITS);
-        unreset_block(RESETS_RESET_USBCTRL_BITS);
-        // Delay a bit, so the PC can figure out that we have disconnected.
-        busy_wait_ms(3);
+        tud_disconnect();
+        busy_wait_ms(100);
         reset_usb_boot(0, 0);
-        while (1); // WDT will fire here
+        while (1); // WDT will fire here, we will reboot to MSD
     }
 }
 


### PR DESCRIPTION
Fixes #3240

Don't reset the USB peripheral, with all that entails, when rebooting from the 1200bps tickle.  Instead just disconnect the port, leaving the USB HW in a sane state.  Wait enough time for the host to note the disconnect, and then reboot to the ROM bootloader.