### PR TITLE
Move Newlib locale table to flash, save 360B RAM

### DIFF
--- a/lib/rp2040/memmap_default.ld
+++ b/lib/rp2040/memmap_default.ld
@@ -136,6 +136,8 @@ SECTIONS
         . = ALIGN(4);
         *(SORT_BY_ALIGNMENT(SORT_BY_NAME(.flashdata*)))
         . = ALIGN(4);
+        *libc_a-locale.o(.data)
+        . = ALIGN(4);
     } > FLASH
 
     .ARM.extab :

--- a/lib/rp2350-riscv/memmap_default.ld
+++ b/lib/rp2350-riscv/memmap_default.ld
@@ -149,6 +149,8 @@ SECTIONS
         . = ALIGN(4);
         *(SORT_BY_ALIGNMENT(SORT_BY_NAME(.flashdata*)))
         . = ALIGN(4);
+        *libc_a-locale.o(.data)
+        . = ALIGN(4);
     } > FLASH
 
     .ARM.extab :

--- a/lib/rp2350/memmap_default.ld
+++ b/lib/rp2350/memmap_default.ld
@@ -149,6 +149,8 @@ SECTIONS
         . = ALIGN(4);
         *(SORT_BY_ALIGNMENT(SORT_BY_NAME(.flashdata*)))
         . = ALIGN(4);
+        *libc_a-locale.o(.data)
+        . = ALIGN(4);
     } > FLASH
 
     .ARM.extab :


### PR DESCRIPTION
Newlib doesn't really support locale operations, so the global locale can be considered const.  Move it to only live in flash, freeing up 360 bytes of RAM for apps.