### PR TITLE
Remove signature from signed OTA files

### DIFF
--- a/libraries/Updater/src/Updater.cpp
+++ b/libraries/Updater/src/Updater.cpp
@@ -256,6 +256,10 @@ bool UpdaterClass::end(bool evenIfRemaining) {
         free(sig);
         _size = binSize; // Adjust size to remove signature, not part of bin payload
 
+        // Remove the signature from being flashed
+        _fp.seek(0);
+        _fp.truncate(_size);
+
 #ifdef DEBUG_UPDATER
         DEBUG_UPDATER.printf_P(PSTR("[Updater] Signature matches\n"));
 #endif


### PR DESCRIPTION
Fixes #3309

Truncate the firmware.bin to the proper length, discarding any signature bits added after real end of .BIN