### PR TITLE
ClientContext.h: Prevent double free by checking in wrapper

### DIFF
--- a/cores/rp2040/freertos/freertos-lwip.cpp
+++ b/cores/rp2040/freertos/freertos-lwip.cpp
@@ -150,7 +150,9 @@ static void lwipThread(void *params) {
             }
             case __tcp_arg: {
                 __tcp_arg_req *r = (__tcp_arg_req *)w.req;
-                __real_tcp_arg(r->pcb, r->arg);
+				if (r->pcb != NULL) {
+					__real_tcp_arg(r->pcb, r->arg);
+				}
                 break;
             }
             case __tcp_new: {
@@ -165,99 +167,157 @@ static void lwipThread(void *params) {
             }
             case __tcp_bind: {
                 __tcp_bind_req *r = (__tcp_bind_req *)w.req;
-                *(r->ret) = __real_tcp_bind(r->pcb, r->ipaddr, r->port);
+				if (r->pcb != NULL) {
+                	*(r->ret) = __real_tcp_bind(r->pcb, r->ipaddr, r->port);
+				} else {
+					*(r->ret) = ERR_PCB_IS_NULLPTR;
+				}
                 break;
             }
             case __tcp_bind_netif: {
                 __tcp_bind_netif_req *r = (__tcp_bind_netif_req *)w.req;
-                *(r->ret) = __real_tcp_bind_netif(r->pcb, r->netif);
+
+                if (r->pcb != NULL) {
+                    *(r->ret) = __real_tcp_bind_netif(r->pcb, r->netif);
+                } else {
+                    *(r->ret) = ERR_PCB_IS_NULLPTR;
+                }
                 break;
             }
             case __tcp_listen_with_backlog: {
                 __tcp_listen_with_backlog_req *r = (__tcp_listen_with_backlog_req *)w.req;
-                *(r->ret) = __real_tcp_listen_with_backlog(r->pcb, r->backlog);
+                if (r->pcb != NULL) {
+                    *(r->ret) = __real_tcp_listen_with_backlog(r->pcb, r->backlog);
+                } else {
+                    *(r->ret) = NULL;
+                }
                 break;
             }
 #if 0
             case __tcp_listen_with_backlog_and_err: {
                 __tcp_listen_with_backlog_and_err_req *r = (__tcp_listen_with_backlog_and_err_req *)w.req;
-                *(r->ret) = __real_tcp_listen_with_backlog_and_err(r->pcb, r->backlog, r->err);
+                if (r->pcb != NULL) {
+                    *(r->ret) = __real_tcp_listen_with_backlog_and_err(r->pcb, r->backlog, r->err);
+                } else {
+                    *(r->ret) = NULL;
+                    *(r->err) = ERR_PCB_IS_NULLPTR;
+                }
                 break;
             }
 #endif
             case __tcp_accept: {
                 __tcp_accept_req *r = (__tcp_accept_req *)w.req;
-                __real_tcp_accept(r->pcb, r->accept);
+                if (r->pcb != NULL) {
+                    __real_tcp_accept(r->pcb, r->accept);
+                }
                 break;
             }
             case __tcp_connect: {
                 __tcp_connect_req *r = (__tcp_connect_req *)w.req;
-                *(r->ret) = __real_tcp_connect(r->pcb, r->ipaddr, r->port, r->connected);
+                if (r->pcb != NULL) {
+                    *(r->ret) = __real_tcp_connect(r->pcb, r->ipaddr, r->port, r->connected);
+                } else {
+                    *(r->ret) = ERR_PCB_IS_NULLPTR;
+                }
                 break;
             }
             case __tcp_write: {
                 __tcp_write_req *r = (__tcp_write_req *)w.req;
-                *(r->ret) = __real_tcp_write(r->pcb, r->dataptr, r->len, r->apiflags);
+                if (r->pcb != NULL) {
+                    *(r->ret) = __real_tcp_write(r->pcb, r->dataptr, r->len, r->apiflags);
+                } else {
+                    *(r->ret) = ERR_PCB_IS_NULLPTR;
+                }
                 break;
             }
             case __tcp_sent: {
                 __tcp_sent_req *r = (__tcp_sent_req *)w.req;
-                __real_tcp_sent(r->pcb, r->sent);
+                if (r->pcb != NULL) {
+                    __real_tcp_sent(r->pcb, r->sent);
+                }
                 break;
             }
             case __tcp_recv: {
                 __tcp_recv_req *r = (__tcp_recv_req *)w.req;
-                __real_tcp_recv(r->pcb, r->recv);
+                if (r->pcb != NULL) {
+                    __real_tcp_recv(r->pcb, r->recv);
+                }
                 break;
             }
             case __tcp_recved: {
                 __tcp_recved_req *r = (__tcp_recved_req *)w.req;
-                __real_tcp_recved(r->pcb, r->len);
+                if (r->pcb != NULL) {
+                    __real_tcp_recved(r->pcb, r->len);
+                }
                 break;
             }
             case __tcp_poll: {
                 __tcp_poll_req *r = (__tcp_poll_req *)w.req;
-                __real_tcp_poll(r->pcb, r->poll, r->interval);
+                if (r->pcb != NULL) {
+                    __real_tcp_poll(r->pcb, r->poll, r->interval);
+                }
                 break;
             }
             case __tcp_close: {
                 __tcp_close_req *r = (__tcp_close_req *)w.req;
-                *(r->ret) = __real_tcp_close(r->pcb);
+                if (r->pcb != NULL) {
+                    *(r->ret) = __real_tcp_close(r->pcb);
+                } else {
+                    *(r->ret) = ERR_PCB_IS_NULLPTR;
+                }
                 break;
             }
             case __tcp_abort: {
                 __tcp_abort_req *r = (__tcp_abort_req *)w.req;
-                __real_tcp_abort(r->pcb);
+                if (r->pcb != NULL) {
+                    __real_tcp_abort(r->pcb);
+                }
                 break;
             }
             case __tcp_err: {
                 __tcp_err_req *r = (__tcp_err_req *)w.req;
-                __real_tcp_err(r->pcb, r->err);
+                if (r->pcb != NULL) {
+                    __real_tcp_err(r->pcb, r->err);
+                }
                 break;
             }
             case __tcp_output: {
                 __tcp_output_req *r = (__tcp_output_req *)w.req;
-                *(r->ret) = __real_tcp_output(r->pcb);
+                if (r->pcb != NULL) {
+                    *(r->ret) = __real_tcp_output(r->pcb);
+                } else {
+                    *(r->ret) = ERR_PCB_IS_NULLPTR;
+                }
                 break;
             }
             case __tcp_setprio: {
                 __tcp_setprio_req *r = (__tcp_setprio_req *)w.req;
-                __real_tcp_setprio(r->pcb, r->prio);
+                if (r->pcb != NULL) {
+                    __real_tcp_setprio(r->pcb, r->prio);
+                }
                 break;
             }
             case __tcp_shutdown: {
                 __tcp_shutdown_req *r = (__tcp_shutdown_req *)w.req;
-                *(r->ret) = __real_tcp_shutdown(r->pcb, r->shut_rx, r->shut_tx);
+                if (r->pcb != NULL) {
+                    *(r->ret) = __real_tcp_shutdown(r->pcb, r->shut_rx, r->shut_tx);
+                } else {
+                    *(r->ret) = ERR_PCB_IS_NULLPTR;
+                }
                 break;
             }
             case __tcp_backlog_delayed: {
                 __tcp_backlog_delayed_req *r = (__tcp_backlog_delayed_req *)w.req;
-                __real_tcp_backlog_delayed(r->pcb);
+                if (r->pcb != NULL) {
+                    __real_tcp_backlog_delayed(r->pcb);
+                }
                 break;
             }
             case __tcp_backlog_accepted: {
                 __tcp_backlog_accepted_req *r = (__tcp_backlog_accepted_req *)w.req;
-                __real_tcp_backlog_accepted(r->pcb);
+                if (r->pcb != NULL) {
+                    __real_tcp_backlog_accepted(r->pcb);
+                }
                 break;
             }
             case __udp_new: {
@@ -272,47 +332,77 @@ static void lwipThread(void *params) {
             }
             case  __udp_remove: {
                 __udp_remove_req *r = (__udp_remove_req *)w.req;
-                __real_udp_remove(r->pcb);
+                if (r->pcb != NULL) {
+                    __real_udp_remove(r->pcb);
+                }
                 break;
             }
             case __udp_bind: {
                 __udp_bind_req *r = (__udp_bind_req *)w.req;
-                *(r->ret) = __real_udp_bind(r->pcb, r->ipaddr, r->port);
+                if (r->pcb != NULL) {
+                    *(r->ret) = __real_udp_bind(r->pcb, r->ipaddr, r->port);
+                } else {
+                    *(r->ret) = ERR_PCB_IS_NULLPTR;
+                }
                 break;
             }
             case __udp_connect: {
                 __udp_connect_req *r = (__udp_connect_req *)w.req;
-                *(r->ret) = __real_udp_connect(r->pcb, r->ipaddr, r->port);
+                if (r->pcb != NULL) {
+                    *(r->ret) = __real_udp_connect(r->pcb, r->ipaddr, r->port);
+                } else {
+                    *(r->ret) = ERR_PCB_IS_NULLPTR;
+                }
                 break;
             }
             case __udp_disconnect: {
                 __udp_disconnect_req *r = (__udp_disconnect_req *)w.req;
-                *(r->ret) = __real_udp_disconnect(r->pcb);
+                if (r->pcb != NULL) {                
+                    *(r->ret) = __real_udp_disconnect(r->pcb);
+                }
                 break;
             }
             case __udp_send: {
                 __udp_send_req *r = (__udp_send_req *)w.req;
-                *(r->ret) = __real_udp_send(r->pcb, r->p);
+                if (r->pcb != NULL) {
+                    *(r->ret) = __real_udp_send(r->pcb, r->p);
+                } else {
+                    *(r->ret) = ERR_PCB_IS_NULLPTR;
+                }
                 break;
             }
             case __udp_recv: {
                 __udp_recv_req *r = (__udp_recv_req *)w.req;
-                __real_udp_recv(r->pcb, r->recv, r->recv_arg);
+                if (r->pcb != NULL) {
+                    __real_udp_recv(r->pcb, r->recv, r->recv_arg);
+                }
                 break;
             }
             case __udp_sendto: {
                 __udp_sendto_req *r = (__udp_sendto_req *)w.req;
-                *(r->ret) = __real_udp_sendto(r->pcb, r->p, r->dst_ip, r->dst_port);
+                if (r->pcb != NULL) {
+                    *(r->ret) = __real_udp_sendto(r->pcb, r->p, r->dst_ip, r->dst_port);
+                } else {
+                    *(r->ret) = ERR_PCB_IS_NULLPTR;
+                }
                 break;
             }
             case __udp_sendto_if: {
                 __udp_sendto_if_req *r = (__udp_sendto_if_req *)w.req;
-                *(r->ret) = __real_udp_sendto_if(r->pcb, r->p, r->dst_ip, r->dst_port, r->netif);
+                if (r->pcb != NULL) {
+                    *(r->ret) = __real_udp_sendto_if(r->pcb, r->p, r->dst_ip, r->dst_port, r->netif);
+                } else {
+                    *(r->ret) = ERR_PCB_IS_NULLPTR;
+                }
                 break;
             }
             case __udp_sendto_if_src: {
                 __udp_sendto_if_src_req *r = (__udp_sendto_if_src_req *)w.req;
-                *(r->ret) = __real_udp_sendto_if_src(r->pcb, r->p, r->dst_ip, r->dst_port, r->netif, r->src_ip);
+                if (r->pcb != NULL) {
+                    *(r->ret) = __real_udp_sendto_if_src(r->pcb, r->p, r->dst_ip, r->dst_port, r->netif, r->src_ip);
+                } else {
+                    *(r->ret) = ERR_PCB_IS_NULLPTR;
+                }
                 break;
             }
             case __sys_check_timeouts: {
@@ -341,32 +431,52 @@ static void lwipThread(void *params) {
             }
             case __raw_connect: {
                 __raw_connect_req *r = (__raw_connect_req *)w.req;
-                *(r->ret) = __real_raw_connect(r->pcb, r->ipaddr);
+                if (r->pcb != NULL) {
+                    *(r->ret) = __real_raw_connect(r->pcb, r->ipaddr);
+                } else {
+                    *(r->ret) = ERR_PCB_IS_NULLPTR;
+                }
                 break;
             }
             case __raw_recv: {
                 __raw_recv_req *r = (__raw_recv_req *)w.req;
-                __real_raw_recv(r->pcb, r->recv, r->recv_arg);
+                if (r->pcb != NULL) {
+                    __real_raw_recv(r->pcb, r->recv, r->recv_arg);
+                }
                 break;
             }
             case __raw_bind: {
                 __raw_bind_req *r = (__raw_bind_req *)w.req;
-                *(r->ret) = __real_raw_bind(r->pcb, r->ipaddr);
+                if (r->pcb != NULL) {
+                    *(r->ret) = __real_raw_bind(r->pcb, r->ipaddr);
+                } else {
+                    *(r->ret) = ERR_PCB_IS_NULLPTR;
+                }
                 break;
             }
             case __raw_sendto: {
                 __raw_sendto_req *r = (__raw_sendto_req *)w.req;
-                *(r->ret) = __real_raw_sendto(r->pcb, r->p, r->ipaddr);
+                if (r->pcb != NULL) {
+                    *(r->ret) = __real_raw_sendto(r->pcb, r->p, r->ipaddr);
+                } else {
+                    *(r->ret) = ERR_PCB_IS_NULLPTR;
+                }
                 break;
             }
             case __raw_send: {
                 __raw_send_req *r = (__raw_send_req *)w.req;
-                *(r->ret) = __real_raw_send(r->pcb, r->p);
+                if (r->pcb != NULL) {
+                    *(r->ret) = __real_raw_send(r->pcb, r->p);
+                } else {
+                    *(r->ret) = ERR_PCB_IS_NULLPTR;
+                }
                 break;
             }
             case __raw_remove: {
                 __raw_remove_req *r = (__raw_remove_req *)w.req;
-                __real_raw_remove(r->pcb);
+                if (r->pcb != NULL) {
+                    __real_raw_remove(r->pcb);
+                }
                 break;
             }
             case __netif_add: {

--- a/cores/rp2040/freertos/freertos-lwip.cpp
+++ b/cores/rp2040/freertos/freertos-lwip.cpp
@@ -150,9 +150,9 @@ static void lwipThread(void *params) {
             }
             case __tcp_arg: {
                 __tcp_arg_req *r = (__tcp_arg_req *)w.req;
-				if (r->pcb != NULL) {
-					__real_tcp_arg(r->pcb, r->arg);
-				}
+                if (r->pcb != NULL) {
+                    __real_tcp_arg(r->pcb, r->arg);
+                }
                 break;
             }
             case __tcp_new: {
@@ -167,11 +167,11 @@ static void lwipThread(void *params) {
             }
             case __tcp_bind: {
                 __tcp_bind_req *r = (__tcp_bind_req *)w.req;
-				if (r->pcb != NULL) {
-                	*(r->ret) = __real_tcp_bind(r->pcb, r->ipaddr, r->port);
-				} else {
-					*(r->ret) = ERR_PCB_IS_NULLPTR;
-				}
+                if (r->pcb != NULL) {
+                    *(r->ret) = __real_tcp_bind(r->pcb, r->ipaddr, r->port);
+                } else {
+                    *(r->ret) = ERR_PCB_IS_NULLPTR;
+                }
                 break;
             }
             case __tcp_bind_netif: {

--- a/cores/rp2040/lwip_wrap.cpp
+++ b/cores/rp2040/lwip_wrap.cpp
@@ -34,6 +34,7 @@
 #include <pico/btstack_run_loop_async_context.h>
 #ifdef __FREERTOS
 #include "freertos/freertos-lwip.h"
+
 #endif
 
 //auto_init_recursive_mutex(__lwipMutex); // Only for case with no Ethernet or PicoW, but still doing LWIP (PPP?)
@@ -202,7 +203,9 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        __real_tcp_arg(pcb, arg);
+		if (pcb != NULL) {
+			__real_tcp_arg(pcb, arg);
+		}
     }
 
     extern struct tcp_pcb *__real_tcp_new(void);
@@ -245,7 +248,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        return __real_tcp_bind(pcb, ipaddr, port);
+		if (pcb != NULL) {
+        	return __real_tcp_bind(pcb, ipaddr, port);
+		} else {
+			return ERR_PCB_IS_NULLPTR;
+		}
     }
 
     extern err_t __real_tcp_bind_netif(struct tcp_pcb *pcb, const struct netif *netif);
@@ -259,7 +266,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        return __real_tcp_bind_netif(pcb, netif);
+		if (pcb != NULL) {
+        	return __real_tcp_bind_netif(pcb, netif);
+		} else {
+			return ERR_PCB_IS_NULLPTR;
+		}
     }
 
     extern struct tcp_pcb *__real_tcp_listen_with_backlog(struct tcp_pcb *pcb, u8_t backlog);
@@ -273,7 +284,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        return __real_tcp_listen_with_backlog(pcb, backlog);
+		if (pcb != NULL) {
+	        return __real_tcp_listen_with_backlog(pcb, backlog);
+		} else {
+			return NULL;
+		}
     }
 
 #if 0
@@ -288,7 +303,12 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        return __real_tcp_listen_with_backlog_and_err(pcb, backlog, err);
+		if (pcb != NULL) {
+        	return __real_tcp_listen_with_backlog_and_err(pcb, backlog, err);
+		} else {
+			(*err) = ERR_PCB_IS_NULLPTR;
+			return NULL;
+		}
     }
 #endif
 
@@ -303,7 +323,9 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        __real_tcp_accept(pcb, accept);
+		if (pcb != NULL) {
+        	__real_tcp_accept(pcb, accept);
+		}
     }
 
     extern err_t __real_tcp_connect(struct tcp_pcb *pcb, ip_addr_t *ipaddr, u16_t port, err_t (* connected)(void *arg, struct tcp_pcb *tpcb, err_t err));
