### PR TITLE
Replace micros() implementation with time_us_32()

### DIFF
--- a/cores/rp2040/delay.cpp
+++ b/cores/rp2040/delay.cpp
@@ -60,7 +60,7 @@ extern "C"
     }
 
     uint32_t micros() {
-        return to_us_since_boot(get_absolute_time());
+        return time_us_32();
     }
 
 } // extern C


### PR DESCRIPTION
Replace micros() implementation with time_us_32() to reduce CPU cycles from 31 to 3:

```
/*output on a RP2350: 
overhead:20107ps 3.02clk   time_us_32:20022ps 3.00clk   micros:207282ps 31.09clk
overhead:20111ps 3.02clk   time_us_32:20018ps 3.00clk   micros:207278ps 31.09clk
overhead:20117ps 3.02clk   time_us_32:20012ps 3.00clk   micros:207272ps 31.09clk
overhead:20105ps 3.02clk   time_us_32:20024ps 3.00clk   micros:207287ps 31.09clk
overhead:20106ps 3.02clk   time_us_32:20023ps 3.00clk   micros:207283ps 31.09clk
*/

void setup() {
  Serial.begin(115200);
}

void loop() {
  const int n = 1000000;
  volatile uint32_t t = 0;
  (void)t;

  //measure overhead
  volatile uint32_t t1 = time_us_32();
  for(int i = 0; i < n; i++) t = 1;

  //measure time_us_32()
  volatile uint32_t t2 = time_us_32();
  for(int i = 0; i < n; i++) t = time_us_32();

  //measure micros()
  volatile uint32_t t3 = time_us_32();
  for(int i = 0; i < n; i++) t = micros();

  volatile uint32_t t4 = time_us_32();

  int32_t dt1 = t2 - t1;         //overhead for 1 loop and assignment in pico-seconds
  int32_t dt2 = (t3 - t2) - dt1; //time for 1 time_us_32() call in pico-seconds
  int32_t dt3 = (t4 - t3) - dt1; //time for 1 micros() call in pico-second

  //same in CPU clocks
  float clk1 = 1e-12 * dt1 * F_CPU;
  float clk2 = 1e-12 * dt2 * F_CPU;
  float clk3 = 1e-12 * dt3 * F_CPU;

  Serial.printf("overhead:%dps %.2fclk   time_us_32:%dps %.2fclk   micros:%dps %.2fclk\n", dt1, clk1, dt2, clk2, dt3, clk3);
}
```