### PR TITLE
Corrected minor typos and style issues.

### DIFF
--- a/variants/waveshare_rp2350b_plus_w/digital.cpp
+++ b/variants/waveshare_rp2350b_plus_w/digital.cpp
@@ -17,19 +17,19 @@
     Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
 */
 
-// https://datasheets.raspberrypi.com/rm2/rm2-datasheet.pdf
-// https://datasheets.raspberrypi.com/rm2/rm2-product-brief.pdf
-// https://pip.raspberrypi.com/categories/1223-design-files
-// NOTE: LED1: LED_WLGP0 B1_GPIO0
-
 /*
-    Radio Module 2 packages the same Infineon CYW43439 radio used on Raspberry
+    https://datasheets.raspberrypi.com/rm2/rm2-datasheet.pdf
+    https://datasheets.raspberrypi.com/rm2/rm2-product-brief.pdf
+    https://pip.raspberrypi.com/categories/1223-design-files
+    NOTE: LED1: LED_WLGP0 B1_GPIO0
+
+    "Radio Module 2 packages the same Infineon CYW43439 radio used on Raspberry
     Pi Pico W and Pico 2 W, featuring 1×1 single-band 2.4GHz Wi-Fi® 4 (802.11n)
     and Bluetooth® 5.2, with support for both Bluetooth Classic and Bluetooth
     Low Energy. Its integrated internal PA, LNA, and T/R switch deliver
     excellent wireless performance even when sharing a single antenna between
-    Wi-Fi and Bluetooth.
- * */
+    Wi-Fi and Bluetooth."
+*/
 
 #include "Arduino.h"
 #include <cyw43_wrappers.h>

--- a/variants/waveshare_rp2350b_plus_w/pins_arduino.h
+++ b/variants/waveshare_rp2350b_plus_w/pins_arduino.h
@@ -5,7 +5,7 @@
 #include <cyw43_wrappers.h>
 
 // Waveshare RP2350 Plus W
-// Pin definitionsL:
+// Pin definitions:
 // https://www.waveshare.com/wiki/RP2350B-Plus-W
 // https://files.waveshare.com/wiki/RP2350B-Plus-W/RP2350B-Plus-W.pdf
 // https://www.waveshare.com/w/upload/4/41/RP2350B-Plus-W-details-inter.png
@@ -179,7 +179,7 @@ static const uint8_t D37 = (35u); // GPIO35 = P8
 
 // Analog
 static const uint8_t A0 = (40u); // ADC0 = GPIO40
-static const uint8_t A1 = (41u); // ADC1 = GPIO41`
+static const uint8_t A1 = (41u); // ADC1 = GPIO41
 static const uint8_t A2 = (42u); // ADC2 = GPIO42
 static const uint8_t A3 = (43u); // ADC3 = GPIO43
 static const uint8_t A4 = (44u); // ADC4 = GPIO44


### PR DESCRIPTION
**In /variants/waveshare_rp2350b_plus_w/pins_arduino.h:** 
line 8 // Pin definitionsL: -> // Pin definitions: 
line 182 GPIO41` -> GPIO41

**In /variants/waveshare_rp2350b_plus_w/digital.cpp:** 
Adjusted second comment block to match style of the first one, then moved the note and datasheets resource links into the second comment block.
Added quotes around Radio Module 2 description so that it's more obvious that that description was pulled from the databrief.