@@ -317,7 +339,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        return __real_tcp_connect(pcb, ipaddr, port, connected);
+		if (pcb != NULL) {
+        	return __real_tcp_connect(pcb, ipaddr, port, connected);
+		} else {
+			return ERR_PCB_IS_NULLPTR;
+		}
     }
 
     extern err_t __real_tcp_write(struct tcp_pcb *pcb, const void *dataptr, u16_t len, u8_t apiflags);
@@ -331,7 +357,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        return __real_tcp_write(pcb, dataptr, len, apiflags);
+		if (pcb != NULL) {
+        	return __real_tcp_write(pcb, dataptr, len, apiflags);
+		} else {
+			return ERR_PCB_IS_NULLPTR;
+		}
     }
 
     extern void __real_tcp_sent(struct tcp_pcb *pcb, err_t (* sent)(void *arg, struct tcp_pcb *tpcb, u16_t len));
@@ -344,7 +374,9 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        __real_tcp_sent(pcb, sent);
+		if (pcb != NULL) {
+        	__real_tcp_sent(pcb, sent);
+		}
     }
 
     extern void __real_tcp_recv(struct tcp_pcb *pcb, err_t (* recv)(void *arg, struct tcp_pcb *tpcb, struct pbuf *p, err_t err));
@@ -357,7 +389,9 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        __real_tcp_recv(pcb, recv);
+		if (pcb != NULL) {
+        	__real_tcp_recv(pcb, recv);
+		}
     }
 
     extern void __real_tcp_recved(struct tcp_pcb *pcb, u16_t len);
