### PR TITLE
Add a busywait callback to BT scan/pair

### DIFF
--- a/docs/bluetooth.rst
+++ b/docs/bluetooth.rst
@@ -1,8 +1,6 @@
 Bluetooth on PicoW Support
 ==========================
 
-As of the Pico-SDK version 1.5.0, the PicoW has **BETA** Bluetooth support.
-
 Enabling Bluetooth
 ------------------
 To enable Bluetooth (BT), use the ``Tools->IP/Bluetooth Stack`` menu.  It

--- a/libraries/BluetoothHCI/src/BluetoothHCI.cpp
+++ b/libraries/BluetoothHCI/src/BluetoothHCI.cpp
@@ -104,7 +104,7 @@ bool BluetoothHCI::running() {
     return _hciRunning;
 }
 
-std::vector<BTDeviceInfo> BluetoothHCI::scan(uint32_t mask, int scanTimeSec, bool async) {
+std::vector<BTDeviceInfo> BluetoothHCI::scan(uint32_t mask, int scanTimeSec, bool async, void (*idleFcn)(void *), void *idleFcnData) {
     _scanMask = mask;
     _btdList.reserve(MAX_DEVICES_TO_DISCOVER);
     _btdList.clear();
@@ -131,6 +131,9 @@ std::vector<BTDeviceInfo> BluetoothHCI::scan(uint32_t mask, int scanTimeSec, boo
     }
 
     while (_scanning) {
+        if (idleFcn) {
+            idleFcn(idleFcnData);
+        }
         delay(10);
     }
     DEBUGV("HCI::scan(): inquiry end, start name requests\n");
@@ -151,7 +154,7 @@ std::vector<BTDeviceInfo> BluetoothHCI::scan(uint32_t mask, int scanTimeSec, boo
     return _btdList;
 }
 
-std::vector<BTDeviceInfo> BluetoothHCI::scanBLE(uint32_t uuid, int scanTimeSec) {
+std::vector<BTDeviceInfo> BluetoothHCI::scanBLE(uint32_t uuid, int scanTimeSec, void (*idleFcn)(void *), void *idleFcnData) {
     _scanMask = uuid;
     _btdList.reserve(MAX_DEVICES_TO_DISCOVER);
     _btdList.clear();
@@ -177,6 +180,9 @@ std::vector<BTDeviceInfo> BluetoothHCI::scanBLE(uint32_t uuid, int scanTimeSec) 
     uint32_t scanStart = millis();
 
     while (_scanning && ((millis() - scanStart) < inquiryTime)) {
+        if (idleFcn) {
+            idleFcn(idleFcnData);
+        }
         delay(10);
     }
     DEBUGV("HCI::scanBLE(): inquiry end\n");

--- a/libraries/BluetoothHCI/src/BluetoothHCI.h
+++ b/libraries/BluetoothHCI/src/BluetoothHCI.h
@@ -41,11 +41,11 @@ public:
 
     static const uint32_t speaker_cod = 0x200000 | 0x040000 | 0x000400;  // Service Class: Rendering | Audio, Major Device Class: Audio
     static const uint32_t any_cod = 0;
-    std::vector<BTDeviceInfo> scan(uint32_t mask, int scanTimeSec = 5, bool async = false);
+    std::vector<BTDeviceInfo> scan(uint32_t mask, int scanTimeSec = 5, bool async = false, void (*idleFcn)(void *) = nullptr, void *idleFcnData = nullptr);
     bool scanAsyncDone();
     std::vector<BTDeviceInfo> scanAsyncResult();
 
-    std::vector<BTDeviceInfo> scanBLE(uint32_t uuid, int scanTimeSec = 5);
+    std::vector<BTDeviceInfo> scanBLE(uint32_t uuid, int scanTimeSec = 5, void (*idleFcn)(void *) = nullptr, void *idleFcnData = nullptr);
 
     void scanFree(); // Free allocated scan buffers
 

--- a/libraries/BluetoothHIDMaster/src/BluetoothHIDMaster.h
+++ b/libraries/BluetoothHIDMaster/src/BluetoothHIDMaster.h
@@ -87,8 +87,8 @@ public:
     bool connectJoystick();
     bool connectAny();
 
-    bool connectBLE(const uint8_t *addr, int addrType);
-    bool connectBLE();
+    bool connectBLE(const uint8_t *addr, int addrType, void (*idleFcn)(void *) = nullptr, void *idleFcnData = nullptr);
+    bool connectBLE(void (*idleFcn)(void *) = nullptr, void *idleFcnData = nullptr);
     const uint8_t *lastConnectedAddress() {
         return _lastAddr;
     }


### PR DESCRIPTION
Allows app to easily do things like blink LEDs or make sounds during the pairing process.

Update BLE example to use it to blink fast while trying to reconnect, and slow when trying to pair anew.