### PR TITLE
Add support for Vicharak Shrike-Lite board

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -34750,6 +34750,240 @@ vccgnd_yd_rp2040.menu.uploadmethod.picoprobe_cmsis_dap.upload.tool=picoprobe_cms
 vccgnd_yd_rp2040.menu.uploadmethod.picoprobe_cmsis_dap.upload.tool.default=picoprobe_cmsis_dap
 
 # -----------------------------------
+# Vicharak Shrike-Lite
+# -----------------------------------
+vicharak_shrike-lite.name=Vicharak Shrike-Lite
+vicharak_shrike-lite.vid.0=0x2e8a
+vicharak_shrike-lite.pid.0=0xf00a
+vicharak_shrike-lite.vid.1=0x2e8a
+vicharak_shrike-lite.pid.1=0xf10a
+vicharak_shrike-lite.upload_port.0.vid=0x2e8a
+vicharak_shrike-lite.upload_port.0.pid=0xf00a
+vicharak_shrike-lite.upload_port.1.vid=0x2e8a
+vicharak_shrike-lite.upload_port.1.pid=0xf10a
+vicharak_shrike-lite.build.usbvid=-DUSBD_VID=0x2e8a
+vicharak_shrike-lite.build.usbpid=-DUSBD_PID=0xf00a
+vicharak_shrike-lite.build.usbpwr=-DUSBD_MAX_POWER_MA=500
+vicharak_shrike-lite.build.board=VICHARAK_SHRIKELITE
+vicharak_shrike-lite.build.mcu=cortex-m0plus
+vicharak_shrike-lite.build.chip=rp2040
+vicharak_shrike-lite.build.toolchain=arm-none-eabi
+vicharak_shrike-lite.build.toolchainpkg=pqt-gcc
+vicharak_shrike-lite.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
+vicharak_shrike-lite.build.uf2family=--family rp2040
+vicharak_shrike-lite.build.variant=vicharak_shrike-lite
+vicharak_shrike-lite.upload.maximum_size=4194304
+vicharak_shrike-lite.upload.wait_for_upload_port=true
+vicharak_shrike-lite.upload.erase_cmd=
+vicharak_shrike-lite.serial.disableDTR=false
+vicharak_shrike-lite.serial.disableRTS=false
+vicharak_shrike-lite.build.f_cpu=125000000
+vicharak_shrike-lite.build.led=
+vicharak_shrike-lite.build.core=rp2040
+vicharak_shrike-lite.build.ldscript=memmap_default.ld
+vicharak_shrike-lite.build.boot2=boot2_generic_03h_4_padded_checksum
+vicharak_shrike-lite.build.usb_manufacturer="Vicharak"
+vicharak_shrike-lite.build.usb_product="Shrike-Lite"
+vicharak_shrike-lite.menu.flash.4194304_0=4MB (no FS)
+vicharak_shrike-lite.menu.flash.4194304_0.upload.maximum_size=4190208
+vicharak_shrike-lite.menu.flash.4194304_0.build.flash_total=4194304
+vicharak_shrike-lite.menu.flash.4194304_0.build.flash_length=4190208
+vicharak_shrike-lite.menu.flash.4194304_0.build.eeprom_start=272625664
+vicharak_shrike-lite.menu.flash.4194304_0.build.fs_start=272625664
+vicharak_shrike-lite.menu.flash.4194304_0.build.fs_end=272625664
+vicharak_shrike-lite.menu.flash.4194304_65536=4MB (Sketch: 4032KB, FS: 64KB)
+vicharak_shrike-lite.menu.flash.4194304_65536.upload.maximum_size=4124672
+vicharak_shrike-lite.menu.flash.4194304_65536.build.flash_total=4194304
+vicharak_shrike-lite.menu.flash.4194304_65536.build.flash_length=4124672
+vicharak_shrike-lite.menu.flash.4194304_65536.build.eeprom_start=272625664
+vicharak_shrike-lite.menu.flash.4194304_65536.build.fs_start=272560128
+vicharak_shrike-lite.menu.flash.4194304_65536.build.fs_end=272625664
+vicharak_shrike-lite.menu.flash.4194304_131072=4MB (Sketch: 3968KB, FS: 128KB)
+vicharak_shrike-lite.menu.flash.4194304_131072.upload.maximum_size=4059136
+vicharak_shrike-lite.menu.flash.4194304_131072.build.flash_total=4194304
+vicharak_shrike-lite.menu.flash.4194304_131072.build.flash_length=4059136
+vicharak_shrike-lite.menu.flash.4194304_131072.build.eeprom_start=272625664
+vicharak_shrike-lite.menu.flash.4194304_131072.build.fs_start=272494592
+vicharak_shrike-lite.menu.flash.4194304_131072.build.fs_end=272625664
+vicharak_shrike-lite.menu.flash.4194304_262144=4MB (Sketch: 3840KB, FS: 256KB)
+vicharak_shrike-lite.menu.flash.4194304_262144.upload.maximum_size=3928064
+vicharak_shrike-lite.menu.flash.4194304_262144.build.flash_total=4194304
+vicharak_shrike-lite.menu.flash.4194304_262144.build.flash_length=3928064
+vicharak_shrike-lite.menu.flash.4194304_262144.build.eeprom_start=272625664
+vicharak_shrike-lite.menu.flash.4194304_262144.build.fs_start=272363520
+vicharak_shrike-lite.menu.flash.4194304_262144.build.fs_end=272625664
+vicharak_shrike-lite.menu.flash.4194304_524288=4MB (Sketch: 3584KB, FS: 512KB)
+vicharak_shrike-lite.menu.flash.4194304_524288.upload.maximum_size=3665920
+vicharak_shrike-lite.menu.flash.4194304_524288.build.flash_total=4194304
+vicharak_shrike-lite.menu.flash.4194304_524288.build.flash_length=3665920
+vicharak_shrike-lite.menu.flash.4194304_524288.build.eeprom_start=272625664
+vicharak_shrike-lite.menu.flash.4194304_524288.build.fs_start=272101376
+vicharak_shrike-lite.menu.flash.4194304_524288.build.fs_end=272625664
+vicharak_shrike-lite.menu.flash.4194304_1048576=4MB (Sketch: 3MB, FS: 1MB)
+vicharak_shrike-lite.menu.flash.4194304_1048576.upload.maximum_size=3141632
+vicharak_shrike-lite.menu.flash.4194304_1048576.build.flash_total=4194304
+vicharak_shrike-lite.menu.flash.4194304_1048576.build.flash_length=3141632
+vicharak_shrike-lite.menu.flash.4194304_1048576.build.eeprom_start=272625664
+vicharak_shrike-lite.menu.flash.4194304_1048576.build.fs_start=271577088
+vicharak_shrike-lite.menu.flash.4194304_1048576.build.fs_end=272625664
+vicharak_shrike-lite.menu.flash.4194304_2097152=4MB (Sketch: 2MB, FS: 2MB)
+vicharak_shrike-lite.menu.flash.4194304_2097152.upload.maximum_size=2093056
+vicharak_shrike-lite.menu.flash.4194304_2097152.build.flash_total=4194304
+vicharak_shrike-lite.menu.flash.4194304_2097152.build.flash_length=2093056
+vicharak_shrike-lite.menu.flash.4194304_2097152.build.eeprom_start=272625664
+vicharak_shrike-lite.menu.flash.4194304_2097152.build.fs_start=270528512
+vicharak_shrike-lite.menu.flash.4194304_2097152.build.fs_end=272625664
+vicharak_shrike-lite.menu.flash.4194304_3145728=4MB (Sketch: 1MB, FS: 3MB)
+vicharak_shrike-lite.menu.flash.4194304_3145728.upload.maximum_size=1044480
+vicharak_shrike-lite.menu.flash.4194304_3145728.build.flash_total=4194304
+vicharak_shrike-lite.menu.flash.4194304_3145728.build.flash_length=1044480
+vicharak_shrike-lite.menu.flash.4194304_3145728.build.eeprom_start=272625664
+vicharak_shrike-lite.menu.flash.4194304_3145728.build.fs_start=269479936
+vicharak_shrike-lite.menu.flash.4194304_3145728.build.fs_end=272625664
+vicharak_shrike-lite.menu.freq.200=200 MHz
+vicharak_shrike-lite.menu.freq.200.build.f_cpu=200000000L
+vicharak_shrike-lite.menu.freq.50=50 MHz
+vicharak_shrike-lite.menu.freq.50.build.f_cpu=50000000L
+vicharak_shrike-lite.menu.freq.100=100 MHz
+vicharak_shrike-lite.menu.freq.100.build.f_cpu=100000000L
+vicharak_shrike-lite.menu.freq.120=120 MHz
+vicharak_shrike-lite.menu.freq.120.build.f_cpu=120000000L
+vicharak_shrike-lite.menu.freq.125=125 MHz
+vicharak_shrike-lite.menu.freq.125.build.f_cpu=125000000L
+vicharak_shrike-lite.menu.freq.128=128 MHz
+vicharak_shrike-lite.menu.freq.128.build.f_cpu=128000000L
+vicharak_shrike-lite.menu.freq.133=133 MHz
+vicharak_shrike-lite.menu.freq.133.build.f_cpu=133000000L
+vicharak_shrike-lite.menu.freq.150=150 MHz
+vicharak_shrike-lite.menu.freq.150.build.f_cpu=150000000L
+vicharak_shrike-lite.menu.freq.176=176 MHz
+vicharak_shrike-lite.menu.freq.176.build.f_cpu=176000000L
+vicharak_shrike-lite.menu.freq.225=225 MHz (Overclock)
+vicharak_shrike-lite.menu.freq.225.build.f_cpu=225000000L
+vicharak_shrike-lite.menu.freq.240=240 MHz (Overclock)
+vicharak_shrike-lite.menu.freq.240.build.f_cpu=240000000L
+vicharak_shrike-lite.menu.freq.250=250 MHz (Overclock)
+vicharak_shrike-lite.menu.freq.250.build.f_cpu=250000000L
+vicharak_shrike-lite.menu.freq.276=276 MHz (Overclock)
+vicharak_shrike-lite.menu.freq.276.build.f_cpu=276000000L
+vicharak_shrike-lite.menu.freq.300=300 MHz (Overclock)
+vicharak_shrike-lite.menu.freq.300.build.f_cpu=300000000L
+vicharak_shrike-lite.menu.opt.Small=Small (-Os) (standard)
+vicharak_shrike-lite.menu.opt.Small.build.flags.optimize=-Os
+vicharak_shrike-lite.menu.opt.Optimize=Optimize (-O)
+vicharak_shrike-lite.menu.opt.Optimize.build.flags.optimize=-O
+vicharak_shrike-lite.menu.opt.Optimize2=Optimize More (-O2)
+vicharak_shrike-lite.menu.opt.Optimize2.build.flags.optimize=-O2
+vicharak_shrike-lite.menu.opt.Optimize3=Optimize Even More (-O3)
+vicharak_shrike-lite.menu.opt.Optimize3.build.flags.optimize=-O3
+vicharak_shrike-lite.menu.opt.Fast=Fast (-Ofast) (maybe slower)
+vicharak_shrike-lite.menu.opt.Fast.build.flags.optimize=-Ofast
+vicharak_shrike-lite.menu.opt.Debug=Debug (-Og)
+vicharak_shrike-lite.menu.opt.Debug.build.flags.optimize=-Og
+vicharak_shrike-lite.menu.opt.Disabled=Disabled (-O0)
+vicharak_shrike-lite.menu.opt.Disabled.build.flags.optimize=-O0
+vicharak_shrike-lite.menu.os.none=None
+vicharak_shrike-lite.menu.os.none.build.os=
+vicharak_shrike-lite.menu.os.freertos=FreeRTOS SMP
+vicharak_shrike-lite.menu.os.freertos.build.os=-D__FREERTOS
+vicharak_shrike-lite.menu.profile.Disabled=Disabled
+vicharak_shrike-lite.menu.profile.Disabled.build.flags.profile=
+vicharak_shrike-lite.menu.profile.Enabled=Enabled
+vicharak_shrike-lite.menu.profile.Enabled.build.flags.profile=-pg -D__PROFILE
+vicharak_shrike-lite.menu.rtti.Disabled=Disabled
+vicharak_shrike-lite.menu.rtti.Disabled.build.flags.rtti=-fno-rtti
+vicharak_shrike-lite.menu.rtti.Enabled=Enabled
+vicharak_shrike-lite.menu.rtti.Enabled.build.flags.rtti=
+vicharak_shrike-lite.menu.stackprotect.Disabled=Disabled
+vicharak_shrike-lite.menu.stackprotect.Disabled.build.flags.stackprotect=
+vicharak_shrike-lite.menu.stackprotect.Enabled=Enabled
+vicharak_shrike-lite.menu.stackprotect.Enabled.build.flags.stackprotect=-fstack-protector-all
+vicharak_shrike-lite.menu.exceptions.Disabled=Disabled
+vicharak_shrike-lite.menu.exceptions.Disabled.build.flags.exceptions=-fno-exceptions
+vicharak_shrike-lite.menu.exceptions.Disabled.build.flags.libstdcpp=-lstdc++
+vicharak_shrike-lite.menu.exceptions.Enabled=Enabled
+vicharak_shrike-lite.menu.exceptions.Enabled.build.flags.exceptions=-fexceptions
+vicharak_shrike-lite.menu.exceptions.Enabled.build.flags.libstdcpp=-lstdc++-exc
+vicharak_shrike-lite.menu.dbgport.Disabled=Disabled
+vicharak_shrike-lite.menu.dbgport.Disabled.build.debug_port=
+vicharak_shrike-lite.menu.dbgport.Serial=Serial
+vicharak_shrike-lite.menu.dbgport.Serial.build.debug_port=-DDEBUG_RP2040_PORT=Serial
+vicharak_shrike-lite.menu.dbgport.Serial1=Serial1
+vicharak_shrike-lite.menu.dbgport.Serial1.build.debug_port=-DDEBUG_RP2040_PORT=Serial1
+vicharak_shrike-lite.menu.dbgport.Serial2=Serial2
+vicharak_shrike-lite.menu.dbgport.Serial2.build.debug_port=-DDEBUG_RP2040_PORT=Serial2
+vicharak_shrike-lite.menu.dbgport.SerialSemi=SerialSemi
+vicharak_shrike-lite.menu.dbgport.SerialSemi.build.debug_port=-DDEBUG_RP2040_PORT=SerialSemi
+vicharak_shrike-lite.menu.dbglvl.None=None
+vicharak_shrike-lite.menu.dbglvl.None.build.debug_level=
+vicharak_shrike-lite.menu.dbglvl.Core=Core
+vicharak_shrike-lite.menu.dbglvl.Core.build.debug_level=-DDEBUG_RP2040_CORE
+vicharak_shrike-lite.menu.dbglvl.SPI=SPI
+vicharak_shrike-lite.menu.dbglvl.SPI.build.debug_level=-DDEBUG_RP2040_SPI
+vicharak_shrike-lite.menu.dbglvl.Wire=Wire
+vicharak_shrike-lite.menu.dbglvl.Wire.build.debug_level=-DDEBUG_RP2040_WIRE
+vicharak_shrike-lite.menu.dbglvl.Bluetooth=Bluetooth
+vicharak_shrike-lite.menu.dbglvl.Bluetooth.build.debug_level=-DDEBUG_RP2040_BLUETOOTH
+vicharak_shrike-lite.menu.dbglvl.LWIP=LWIP
+vicharak_shrike-lite.menu.dbglvl.LWIP.build.debug_level=-DLWIP_DEBUG=1
+vicharak_shrike-lite.menu.dbglvl.All=All
+vicharak_shrike-lite.menu.dbglvl.All.build.debug_level=-DDEBUG_RP2040_WIRE -DDEBUG_RP2040_SPI -DDEBUG_RP2040_CORE -DDEBUG_RP2040_BLUETOOTH -DLWIP_DEBUG=1
+vicharak_shrike-lite.menu.dbglvl.NDEBUG=NDEBUG
+vicharak_shrike-lite.menu.dbglvl.NDEBUG.build.debug_level=-DNDEBUG
+vicharak_shrike-lite.menu.usbstack.picosdk=Pico SDK
+vicharak_shrike-lite.menu.usbstack.picosdk.build.usbstack_flags=
+vicharak_shrike-lite.menu.usbstack.tinyusb=Adafruit TinyUSB
+vicharak_shrike-lite.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+vicharak_shrike-lite.menu.usbstack.tinyusb_host=Adafruit TinyUSB Host (native)
+vicharak_shrike-lite.menu.usbstack.tinyusb_host.build.usbstack_flags=-DUSE_TINYUSB -DUSE_TINYUSB_HOST "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+vicharak_shrike-lite.menu.usbstack.nousb=No USB
+vicharak_shrike-lite.menu.usbstack.nousb.build.usbstack_flags="-DNO_USB -DDISABLE_USB_SERIAL -I{runtime.platform.path}/tools/libpico"
+vicharak_shrike-lite.menu.ipbtstack.ipv4only=IPv4 Only
+vicharak_shrike-lite.menu.ipbtstack.ipv4only.build.libpicow=liblwip.a
+vicharak_shrike-lite.menu.ipbtstack.ipv4only.build.libpicowdefs=-DLWIP_IPV6=0 -DLWIP_IPV4=1
+vicharak_shrike-lite.menu.ipbtstack.ipv4ipv6=IPv4 + IPv6
+vicharak_shrike-lite.menu.ipbtstack.ipv4ipv6.build.libpicow=liblwip.a
+vicharak_shrike-lite.menu.ipbtstack.ipv4ipv6.build.libpicowdefs=-DLWIP_IPV6=1 -DLWIP_IPV4=1
+vicharak_shrike-lite.menu.ipbtstack.ipv4btcble=IPv4 + Bluetooth
+vicharak_shrike-lite.menu.ipbtstack.ipv4btcble.build.libpicow=liblwip-bt.a
+vicharak_shrike-lite.menu.ipbtstack.ipv4btcble.build.libpicowdefs=-DLWIP_IPV6=0 -DLWIP_IPV4=1 -DENABLE_CLASSIC=1 -DENABLE_BLE=1 -DCYW43_ENABLE_BLUETOOTH=1
+vicharak_shrike-lite.menu.ipbtstack.ipv4ipv6btcble=IPv4 + IPv6 + Bluetooth
+vicharak_shrike-lite.menu.ipbtstack.ipv4ipv6btcble.build.libpicow=liblwip-bt.a
+vicharak_shrike-lite.menu.ipbtstack.ipv4ipv6btcble.build.libpicowdefs=-DLWIP_IPV6=1 -DLWIP_IPV4=1 -DENABLE_CLASSIC=1 -DENABLE_BLE=1 -DCYW43_ENABLE_BLUETOOTH=1
+vicharak_shrike-lite.menu.ipbtstack.ipv4onlybig=IPv4 Only - 32K
+vicharak_shrike-lite.menu.ipbtstack.ipv4onlybig.build.libpicow=liblwip.a
+vicharak_shrike-lite.menu.ipbtstack.ipv4onlybig.build.libpicowdefs=-DLWIP_IPV6=0 -DLWIP_IPV4=1 -D__LWIP_MEMMULT=2
+vicharak_shrike-lite.menu.ipbtstack.ipv4ipv6big=IPv4 + IPv6 - 32K
+vicharak_shrike-lite.menu.ipbtstack.ipv4ipv6big.build.libpicow=liblwip.a
+vicharak_shrike-lite.menu.ipbtstack.ipv4ipv6big.build.libpicowdefs=-DLWIP_IPV6=1 -DLWIP_IPV4=1 -D__LWIP_MEMMULT=2
+vicharak_shrike-lite.menu.ipbtstack.ipv4btcblebig=IPv4 + Bluetooth - 32K
+vicharak_shrike-lite.menu.ipbtstack.ipv4btcblebig.build.libpicow=liblwip-bt.a
+vicharak_shrike-lite.menu.ipbtstack.ipv4btcblebig.build.libpicowdefs=-DLWIP_IPV6=0 -DLWIP_IPV4=1 -DENABLE_CLASSIC=1 -DENABLE_BLE=1 -DCYW43_ENABLE_BLUETOOTH=1 -D__LWIP_MEMMULT=2
+vicharak_shrike-lite.menu.ipbtstack.ipv4ipv6btcblebig=IPv4 + IPv6 + Bluetooth - 32K
+vicharak_shrike-lite.menu.ipbtstack.ipv4ipv6btcblebig.build.libpicow=liblwip-bt.a
+vicharak_shrike-lite.menu.ipbtstack.ipv4ipv6btcblebig.build.libpicowdefs=-DLWIP_IPV6=1 -DLWIP_IPV4=1 -DENABLE_CLASSIC=1 -DENABLE_BLE=1 -DCYW43_ENABLE_BLUETOOTH=1 -D__LWIP_MEMMULT=2
+vicharak_shrike-lite.menu.uploadmethod.default=Default (UF2)
+vicharak_shrike-lite.menu.uploadmethod.default.build.ram_length=256k
+vicharak_shrike-lite.menu.uploadmethod.default.build.debugscript=picoprobe_cmsis_dap.tcl
+vicharak_shrike-lite.menu.uploadmethod.default.upload.maximum_data_size=262144
+vicharak_shrike-lite.menu.uploadmethod.default.upload.tool=uf2conv
+vicharak_shrike-lite.menu.uploadmethod.default.upload.tool.default=uf2conv
+vicharak_shrike-lite.menu.uploadmethod.default.upload.tool.network=uf2conv-network
+vicharak_shrike-lite.menu.uploadmethod.picotool=Picotool
+vicharak_shrike-lite.menu.uploadmethod.picotool.build.ram_length=256k
+vicharak_shrike-lite.menu.uploadmethod.picotool.build.debugscript=picoprobe.tcl
+vicharak_shrike-lite.menu.uploadmethod.picotool.build.picodebugflags=-DENABLE_PICOTOOL_USB
+vicharak_shrike-lite.menu.uploadmethod.picotool.upload.maximum_data_size=262144
+vicharak_shrike-lite.menu.uploadmethod.picotool.upload.tool=picotool
+vicharak_shrike-lite.menu.uploadmethod.picotool.upload.tool.default=picotool
+vicharak_shrike-lite.menu.uploadmethod.picoprobe_cmsis_dap=Picoprobe/Debugprobe (CMSIS-DAP)
+vicharak_shrike-lite.menu.uploadmethod.picoprobe_cmsis_dap.build.ram_length=256k
+vicharak_shrike-lite.menu.uploadmethod.picoprobe_cmsis_dap.build.debugscript=picoprobe_cmsis_dap.tcl
+vicharak_shrike-lite.menu.uploadmethod.picoprobe_cmsis_dap.upload.maximum_data_size=262144
+vicharak_shrike-lite.menu.uploadmethod.picoprobe_cmsis_dap.upload.tool=picoprobe_cmsis_dap
+vicharak_shrike-lite.menu.uploadmethod.picoprobe_cmsis_dap.upload.tool.default=picoprobe_cmsis_dap
+
+# -----------------------------------
 # Viyalab Mizu RP2040
 # -----------------------------------
 viyalab_mizu.name=Viyalab Mizu RP2040