@@ -370,7 +404,9 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        __real_tcp_recved(pcb, len);
+		if (pcb != NULL) {
+        	__real_tcp_recved(pcb, len);
+		}
     }
 
     extern void __real_tcp_poll(struct tcp_pcb *pcb, err_t (* poll)(void *arg, struct tcp_pcb *tpcb), u8_t interval);
@@ -383,7 +419,9 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        __real_tcp_poll(pcb, poll, interval);
+		if (pcb != NULL) {
+        	__real_tcp_poll(pcb, poll, interval);
+		}
     }
 
     extern err_t __real_tcp_close(struct tcp_pcb *pcb);
@@ -397,7 +435,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        return __real_tcp_close(pcb);
+		if (pcb != NULL) {
+        	return __real_tcp_close(pcb);
+		} else {
+			return ERR_PCB_IS_NULLPTR;
+		}
     }
 
     extern void __real_tcp_abort(struct tcp_pcb *pcb);
@@ -410,7 +452,9 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        __real_tcp_abort(pcb);
+		if (pcb != NULL) {
+        	__real_tcp_abort(pcb);
+		}
     }
 
     extern void __real_tcp_err(struct tcp_pcb *pcb, void (* err)(void *arg, err_t err));
@@ -423,7 +467,9 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        __real_tcp_err(pcb, err);
+		if (pcb != NULL) {
+        	__real_tcp_err(pcb, err);
+		}
     }
 
     extern err_t __real_tcp_output(struct tcp_pcb *pcb);
