### PR TITLE
Do name requests for BT classic scan automatically

### DIFF
--- a/libraries/BluetoothHCI/src/BluetoothDevice.h
+++ b/libraries/BluetoothHCI/src/BluetoothDevice.h
@@ -25,7 +25,7 @@
 class BTDeviceInfo {
 public:
     // Classic Bluetooth Device
-    BTDeviceInfo(uint32_t dc, const uint8_t addr[6], int rssi, const char *name) {
+    BTDeviceInfo(uint32_t dc, const uint8_t addr[6], int rssi, const char *name, int psrm, int co) {
         _deviceClass = dc;
         memcpy(_address, addr, sizeof(_address));
         _addressType = -1;
@@ -33,6 +33,8 @@ public:
         _rssi = rssi;
         strncpy(_name, name, sizeof(_name));
         _name[sizeof(_name) - 1] = 0;
+        _pageScanRepetitionMode = psrm;
+        _clockOffset = co;
     }
 
     // Bluetooth BLE Device
@@ -73,11 +75,22 @@ public:
         return _addressType;
     }
 
+    int pageScanRepetitionMode() {
+        return _pageScanRepetitionMode;
+    }
+
+    int clockOffset() {
+        return _clockOffset;
+    }
+
 private:
+    friend class BluetoothHCI;
     uint32_t _deviceClass;
     uint8_t _address[6];
     int _addressType;
     char _addressString[18];
     int8_t _rssi;
     char _name[241];
+    int _pageScanRepetitionMode;
+    int _clockOffset;
 };

--- a/libraries/BluetoothHCI/src/BluetoothHCI.h
+++ b/libraries/BluetoothHCI/src/BluetoothHCI.h
@@ -77,6 +77,7 @@ private:
     enum { MAX_DEVICES_TO_DISCOVER = 32 };
     std::vector<BTDeviceInfo> _btdList;
     volatile bool _scanning = false;
+    BTDeviceInfo *_requested; // BTClassic name request
     bool _running = false;
 
     // BLE specific

--- a/libraries/BluetoothHIDMaster/src/BluetoothHIDMaster.cpp
+++ b/libraries/BluetoothHIDMaster/src/BluetoothHIDMaster.cpp
@@ -210,15 +210,20 @@ bool BluetoothHIDMaster::connectCOD(uint32_t cod) {
     clearPairing();
     auto l = scan(cod);
     for (auto e : l) {
-        DEBUGV("Scan connecting %s at %s ...\n ", e.name(), e.addressString());
+        DEBUGV("Scan connecting %s at %s ...\n", e.name(), e.addressString());
         memcpy(a, e.address(), sizeof(a));
-        if (ERROR_CODE_SUCCESS == hid_host_connect(a, HID_PROTOCOL_MODE_REPORT, &_hid_host_cid)) {
+        int ret;
+        do {
+            BluetoothLock l;
+            ret = hid_host_connect(a, HID_PROTOCOL_MODE_REPORT, &_hid_host_cid);
+        } while (0);
+        if (ERROR_CODE_SUCCESS == ret) {
             DEBUGV("Connection established\n");
             memcpy(_lastAddr, e.address(), sizeof(_lastAddr));
             _lastAddrType = e.addressType();
             return true;
         }
-        DEBUGV("Failed\n");
+        DEBUGV("Connection failed %02x\n", ret);
     }
     return false;
 }


### PR DESCRIPTION
BT classic sometimes needs a separate message to get a device name. Ensure HCI::scan() does that step of processing to collect names.