--- a/package/package_pico_index.template.json
+++ b/package/package_pico_index.template.json
@@ -366,6 +366,9 @@
                      "name": "VCC-GND YD RP2040"
                   },
                   {
+                     "name": "Vicharak Shrike-Lite"
+                  },
+                  {
                      "name": "Viyalab Mizu RP2040"
                   },
                   {

--- a/tools/json/vicharak_shrike-lite.json
+++ b/tools/json/vicharak_shrike-lite.json
@@ -1,0 +1,56 @@
+{
+    "build": {
+        "arduino": {
+            "earlephilhower": {
+                "boot2_source": "boot2_generic_03h_4_padded_checksum.S",
+                "usb_vid": "0x2E8A",
+                "usb_pid": "0xF00A"
+            }
+        },
+        "core": "earlephilhower",
+        "cpu": "cortex-m0plus",
+        "extra_flags": "-DARDUINO_VICHARAK_SHRIKELITE -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=500 ",
+        "f_cpu": "133000000L",
+        "hwids": [
+            [
+                "0x2E8A",
+                "0x00C0"
+            ],
+            [
+                "0x2E8A",
+                "0xF00A"
+            ]
+        ],
+        "mcu": "rp2040",
+        "variant": "vicharak_shrike-lite"
+    },
+    "debug": {
+        "jlink_device": "RP2040_M0_0",
+        "openocd_target": "rp2040.cfg",
+        "svd_path": "rp2040.svd"
+    },
+    "frameworks": [
+        "arduino",
+        "picosdk"
+    ],
+    "name": "Shrike-Lite",
+    "upload": {
+        "maximum_ram_size": 262144,
+        "maximum_size": 4194304,
+        "require_upload_port": true,
+        "native_usb": true,
+        "use_1200bps_touch": true,
+        "wait_for_upload_port": false,
+        "protocol": "picotool",
+        "protocols": [
+            "blackmagic",
+            "cmsis-dap",
+            "jlink",
+            "raspberrypi-swd",
+            "picotool",
+            "picoprobe"
+        ]
+    },
+    "url": "https://github.com/vicharak-in/shrike-lite.git",
+    "vendor": "Vicharak"
+}

--- a/tools/makeboards.py
+++ b/tools/makeboards.py
@@ -707,6 +707,9 @@ MakeBoard("upesy_rp2040_devkit", "rp2040", "uPesy", "RP2040 DevKit", "0x2e8a", "
 # VCC-GND YD-2040 - Use generic SPI/4 because boards seem to come with varied flash modules but same name
 MakeBoard('vccgnd_yd_rp2040', "rp2040", "VCC-GND", "YD RP2040", "0x2e8a", "0x800a", 500, "YD_RP2040", 16, 0, "boot2_generic_03h_4_padded_checksum")
 
+# Vicharak
+MakeBoard("vicharak_shrike-lite", "rp2040", "Vicharak", "Shrike-Lite", "0x2e8a", "0xf00a", 500, "VICHARAK_SHRIKELITE", 4, 0, "boot2_generic_03h_4_padded_checksum", board_url="https://github.com/vicharak-in/shrike-lite.git")
+
 # Viyalab
 MakeBoard("viyalab_mizu", "rp2040", "Viyalab", "Mizu RP2040", "0x2e8a", "0x000a", 250, "VIYALAB_MIZU_RP2040", 8, 0, "boot2_generic_03h_4_padded_checksum")
 

--- a/variants/vicharak_shrike-lite/pins_arduino.h
+++ b/variants/vicharak_shrike-lite/pins_arduino.h
@@ -1,0 +1,40 @@
+#pragma once
+
+// Pin definitions taken from:
+//    https://github.com/vicharak-in/shrike-lite.git
+
+
+// LEDs
+#define PIN_LED        (4u)
+#define LED_BUILTIN     PIN_LED
+
+// UART
+#define PIN_SERIAL1_TX (16u)
+#define PIN_SERIAL1_RX (17u)
+
+#define PIN_SERIAL2_TX (8u)
+#define PIN_SERIAL2_RX (9u)
+
+// SPI
+#define PIN_SPI0_MISO  (20u)
+#define PIN_SPI0_MOSI  (19u)
+#define PIN_SPI0_SCK   (18u)
+#define PIN_SPI0_SS    (21u)
+
+#define PIN_SPI1_MISO  (28u)
+#define PIN_SPI1_MOSI  (27u)
+#define PIN_SPI1_SCK   (26u)
+#define PIN_SPI1_SS    (29u)
+
+// Wire
+#define PIN_WIRE0_SDA  (24u)
+#define PIN_WIRE0_SCL  (25u)
+
+#define PIN_WIRE1_SDA  (6u)
+#define PIN_WIRE1_SCL  (7u)
+
+#define SERIAL_HOWMANY (3u)
+#define SPI_HOWMANY    (2u)
+#define WIRE_HOWMANY   (2u)
+
+#include "../generic/common.h"


### PR DESCRIPTION
[Shrike-Lite](https://github.com/vicharak-in/shrike-lite.git) is an RP2040-based development board with **4 MB** of QSPI (W25Q32JV) flash paired with a SLG47910 Renesas Forge FPGA  by [Vicharak](https://vicharak.in/)

- RP2040 pins on Shrike-LIte:
```
    SPI0 CSn | UART1 RX | I2C0 SCL  <- IO5  ◦      ◦ IO29 -> SPI1 CSn | UART0 RX | I2C0 SCL
    SPI0 SCK |          | I2C1 SDA  <- IO6  ◦      ◦ IO28 -> SPI1 RX  | UART0 TX | I2C0 SDA 
    SPI0 TX  |          | I2C1 SCL  <- IO7  ◦      ◦ IO27 -> SPI1 TX  |          | I2C1 SCL
    SPI1 RX  | UART1 TX | I2C0 SDA  <- IO8  ◦      ◦ IO26 -> SPI1 SCK |          | I2C1 SDA 
    SPI1 CSn | UART1 RX | I2C0 SCL  <- IO9  ◦      ◦ GND
                                       GND  ◦      ◦ IO25 -> SPI1 CSn | UART1 RX | I2C0 SCL 
    SPI1 SCK |          | I2C1 SDA  <- IO10 ◦      ◦ IO24 -> SPI1 RX  | UART1 TX | I2C0 SDA 
    SPI1 TX  |          | I2C1 SCL  <- IO11 ◦      ◦ IO23 -> SPI0 TX  |          | I2C1 SCL
    SPI1 SCK |          | I2C1 SDA  <- IO14 ◦      ◦ IO22 -> SPI0 SCK |          | I2C1 SDA 
    SPI1 TX  |          | I2C1 SCL  <- IO15 ◦      ◦ IO21 -> SPI0 CSn | UART1 RX | I2C0 SCL 
                                       GND  ◦      ◦ GND
                                            ◦      ◦ IO20 -> SPI0 RX  | UART1 TX | I2C0 SDA
                                            ◦      ◦ IO19 -> SPI0 TX  |          | I2C1 SCL
                                            ◦      ◦ IO18 -> SPI0 SCK |          | I2C1 SDA 
                                            ◦      ◦ IO17 -> SPI0 CSn | UART0 RX | I2C0 SCL
                                            ◦      ◦ IO16 -> SPI0 RX  | UART0 TX | I2C0 SDA 
                                            ◦      ◦ GND
```