@@ -437,7 +483,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        return __real_tcp_output(pcb);
+		if (pcb != NULL) {
+        	return __real_tcp_output(pcb);
+		} else {
+			return ERR_PCB_IS_NULLPTR;
+		}
     }
 
     extern void __real_tcp_setprio(struct tcp_pcb *pcb, u8_t prio);
@@ -450,7 +500,9 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        __real_tcp_setprio(pcb, prio);
+		if (pcb != NULL) {
+        	__real_tcp_setprio(pcb, prio);
+		}
     }
 
     extern err_t __real_tcp_shutdown(struct tcp_pcb *pcb, int shut_rx, int shut_tx);
@@ -464,7 +516,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        return __real_tcp_shutdown(pcb, shut_rx, shut_tx);
+		if (pcb != NULL) {
+        	return __real_tcp_shutdown(pcb, shut_rx, shut_tx);
+		} else {
+			return ERR_PCB_IS_NULLPTR;
+		}
     }
 
 
@@ -478,7 +534,9 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        __real_tcp_backlog_delayed(pcb);
+		if (pcb != NULL) {
+        	__real_tcp_backlog_delayed(pcb);
+		}
     }
 
     extern void __real_tcp_backlog_accepted(struct tcp_pcb* pcb);
@@ -491,8 +549,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        __real_tcp_backlog_accepted(pcb);
+		if (pcb != NULL) {
+        	__real_tcp_backlog_accepted(pcb);
+		}
     }
+
     extern struct udp_pcb *__real_udp_new(void);
     struct udp_pcb *__wrap_udp_new(void) {
 #ifdef __FREERTOS
@@ -531,7 +592,9 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        __real_udp_remove(pcb);
+		if (pcb != NULL) {
+        	__real_udp_remove(pcb);
+		}
     }
 
     extern err_t __real_udp_bind(struct udp_pcb *pcb, ip_addr_t *ipaddr, u16_t port);
@@ -545,7 +608,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        return __real_udp_bind(pcb, ipaddr, port);
+		if (pcb != NULL) {
+        	return __real_udp_bind(pcb, ipaddr, port);
+		} else {
+			return ERR_PCB_IS_NULLPTR;
+		}
     }
 
     extern err_t __real_udp_connect(struct udp_pcb *pcb, ip_addr_t *ipaddr, u16_t port);
@@ -559,7 +626,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        return __real_udp_connect(pcb, ipaddr, port);
+		if (pcb != NULL) {
+        	return __real_udp_connect(pcb, ipaddr, port);
+		} else {
+			return ERR_PCB_IS_NULLPTR;
+		}
     }
 
     extern err_t __real_udp_disconnect(struct udp_pcb *pcb);
@@ -573,7 +644,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        return __real_udp_disconnect(pcb);
+		if (pcb != NULL) {
+        	return __real_udp_disconnect(pcb);
+		} else {
+			return ERR_PCB_IS_NULLPTR;
+		}
     }
 
     extern err_t __real_udp_send(struct udp_pcb *pcb, struct pbuf *p);
@@ -587,7 +662,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        return __real_udp_send(pcb, p);
+		if (pcb != NULL) {
+        	return __real_udp_send(pcb, p);
+		} else {
+			return ERR_PCB_IS_NULLPTR;
+		}
     }
 
     extern void __real_udp_recv(struct udp_pcb *pcb, void (* recv)(void *arg, struct udp_pcb *upcb, struct pbuf *p, ip_addr_t *addr, u16_t port), void *recv_arg);
@@ -600,7 +679,9 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        __real_udp_recv(pcb, recv, recv_arg);
+		if (pcb != NULL) {
+        	__real_udp_recv(pcb, recv, recv_arg);
+		}
     }
 
     extern err_t __real_udp_sendto(struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *dst_ip, u16_t dst_port);
