### PR TITLE
set ttl to show ping response

### DIFF
--- a/libraries/lwIP_Ethernet/src/LwipIntfDev.h
+++ b/libraries/lwIP_Ethernet/src/LwipIntfDev.h
@@ -236,7 +236,7 @@ u8_t LwipIntfDev<RawDev>::_pingCB(void *arg, struct raw_pcb *pcb, struct pbuf *p
     if (p->len > 20) {
         iecho = (struct icmp_echo_hdr *)((uint8_t*)p->payload + 20);
         if ((iecho->id == w->_ping_id) && (iecho->seqno == htons(w->_ping_seq_num))) {
-            w->_ping_ttl = pcb->ttl;
+            w->_ping_ttl = ip4_current_header()->_ttl;
             pbuf_free(p);
             return 1; // We've processed it
         }


### PR DESCRIPTION
ping return value was always equal to the value ping was called with, instead of the ttl of the ping response received