### PR TITLE
Fix _lseek POSIX return value

### DIFF
--- a/cores/rp2040/FS.cpp
+++ b/cores/rp2040/FS.cpp
@@ -231,7 +231,7 @@ bool File::stat(FSStat *st) {
     }
     size_t pos = position();
     seek(0, SeekEnd);
-    st->size = position() - pos;
+    st->size = position();
     seek(pos, SeekSet);
     st->blocksize = 0; // Not set here
     st->ctime = getCreationTime();

--- a/libraries/LittleFS/src/LittleFS.h
+++ b/libraries/LittleFS/src/LittleFS.h
@@ -416,9 +416,6 @@ public:
             return false;
         }
         int32_t offset = static_cast<int32_t>(pos);
-        if (mode == SeekEnd) {
-            offset = -offset; // TODO - this seems like its plain wrong vs. POSIX
-        }
         auto lastPos = position();
         int rc = lfs_file_seek(_fs->getFS(), _getFD(), offset, (int)mode); // NB. SeekMode === LFS_SEEK_TYPES
         if (rc < 0) {

--- a/libraries/VFS/src/VFS.cpp
+++ b/libraries/VFS/src/VFS.cpp
@@ -128,7 +128,7 @@ extern "C" int _lseek(int fd, int ptr, int dir) {
     } else if (dir == SEEK_END) {
         d = SeekEnd;
     }
-    return f->second.seek(ptr, d) ? 0 : 1;
+    return f->second.seek(ptr, d) ? f->second.position() : -1;
 }
 
 extern "C" int _read(int fd, char *buf, int size) {


### PR DESCRIPTION
_lseek() should return the current position on success, not 0.

Fixes #3317