@@ -614,7 +695,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        return __real_udp_sendto(pcb, p, dst_ip, dst_port);
+		if (pcb != NULL) {
+        	return __real_udp_sendto(pcb, p, dst_ip, dst_port);
+		} else {
+			return ERR_PCB_IS_NULLPTR;
+		}
     }
 
     extern err_t __real_udp_sendto_if(struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *dst_ip, u16_t dst_port, struct netif *netif);
@@ -628,7 +713,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        return __real_udp_sendto_if(pcb, p, dst_ip, dst_port, netif);
+		if (pcb != NULL) {
+        	return __real_udp_sendto_if(pcb, p, dst_ip, dst_port, netif);
+		} else {
+			return ERR_PCB_IS_NULLPTR;
+		}
     }
 
     extern err_t __real_udp_sendto_if_src(struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *dst_ip, u16_t dst_port, struct netif *netif, const ip_addr_t *src_ip);
@@ -642,7 +731,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        return __real_udp_sendto_if_src(pcb, p, dst_ip, dst_port, netif, src_ip);
+		if (pcb != NULL) {
+        	return __real_udp_sendto_if_src(pcb, p, dst_ip, dst_port, netif, src_ip);
+		} else {
+			return ERR_PCB_IS_NULLPTR;
+		}
     }
 
     // sys_check_timeouts is special case because the async process will call it.  If we're already in a timeout check, just do a noop
@@ -725,7 +818,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        return __real_raw_connect(pcb, ipaddr);
+		if (pcb != NULL) {
+        	return __real_raw_connect(pcb, ipaddr);
+		} else {
+			return ERR_PCB_IS_NULLPTR;
+		}
     }
 
     extern void __real_raw_recv(struct raw_pcb *pcb, raw_recv_fn recv, void *recv_arg);
@@ -738,7 +835,9 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        __real_raw_recv(pcb, recv, recv_arg);
+		if (pcb != NULL) {
+        	__real_raw_recv(pcb, recv, recv_arg);
+		}
     }
 
     extern err_t __real_raw_bind(struct raw_pcb *pcb, const ip_addr_t *ipaddr);
@@ -752,7 +851,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        return __real_raw_bind(pcb, ipaddr);
+		if (pcb != NULL) {
+        	return __real_raw_bind(pcb, ipaddr);
+		} else {
+			return ERR_PCB_IS_NULLPTR;
+		}
     }
 
     extern err_t __real_raw_sendto(struct raw_pcb *pcb, struct pbuf *p, const ip_addr_t *ipaddr);
@@ -766,7 +869,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        return __real_raw_sendto(pcb, p, ipaddr);
+		if (pcb != NULL) {
+        	return __real_raw_sendto(pcb, p, ipaddr);
+		} else {
+			return ERR_PCB_IS_NULLPTR;
+		}
     }
 
     extern err_t __real_raw_send(struct raw_pcb *pcb, struct pbuf *p);
@@ -780,7 +887,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        return __real_raw_send(pcb, p);
+		if (pcb != NULL) {
+        	return __real_raw_send(pcb, p);
+		} else {
+			return ERR_PCB_IS_NULLPTR;
+		}
     }
 
     extern void __real_raw_remove(struct raw_pcb *pcb);
@@ -793,7 +904,9 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-        __real_raw_remove(pcb);
+		if (pcb != NULL) {
+        	__real_raw_remove(pcb);
+		}
     }
 
     extern struct netif *__real_netif_add(struct netif *netif, const ip4_addr_t *ipaddr, const ip4_addr_t *netmask, const ip4_addr_t *gw, void *state, netif_init_fn init, netif_input_fn input);

--- a/cores/rp2040/lwip_wrap.cpp
+++ b/cores/rp2040/lwip_wrap.cpp
@@ -203,9 +203,9 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-			__real_tcp_arg(pcb, arg);
-		}
+        if (pcb != nullptr) {
+            __real_tcp_arg(pcb, arg);
+        }
     }
 
     extern struct tcp_pcb *__real_tcp_new(void);
@@ -248,11 +248,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-        	return __real_tcp_bind(pcb, ipaddr, port);
-		} else {
-			return ERR_PCB_IS_NULLPTR;
-		}
+        if (pcb != nullptr) {
+            return __real_tcp_bind(pcb, ipaddr, port);
+        } else {
+            return ERR_PCB_IS_NULLPTR;
+        }
     }
 
     extern err_t __real_tcp_bind_netif(struct tcp_pcb *pcb, const struct netif *netif);
@@ -266,11 +266,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-        	return __real_tcp_bind_netif(pcb, netif);
-		} else {
-			return ERR_PCB_IS_NULLPTR;
-		}
+        if (pcb != nullptr) {
+            return __real_tcp_bind_netif(pcb, netif);
+        } else {
+            return ERR_PCB_IS_NULLPTR;
+        }
     }
 
     extern struct tcp_pcb *__real_tcp_listen_with_backlog(struct tcp_pcb *pcb, u8_t backlog);
@@ -284,11 +284,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-	        return __real_tcp_listen_with_backlog(pcb, backlog);
-		} else {
-			return NULL;
-		}
+        if (pcb != nullptr) {
+            return __real_tcp_listen_with_backlog(pcb, backlog);
+        } else {
+            return nullptr;
+        }
     }
 
 #if 0
@@ -303,12 +303,12 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-        	return __real_tcp_listen_with_backlog_and_err(pcb, backlog, err);
-		} else {
-			(*err) = ERR_PCB_IS_NULLPTR;
-			return NULL;
-		}
+        if (pcb != nullptr) {
+            return __real_tcp_listen_with_backlog_and_err(pcb, backlog, err);
+        } else {
+            (*err) = ERR_PCB_IS_NULLPTR;
+            return nullptr;
+        }
     }
 #endif
 
@@ -323,9 +323,9 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-        	__real_tcp_accept(pcb, accept);
-		}
+        if (pcb != nullptr) {
+            __real_tcp_accept(pcb, accept);
+        }
     }
 
     extern err_t __real_tcp_connect(struct tcp_pcb *pcb, ip_addr_t *ipaddr, u16_t port, err_t (* connected)(void *arg, struct tcp_pcb *tpcb, err_t err));
