### PR TITLE
Add include guard to EthernetLinkStatus enum to prevent multiple definitions

### DIFF
--- a/libraries/lwIP_Ethernet/src/LwipIntfDev.h
+++ b/libraries/lwIP_Ethernet/src/LwipIntfDev.h
@@ -66,12 +66,14 @@ static void _cyw43_hal_generate_laa_mac(__unused int idx, uint8_t buf[6]) {
 }
 
 
-
+#ifndef ETHERNET_LINK_STATUS_ENUM
 enum EthernetLinkStatus {
     Unknown,
     LinkON,
     LinkOFF
 };
+#define ETHERNET_LINK_STATUS_ENUM
+#endif
 
 #include <lwip_wrap.h>
 


### PR DESCRIPTION
When both Ethernet and WiFi libraries are included, the EthernetLinkStatus enum
is defined in both Ethernet.h and LwipIntfDev.h, causing a compilation error.
This guard ensures the enum is defined only once.