### PR TITLE
Fix multicore SoftwareSerial IRQ handling

### DIFF
--- a/cores/rp2040/SerialPIO.cpp
+++ b/cores/rp2040/SerialPIO.cpp
@@ -90,7 +90,7 @@ static void __not_in_flash_func(_fifoIRQ)() {
 }
 
 void __not_in_flash_func(SerialPIO::_handleIRQ)() {
-    if (_rx == NOPIN) {
+    if ((_rx == NOPIN) || (_onCore != get_core_num())) {
         return;
     }
     while (!pio_sm_is_rx_fifo_empty(_rxPIO, _rxSM)) {
@@ -149,6 +149,7 @@ static int pio_irq_0(PIO p) {
 }
 
 void SerialPIO::begin(unsigned long baud, uint16_t config) {
+    _onCore = get_core_num();
     _overflow = false;
     _baud = baud;
     switch (config & SERIAL_PARITY_MASK) {

--- a/cores/rp2040/SerialPIO.h
+++ b/cores/rp2040/SerialPIO.h
@@ -93,6 +93,8 @@ protected:
 
     LocklessQueue<uint8_t> *_queue;
     size_t   _fifoSize;
+
+    uint _onCore;
 };
 
 #ifdef ARDUINO_NANO_RP2040_CONNECT


### PR DESCRIPTION
The _handleIRQ callback for SerialPIO would be called for both cores if both had SerialPIO objects running.  This would cause both cores to execute reads and queue updates, in parallel, at the same time, from the same PIO.  This is a very bad thing and causes random data corruption.

Now, store the core we started on and only handleIRQ if the current core matches the one we're running on.