@@ -339,11 +339,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-        	return __real_tcp_connect(pcb, ipaddr, port, connected);
-		} else {
-			return ERR_PCB_IS_NULLPTR;
-		}
+        if (pcb != nullptr) {
+            return __real_tcp_connect(pcb, ipaddr, port, connected);
+        } else {
+            return ERR_PCB_IS_NULLPTR;
+        }
     }
 
     extern err_t __real_tcp_write(struct tcp_pcb *pcb, const void *dataptr, u16_t len, u8_t apiflags);
@@ -357,11 +357,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-        	return __real_tcp_write(pcb, dataptr, len, apiflags);
-		} else {
-			return ERR_PCB_IS_NULLPTR;
-		}
+        if (pcb != nullptr) {
+            return __real_tcp_write(pcb, dataptr, len, apiflags);
+        } else {
+            return ERR_PCB_IS_NULLPTR;
+        }
     }
 
     extern void __real_tcp_sent(struct tcp_pcb *pcb, err_t (* sent)(void *arg, struct tcp_pcb *tpcb, u16_t len));
@@ -374,9 +374,9 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-        	__real_tcp_sent(pcb, sent);
-		}
+        if (pcb != nullptr) {
+            __real_tcp_sent(pcb, sent);
+        }
     }
 
     extern void __real_tcp_recv(struct tcp_pcb *pcb, err_t (* recv)(void *arg, struct tcp_pcb *tpcb, struct pbuf *p, err_t err));
@@ -389,9 +389,9 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-        	__real_tcp_recv(pcb, recv);
-		}
+        if (pcb != nullptr) {
+            __real_tcp_recv(pcb, recv);
+        }
     }
 
     extern void __real_tcp_recved(struct tcp_pcb *pcb, u16_t len);
@@ -404,9 +404,9 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-        	__real_tcp_recved(pcb, len);
-		}
+        if (pcb != nullptr) {
+            __real_tcp_recved(pcb, len);
+        }
     }
 
     extern void __real_tcp_poll(struct tcp_pcb *pcb, err_t (* poll)(void *arg, struct tcp_pcb *tpcb), u8_t interval);
@@ -419,9 +419,9 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-        	__real_tcp_poll(pcb, poll, interval);
-		}
+        if (pcb != nullptr) {
+            __real_tcp_poll(pcb, poll, interval);
+        }
     }
 
     extern err_t __real_tcp_close(struct tcp_pcb *pcb);
@@ -435,11 +435,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-        	return __real_tcp_close(pcb);
-		} else {
-			return ERR_PCB_IS_NULLPTR;
-		}
+        if (pcb != nullptr) {
+            return __real_tcp_close(pcb);
+        } else {
+            return ERR_PCB_IS_NULLPTR;
+        }
     }
 
     extern void __real_tcp_abort(struct tcp_pcb *pcb);
@@ -452,9 +452,9 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-        	__real_tcp_abort(pcb);
-		}
+        if (pcb != nullptr) {
+            __real_tcp_abort(pcb);
+        }
     }
 
     extern void __real_tcp_err(struct tcp_pcb *pcb, void (* err)(void *arg, err_t err));
@@ -467,9 +467,9 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-        	__real_tcp_err(pcb, err);
-		}
+        if (pcb != nullptr) {
+            __real_tcp_err(pcb, err);
+        }
     }
 
     extern err_t __real_tcp_output(struct tcp_pcb *pcb);
@@ -483,11 +483,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-        	return __real_tcp_output(pcb);
-		} else {
-			return ERR_PCB_IS_NULLPTR;
-		}
+        if (pcb != nullptr) {
+            return __real_tcp_output(pcb);
+        } else {
+            return ERR_PCB_IS_NULLPTR;
+        }
     }
 
     extern void __real_tcp_setprio(struct tcp_pcb *pcb, u8_t prio);
@@ -500,9 +500,9 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-        	__real_tcp_setprio(pcb, prio);
-		}
+        if (pcb != nullptr) {
+            __real_tcp_setprio(pcb, prio);
+        }
     }
 
     extern err_t __real_tcp_shutdown(struct tcp_pcb *pcb, int shut_rx, int shut_tx);
@@ -516,11 +516,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-        	return __real_tcp_shutdown(pcb, shut_rx, shut_tx);
-		} else {
-			return ERR_PCB_IS_NULLPTR;
-		}
+        if (pcb != nullptr) {
+            return __real_tcp_shutdown(pcb, shut_rx, shut_tx);
+        } else {
+            return ERR_PCB_IS_NULLPTR;
+        }
     }
 
 
@@ -534,9 +534,9 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-        	__real_tcp_backlog_delayed(pcb);
-		}
+        if (pcb != nullptr) {
+            __real_tcp_backlog_delayed(pcb);
+        }
     }
 
     extern void __real_tcp_backlog_accepted(struct tcp_pcb* pcb);
@@ -549,9 +549,9 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-        	__real_tcp_backlog_accepted(pcb);
-		}
+        if (pcb != nullptr) {
+            __real_tcp_backlog_accepted(pcb);
+        }
     }
 
     extern struct udp_pcb *__real_udp_new(void);
@@ -592,9 +592,9 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-        	__real_udp_remove(pcb);
-		}
+        if (pcb != nullptr) {
+            __real_udp_remove(pcb);
+        }
     }
 
     extern err_t __real_udp_bind(struct udp_pcb *pcb, ip_addr_t *ipaddr, u16_t port);
@@ -608,11 +608,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-        	return __real_udp_bind(pcb, ipaddr, port);
-		} else {
-			return ERR_PCB_IS_NULLPTR;
-		}
+        if (pcb != nullptr) {
+            return __real_udp_bind(pcb, ipaddr, port);
+        } else {
+            return ERR_PCB_IS_NULLPTR;
+        }
     }
 
     extern err_t __real_udp_connect(struct udp_pcb *pcb, ip_addr_t *ipaddr, u16_t port);
@@ -626,11 +626,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-        	return __real_udp_connect(pcb, ipaddr, port);
-		} else {
-			return ERR_PCB_IS_NULLPTR;
-		}
+        if (pcb != nullptr) {
+            return __real_udp_connect(pcb, ipaddr, port);
+        } else {
+            return ERR_PCB_IS_NULLPTR;
+        }
     }
 
     extern err_t __real_udp_disconnect(struct udp_pcb *pcb);
