### PR TITLE
Use BTStack packet log format for debug

### DIFF
--- a/cores/rp2040/BluetoothDebug.cpp
+++ b/cores/rp2040/BluetoothDebug.cpp
@@ -25,12 +25,87 @@
 
 static Print *_print;
 
-static void _log_packet(uint8_t packet_type, uint8_t in, uint8_t *packet, uint16_t len) {
-    if (!_print) {
-        return;
-    }
-    _print->printf("[BT @%lu] ", millis());
+// Taken from hci_dump_embedded_stdout.c
 
+/*
+    Copyright (C) 2014 BlueKitchen GmbH
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holders nor the names of
+      contributors may be used to endorse or promote products derived
+      from this software without specific prior written permission.
+    4. Any redistribution, use, or modification is done solely for
+      personal benefit and not for any commercial purpose or for
+      monetary gain.
+
+    THIS SOFTWARE IS PROVIDED BY BLUEKITCHEN GMBH AND CONTRIBUTORS
+    ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+    LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+    FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL BLUEKITCHEN
+    GMBH OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+    BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+    OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+    AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF
+    THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+    SUCH DAMAGE.
+
+    Please inquire about commercial licensing options at
+    contact@bluekitchen-gmbh.com
+
+*/
+
+
+static inline char char_for_high_nibble(int value) {
+    return char_for_nibble((value >> 4) & 0x0f);
+}
+
+static inline char char_for_low_nibble(int value) {
+    return char_for_nibble(value & 0x0f);
+}
+
+
+static void Xprintf_hexdump(const void * data, int size) {
+    char buffer[4];
+    buffer[2] = ' ';
+    buffer[3] =  0;
+    const uint8_t * ptr = (const uint8_t *) data;
+    while (size > 0) {
+        uint8_t byte = *ptr++;
+        buffer[0] = char_for_high_nibble(byte);
+        buffer[1] = char_for_low_nibble(byte);
+        _print->printf("%s", buffer);
+        size--;
+    }
+    printf("\n");
+}
+
+
+
+static char log_message_buffer[256];
+
+static void hci_dump_embedded_stdout_timestamp(void) {
+    uint32_t time_ms = btstack_run_loop_get_time_ms();
+    int      seconds = time_ms / 1000u;
+    int      minutes = seconds / 60;
+    unsigned int hours = minutes / 60;
+
+    uint16_t p_ms      = time_ms - (seconds * 1000u);
+    uint16_t p_seconds = seconds - (minutes * 60);
+    uint16_t p_minutes = minutes - (hours   * 60u);
+    _print->printf("[%02u:%02u:%02u.%03u] ", hours, p_minutes, p_seconds, p_ms);
+}
+
+static void hci_dump_embedded_stdout_packet(uint8_t packet_type, uint8_t in, uint8_t * packet, uint16_t len) {
     switch (packet_type) {
     case HCI_COMMAND_DATA_PACKET:
         _print->printf("CMD => ");
@@ -39,47 +114,55 @@ static void _log_packet(uint8_t packet_type, uint8_t in, uint8_t *packet, uint16
         _print->printf("EVT <= ");
         break;
     case HCI_ACL_DATA_PACKET:
-        _print->printf("ACL %s ", in ? "<=" : "=>");
+        if (in) {
+            _print->printf("ACL <= ");
+        } else {
+            _print->printf("ACL => ");
+        }
         break;
     case HCI_SCO_DATA_PACKET:
-        _print->printf("SCO %s ", in ? "<=" : "=>");
+        if (in) {
+            _print->printf("SCO <= ");
+        } else {
+            _print->printf("SCO => ");
+        }
         break;
     case HCI_ISO_DATA_PACKET:
-        _print->printf("ISO %s ", in ? "<=" : "=>");
+        if (in) {
+            _print->printf("ISO <= ");
+        } else {
+            _print->printf("ISO => ");
+        }
         break;
     case LOG_MESSAGE_PACKET:
         _print->printf("LOG -- %s\n", (char*) packet);
         return;
     default:
-        _print->printf("UNK(%x) %s ", packet_type, in ? "<=" : "=>");
-        break;
-    }
-
-    for (uint16_t i = 0; i < len; i++) {
-        _print->printf("%02X ", packet[i]);
-    }
-    _print->printf("\n");
-}
-
-static void _log_message(int log_level, const char * format, va_list argptr) {
-    (void)log_level;
-    char log_message_buffer[HCI_DUMP_MAX_MESSAGE_LEN];
-    if (!_print) {
         return;
     }
-    vsnprintf(log_message_buffer, sizeof(log_message_buffer), format, argptr);
-    _print->printf("[BT @%lu] LOG -- %s\n", millis(), log_message_buffer);
+    Xprintf_hexdump(packet, len);
 }
 
+static void hci_dump_embedded_stdout_log_packet(uint8_t packet_type, uint8_t in, uint8_t *packet, uint16_t len) {
+    hci_dump_embedded_stdout_timestamp();
+    hci_dump_embedded_stdout_packet(packet_type, in, packet, len);
+}
 
-static const hci_dump_t hci_dump_instance = {
-    NULL,
-    _log_packet,
-    _log_message
-};
-
+static void hci_dump_embedded_stdout_log_message(int log_level, const char * format, va_list argptr) {
+    UNUSED(log_level);
+    int len = vsnprintf(log_message_buffer, sizeof(log_message_buffer), format, argptr);
+    hci_dump_embedded_stdout_log_packet(LOG_MESSAGE_PACKET, 0, (uint8_t*) log_message_buffer, len);
+}
 
 void __EnableBluetoothDebug(Print &print) {
+    static const hci_dump_t hci_dump_instance = {
+        // void (*reset)(void);
+        NULL,
+        // void (*log_packet)(uint8_t packet_type, uint8_t in, uint8_t *packet, uint16_t len);
+        &hci_dump_embedded_stdout_log_packet,
+        // void (*log_message)(int log_level, const char * format, va_list argptr);
+        &hci_dump_embedded_stdout_log_message,
+    };
     _print = &print;
     hci_dump_init(&hci_dump_instance);
 }


### PR DESCRIPTION
Allows the BTStack tools to make Wireshark packet files and others access our debug logs.