### PR TITLE
Fix HID endpoint size, remove 512b MSC

### DIFF
--- a/include/tusb_config.h
+++ b/include/tusb_config.h
@@ -80,10 +80,10 @@
 #define CFG_TUD_CDC_RX_BUFSIZE  (256)
 #define CFG_TUD_CDC_TX_BUFSIZE  (256)
 
-#define CFG_TUD_MSC_EP_BUFSIZE  (64)
+#define CFG_TUD_MSC_EP_BUFSIZE  (64) // Max for RP2040, not OPT_MODE_HS
 
 // HID buffer size Should be sufficient to hold ID (if any) + Data
-#define CFG_TUD_HID_EP_BUFSIZE  (512)
+#define CFG_TUD_HID_EP_BUFSIZE  (64)
 
 // MIDI
 #define CFG_TUD_MIDI_RX_BUFSIZE (64)


### PR DESCRIPTION
The HID endpoint size was set incorrectly, update.  No need for new libraries because the only file that uses the define is in tusb-hid and will be built dynamically.

The RP2040 endpoints seem to be limited to 64b (also seen in the tinyusb examples), so don't extend it to 512b.