@@ -644,11 +644,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-        	return __real_udp_disconnect(pcb);
-		} else {
-			return ERR_PCB_IS_NULLPTR;
-		}
+        if (pcb != nullptr) {
+            return __real_udp_disconnect(pcb);
+        } else {
+            return ERR_PCB_IS_NULLPTR;
+        }
     }
 
     extern err_t __real_udp_send(struct udp_pcb *pcb, struct pbuf *p);
@@ -662,11 +662,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-        	return __real_udp_send(pcb, p);
-		} else {
-			return ERR_PCB_IS_NULLPTR;
-		}
+        if (pcb != nullptr) {
+            return __real_udp_send(pcb, p);
+        } else {
+            return ERR_PCB_IS_NULLPTR;
+        }
     }
 
     extern void __real_udp_recv(struct udp_pcb *pcb, void (* recv)(void *arg, struct udp_pcb *upcb, struct pbuf *p, ip_addr_t *addr, u16_t port), void *recv_arg);
@@ -679,9 +679,9 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-        	__real_udp_recv(pcb, recv, recv_arg);
-		}
+        if (pcb != nullptr) {
+            __real_udp_recv(pcb, recv, recv_arg);
+        }
     }
 
     extern err_t __real_udp_sendto(struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *dst_ip, u16_t dst_port);
@@ -695,11 +695,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-        	return __real_udp_sendto(pcb, p, dst_ip, dst_port);
-		} else {
-			return ERR_PCB_IS_NULLPTR;
-		}
+        if (pcb != nullptr) {
+            return __real_udp_sendto(pcb, p, dst_ip, dst_port);
+        } else {
+            return ERR_PCB_IS_NULLPTR;
+        }
     }
 
     extern err_t __real_udp_sendto_if(struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *dst_ip, u16_t dst_port, struct netif *netif);
@@ -713,11 +713,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-        	return __real_udp_sendto_if(pcb, p, dst_ip, dst_port, netif);
-		} else {
-			return ERR_PCB_IS_NULLPTR;
-		}
+        if (pcb != nullptr) {
+            return __real_udp_sendto_if(pcb, p, dst_ip, dst_port, netif);
+        } else {
+            return ERR_PCB_IS_NULLPTR;
+        }
     }
 
     extern err_t __real_udp_sendto_if_src(struct udp_pcb *pcb, struct pbuf *p, const ip_addr_t *dst_ip, u16_t dst_port, struct netif *netif, const ip_addr_t *src_ip);
@@ -731,11 +731,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-        	return __real_udp_sendto_if_src(pcb, p, dst_ip, dst_port, netif, src_ip);
-		} else {
-			return ERR_PCB_IS_NULLPTR;
-		}
+        if (pcb != nullptr) {
+            return __real_udp_sendto_if_src(pcb, p, dst_ip, dst_port, netif, src_ip);
+        } else {
+            return ERR_PCB_IS_NULLPTR;
+        }
     }
 
     // sys_check_timeouts is special case because the async process will call it.  If we're already in a timeout check, just do a noop
@@ -818,11 +818,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-        	return __real_raw_connect(pcb, ipaddr);
-		} else {
-			return ERR_PCB_IS_NULLPTR;
-		}
+        if (pcb != nullptr) {
+            return __real_raw_connect(pcb, ipaddr);
+        } else {
+            return ERR_PCB_IS_NULLPTR;
+        }
     }
 
     extern void __real_raw_recv(struct raw_pcb *pcb, raw_recv_fn recv, void *recv_arg);
@@ -835,9 +835,9 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-        	__real_raw_recv(pcb, recv, recv_arg);
-		}
+        if (pcb != nullptr) {
+            __real_raw_recv(pcb, recv, recv_arg);
+        }
     }
 
     extern err_t __real_raw_bind(struct raw_pcb *pcb, const ip_addr_t *ipaddr);
@@ -851,11 +851,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-        	return __real_raw_bind(pcb, ipaddr);
-		} else {
-			return ERR_PCB_IS_NULLPTR;
-		}
+        if (pcb != nullptr) {
+            return __real_raw_bind(pcb, ipaddr);
+        } else {
+            return ERR_PCB_IS_NULLPTR;
+        }
     }
 
     extern err_t __real_raw_sendto(struct raw_pcb *pcb, struct pbuf *p, const ip_addr_t *ipaddr);
@@ -869,11 +869,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-        	return __real_raw_sendto(pcb, p, ipaddr);
-		} else {
-			return ERR_PCB_IS_NULLPTR;
-		}
+        if (pcb != nullptr) {
+            return __real_raw_sendto(pcb, p, ipaddr);
+        } else {
+            return ERR_PCB_IS_NULLPTR;
+        }
     }
 
     extern err_t __real_raw_send(struct raw_pcb *pcb, struct pbuf *p);
@@ -887,11 +887,11 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-        	return __real_raw_send(pcb, p);
-		} else {
-			return ERR_PCB_IS_NULLPTR;
-		}
+        if (pcb != nullptr) {
+            return __real_raw_send(pcb, p);
+        } else {
+            return ERR_PCB_IS_NULLPTR;
+        }
     }
 
     extern void __real_raw_remove(struct raw_pcb *pcb);
@@ -904,9 +904,9 @@ extern "C" {
         }
 #endif
         LWIPMutex m;
-		if (pcb != NULL) {
-        	__real_raw_remove(pcb);
-		}
+        if (pcb != nullptr) {
+            __real_raw_remove(pcb);
+        }
     }
 
     extern struct netif *__real_netif_add(struct netif *netif, const ip4_addr_t *ipaddr, const ip4_addr_t *netmask, const ip4_addr_t *gw, void *state, netif_init_fn init, netif_input_fn input);

--- a/cores/rp2040/lwip_wrap.h
+++ b/cores/rp2040/lwip_wrap.h
@@ -29,6 +29,7 @@
 #include <lwip/raw.h>
 #include <lwip/timeouts.h>
 
+#define ERR_PCB_IS_NULLPTR -200
 
 extern void ethernet_arch_lwip_begin() __attribute__((weak));
 extern void ethernet_arch_lwip_end() __attribute__((weak));

