### PR TITLE
Revert "Move Newlib locale table to flash, save 360B RAM"

### DIFF
--- a/lib/rp2040/memmap_default.ld
+++ b/lib/rp2040/memmap_default.ld
@@ -136,8 +136,6 @@ SECTIONS
         . = ALIGN(4);
         *(SORT_BY_ALIGNMENT(SORT_BY_NAME(.flashdata*)))
         . = ALIGN(4);
-        *libc_a-locale.o(.data)
-        . = ALIGN(4);
     } > FLASH
 
     .ARM.extab :

--- a/lib/rp2350-riscv/memmap_default.ld
+++ b/lib/rp2350-riscv/memmap_default.ld
@@ -149,8 +149,6 @@ SECTIONS
         . = ALIGN(4);
         *(SORT_BY_ALIGNMENT(SORT_BY_NAME(.flashdata*)))
         . = ALIGN(4);
-        *libc_a-locale.o(.data)
-        . = ALIGN(4);
     } > FLASH
 
     .ARM.extab :

--- a/lib/rp2350/memmap_default.ld
+++ b/lib/rp2350/memmap_default.ld
@@ -149,8 +149,6 @@ SECTIONS
         . = ALIGN(4);
         *(SORT_BY_ALIGNMENT(SORT_BY_NAME(.flashdata*)))
         . = ALIGN(4);
-        *libc_a-locale.o(.data)
-        . = ALIGN(4);
     } > FLASH
 
     .ARM.extab :


### PR DESCRIPTION
Reverts earlephilhower/arduino-pico#3267

Think I just found a couple supported cases where global locale could be updated with the existing Newlib build, darn it.