### PR TITLE
Avoid race condition w/ClientContext::close/abort

### DIFF
--- a/libraries/WiFi/src/include/ClientContext.h
+++ b/libraries/WiFi/src/include/ClientContext.h
@@ -64,6 +64,7 @@ public:
     }
 
     err_t abort() {
+        LWIPMutex m;
         if (_pcb) {
             DEBUGV(":abort\r\n");
             tcp_arg(_pcb, nullptr);
@@ -78,6 +79,7 @@ public:
     }
 
     err_t close() {
+        LWIPMutex m;
         err_t err = ERR_OK;
         if (_pcb) {
             DEBUGV(":close\r\n");


### PR DESCRIPTION
As identified and fixed by @functionpointer in #3265

It is possible for the tcp_pcb to disapper in the middle of teardown during close() or abort() causing a nullptr derefence or a use-after-free.

Avoid this by blocking the LWIP IRQ for the entirety of the methods.