--- a/libraries/WiFi/src/include/ClientContext.h
+++ b/libraries/WiFi/src/include/ClientContext.h
@@ -153,28 +153,27 @@ public:
     }
 
     size_t availableForWrite() const {
-		// unsafe! _pcb can become NULL at any point
+        LwipMutexOrVTaskSuspendAll m;
         return _pcb ? tcp_sndbuf(_pcb) : 0;
     }
 
     void setNoDelay(bool nodelay) {
+        LwipMutexOrVTaskSuspendAll m;
         if (!_pcb) {
             return;
         }
         if (nodelay) {
-			// unsafe! _pcb can become NULL at any point
             tcp_nagle_disable(_pcb);
         } else {
-			// unsafe! _pcb can become NULL at any point
             tcp_nagle_enable(_pcb);
         }
     }
 
     bool getNoDelay() const {
+        LwipMutexOrVTaskSuspendAll m;
         if (!_pcb) {
             return false;
         }
-		// unsafe! _pcb can become NULL at any point
         return tcp_nagle_disabled(_pcb);
     }
 
@@ -195,16 +194,16 @@ public:
             return 0;
         }
 
-		// extra unsafe: we are giving out a pointer into _pcb!
+        // extra unsafe: we are giving out a pointer into _pcb!
         return &_pcb->remote_ip;
     }
 
     uint16_t getRemotePort() const {
+        LwipMutexOrVTaskSuspendAll m;
         if (!_pcb) {
             return 0;
         }
 
-		// unsafe! _pcb can become NULL at any point
         return _pcb->remote_port;
     }
 
@@ -213,16 +212,16 @@ public:
             return 0;
         }
 
-		// extra unsafe: we are giving out a pointer into _pcb!
+        // extra unsafe: we are giving out a pointer into _pcb!
         return &_pcb->local_ip;
     }
 
     uint16_t getLocalPort() const {
+        LwipMutexOrVTaskSuspendAll m;
         if (!_pcb) {
             return 0;
         }
 
-		// unsafe! _pcb can become NULL at any point
         return _pcb->local_port;
     }
 
@@ -355,7 +354,7 @@ public:
     }
 
     uint8_t state() const {
-		// unsafe! _pcb can become NULL between NULL check and ->state read
+        LwipMutexOrVTaskSuspendAll m;
         if (!_pcb || _pcb->state == CLOSE_WAIT || _pcb->state == CLOSING) {
             // CLOSED for WiFIClient::status() means nothing more can be written
             return CLOSED;
@@ -399,6 +398,7 @@ public:
     }
 
     void keepAlive(uint16_t idle_sec = TCP_DEFAULT_KEEPALIVE_IDLE_SEC, uint16_t intv_sec = TCP_DEFAULT_KEEPALIVE_INTERVAL_SEC, uint8_t count = TCP_DEFAULT_KEEPALIVE_COUNT) {
+        LwipMutexOrVTaskSuspendAll m;
         if (idle_sec && intv_sec && count) {
             _pcb->so_options |= SOF_KEEPALIVE;
             _pcb->keep_idle = (uint32_t)1000 * idle_sec;
@@ -410,22 +410,22 @@ public:
     }
 
     bool isKeepAliveEnabled() const {
-		// unsafe! _pcb can become NULL without warning
+        LwipMutexOrVTaskSuspendAll m;
         return !!(_pcb->so_options & SOF_KEEPALIVE);
     }
 
     uint16_t getKeepAliveIdle() const {
-		// unsafe! _pcb can become NULL without warning
+        LwipMutexOrVTaskSuspendAll m;
         return isKeepAliveEnabled() ? (_pcb->keep_idle + 500) / 1000 : 0;
     }
 
     uint16_t getKeepAliveInterval() const {
-		// unsafe! _pcb can become NULL without warning
+        LwipMutexOrVTaskSuspendAll m;
         return isKeepAliveEnabled() ? (_pcb->keep_intvl + 500) / 1000 : 0;
     }
 
     uint8_t getKeepAliveCount() const {
-		// unsafe! _pcb can become NULL without warning
+        LwipMutexOrVTaskSuspendAll m;
         return isKeepAliveEnabled() ? _pcb->keep_cnt : 0;
     }
 
@@ -528,9 +528,9 @@ protected:
             const auto remaining = _datalen - _written;
             size_t next_chunk_size;
             {
-				// trick to read safely maybe?
-				// should be safe against interrupts in single core
-				// but with dual core this may be problematic unless reads are atomic
+                // trick to read safely maybe?
+                // should be safe against interrupts in single core
+                // but with dual core this may be problematic unless reads are atomic
                 volatile tcp_pcb *pcb = _pcb;
                 if(!pcb) {
                     return false;
@@ -757,4 +757,27 @@ private:
     ClientContext* _next;
 
     bool _sync;
+
+    class LwipMutexOrVTaskSuspendAll:public LWIPMutex {
+        // When using IRQ-driven Ethernet, an interrupt can cause lwIP to free _pcb and call _error() at any time.
+        // So ClientContext can never assume _pcb != nullptr unless lwIP is blocked from running.
+
+        // On baremetal, we can simply use LwipMutex.
+
+        // On freeRTOS, that is solved by null checks in lwip_wrap.cpp, which happen after switching to the lwIP task.
+        // However, that does not work for macros like tcp_sndbuf or tcp_nagle_disable.
+        // Since they are extremely simple and fast, we just disable all task switching for those.
+    public:
+        LwipMutexOrVTaskSuspendAll() {
+#if defined(__FREERTOS)
+            vTaskSuspendAll();
+#endif
+        }
+
+        ~LwipMutexOrVTaskSuspendAll() {
+#if defined(__FREERTOS)
+            xTaskResumeAll();
+#endif
+        }
+    };
 };


### PR DESCRIPTION
Adds NULL checks in lwip_wrap.cpp to prevent double frees in ClientContext.h

See https://github.com/earlephilhower/arduino-pico/pull/3265 and https://github.com/earlephilhower/arduino-pico/pull/3368
It is an alternative to https://github.com/earlephilhower/arduino-pico/pull/3370

As mentioned in https://github.com/earlephilhower/arduino-pico/pull/3368#issuecomment-3897446991, this is currently incomplete as it does not all accesses of pcb go through the wrapper.