### PR TITLE
RP2350 UART_AUX works on A and B variants

### DIFF
--- a/cores/rp2040/SerialUART.cpp
+++ b/cores/rp2040/SerialUART.cpp
@@ -182,7 +182,7 @@ static void _uart1IRQ();
 // Does the selected TX/RX need UART_AUX function (rp2350)
 static gpio_function_t __gpioFunction(int pin) {
     switch (pin) {
-#if defined(PICO_RP2350) && !PICO_RP2350A
+#if defined(PICO_RP2350)
     case 2:
     case 3:
     case 6:


### PR DESCRIPTION
The UART I/Os can be places on alternate pins on all RP2350 variants, not just the RP2350B version.  Fix the SerialUART condition.

Disconvered while helping a user debug their RP2350 serial port issue.