### PR TITLE
Add PicoLume Transceiver board

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ Read the [Contributing Guide](https://github.com/earlephilhower/arduino-pico/blo
 * Olimex Pico2XL
 * Olimex Pico2XXL
 * Olimex RP2040-Pico30
+* PicoLume Transceiver
 * Pimoroni PGA2040
 * Pimoroni Pico Plus 2
 * Pimoroni Pico Plus 2W

--- a/boards.txt
+++ b/boards.txt
@@ -24505,6 +24505,252 @@ olimex_rp2040pico30.menu.uploadmethod.picoprobe_cmsis_dap.upload.tool=picoprobe_
 olimex_rp2040pico30.menu.uploadmethod.picoprobe_cmsis_dap.upload.tool.default=picoprobe_cmsis_dap
 
 # -----------------------------------
+# PicoLume Transceiver
+# -----------------------------------
+picolume.name=PicoLume Transceiver
+picolume.vid.0=0x1209
+picolume.pid.0=0x2008
+picolume.vid.1=0x1209
+picolume.pid.1=0x2108
+picolume.vid.2=0x1209
+picolume.pid.2=0x6008
+picolume.vid.3=0x1209
+picolume.pid.3=0x6108
+picolume.vid.4=0x1209
+picolume.pid.4=0xa008
+picolume.vid.5=0x1209
+picolume.pid.5=0xa108
+picolume.vid.6=0x1209
+picolume.pid.6=0xe008
+picolume.vid.7=0x1209
+picolume.pid.7=0xe108
+picolume.upload_port.0.vid=0x1209
+picolume.upload_port.0.pid=0x2008
+picolume.upload_port.1.vid=0x1209
+picolume.upload_port.1.pid=0x2108
+picolume.upload_port.2.vid=0x1209
+picolume.upload_port.2.pid=0x6008
+picolume.upload_port.3.vid=0x1209
+picolume.upload_port.3.pid=0x6108
+picolume.upload_port.4.vid=0x1209
+picolume.upload_port.4.pid=0xa008
+picolume.upload_port.5.vid=0x1209
+picolume.upload_port.5.pid=0xa108
+picolume.upload_port.6.vid=0x1209
+picolume.upload_port.6.pid=0xe008
+picolume.upload_port.7.vid=0x1209
+picolume.upload_port.7.pid=0xe108
+picolume.build.usbvid=-DUSBD_VID=0x1209
+picolume.build.usbpid=-DUSBD_PID=0x2008
+picolume.build.usbpwr=-DUSBD_MAX_POWER_MA=250
+picolume.build.board=PICOLUME
+picolume.build.mcu=cortex-m0plus
+picolume.build.chip=rp2040
+picolume.build.toolchain=arm-none-eabi
+picolume.build.toolchainpkg=pqt-gcc
+picolume.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
+picolume.build.uf2family=--family rp2040
+picolume.build.variant=picolume
+picolume.upload.maximum_size=2097152
+picolume.upload.wait_for_upload_port=true
+picolume.upload.erase_cmd=
+picolume.serial.disableDTR=false
+picolume.serial.disableRTS=false
+picolume.build.f_cpu=125000000
+picolume.build.led=
+picolume.build.core=rp2040
+picolume.build.ldscript=memmap_default.ld
+picolume.build.boot2=boot2_w25q080_2_padded_checksum
+picolume.build.usb_manufacturer="PicoLume"
+picolume.build.usb_product="Transceiver"
+picolume.menu.flash.2097152_0=2MB (no FS)
+picolume.menu.flash.2097152_0.upload.maximum_size=2093056
+picolume.menu.flash.2097152_0.build.flash_total=2097152
+picolume.menu.flash.2097152_0.build.flash_length=2093056
+picolume.menu.flash.2097152_0.build.eeprom_start=270528512
+picolume.menu.flash.2097152_0.build.fs_start=270528512
+picolume.menu.flash.2097152_0.build.fs_end=270528512
+picolume.menu.flash.2097152_65536=2MB (Sketch: 1984KB, FS: 64KB)
+picolume.menu.flash.2097152_65536.upload.maximum_size=2027520
+picolume.menu.flash.2097152_65536.build.flash_total=2097152
+picolume.menu.flash.2097152_65536.build.flash_length=2027520
+picolume.menu.flash.2097152_65536.build.eeprom_start=270528512
+picolume.menu.flash.2097152_65536.build.fs_start=270462976
+picolume.menu.flash.2097152_65536.build.fs_end=270528512
+picolume.menu.flash.2097152_131072=2MB (Sketch: 1920KB, FS: 128KB)
+picolume.menu.flash.2097152_131072.upload.maximum_size=1961984
+picolume.menu.flash.2097152_131072.build.flash_total=2097152
+picolume.menu.flash.2097152_131072.build.flash_length=1961984
+picolume.menu.flash.2097152_131072.build.eeprom_start=270528512
+picolume.menu.flash.2097152_131072.build.fs_start=270397440
+picolume.menu.flash.2097152_131072.build.fs_end=270528512
+picolume.menu.flash.2097152_262144=2MB (Sketch: 1792KB, FS: 256KB)
+picolume.menu.flash.2097152_262144.upload.maximum_size=1830912
+picolume.menu.flash.2097152_262144.build.flash_total=2097152
+picolume.menu.flash.2097152_262144.build.flash_length=1830912
+picolume.menu.flash.2097152_262144.build.eeprom_start=270528512
+picolume.menu.flash.2097152_262144.build.fs_start=270266368
+picolume.menu.flash.2097152_262144.build.fs_end=270528512
+picolume.menu.flash.2097152_524288=2MB (Sketch: 1536KB, FS: 512KB)
+picolume.menu.flash.2097152_524288.upload.maximum_size=1568768
+picolume.menu.flash.2097152_524288.build.flash_total=2097152
+picolume.menu.flash.2097152_524288.build.flash_length=1568768
+picolume.menu.flash.2097152_524288.build.eeprom_start=270528512
+picolume.menu.flash.2097152_524288.build.fs_start=270004224
+picolume.menu.flash.2097152_524288.build.fs_end=270528512
+picolume.menu.flash.2097152_1048576=2MB (Sketch: 1MB, FS: 1MB)
+picolume.menu.flash.2097152_1048576.upload.maximum_size=1044480
+picolume.menu.flash.2097152_1048576.build.flash_total=2097152
+picolume.menu.flash.2097152_1048576.build.flash_length=1044480
+picolume.menu.flash.2097152_1048576.build.eeprom_start=270528512
+picolume.menu.flash.2097152_1048576.build.fs_start=269479936
+picolume.menu.flash.2097152_1048576.build.fs_end=270528512
+picolume.menu.freq.200=200 MHz
+picolume.menu.freq.200.build.f_cpu=200000000L
+picolume.menu.freq.50=50 MHz
+picolume.menu.freq.50.build.f_cpu=50000000L
+picolume.menu.freq.100=100 MHz
+picolume.menu.freq.100.build.f_cpu=100000000L
+picolume.menu.freq.120=120 MHz
+picolume.menu.freq.120.build.f_cpu=120000000L
+picolume.menu.freq.125=125 MHz
+picolume.menu.freq.125.build.f_cpu=125000000L
+picolume.menu.freq.128=128 MHz
+picolume.menu.freq.128.build.f_cpu=128000000L
+picolume.menu.freq.133=133 MHz
+picolume.menu.freq.133.build.f_cpu=133000000L
+picolume.menu.freq.150=150 MHz
+picolume.menu.freq.150.build.f_cpu=150000000L
+picolume.menu.freq.176=176 MHz
+picolume.menu.freq.176.build.f_cpu=176000000L
+picolume.menu.freq.225=225 MHz (Overclock)
+picolume.menu.freq.225.build.f_cpu=225000000L
+picolume.menu.freq.240=240 MHz (Overclock)
+picolume.menu.freq.240.build.f_cpu=240000000L
+picolume.menu.freq.250=250 MHz (Overclock)
+picolume.menu.freq.250.build.f_cpu=250000000L
+picolume.menu.freq.276=276 MHz (Overclock)
+picolume.menu.freq.276.build.f_cpu=276000000L
+picolume.menu.freq.300=300 MHz (Overclock)
+picolume.menu.freq.300.build.f_cpu=300000000L
+picolume.menu.opt.Small=Small (-Os) (standard)
+picolume.menu.opt.Small.build.flags.optimize=-Os
+picolume.menu.opt.Optimize=Optimize (-O)
+picolume.menu.opt.Optimize.build.flags.optimize=-O
+picolume.menu.opt.Optimize2=Optimize More (-O2)
+picolume.menu.opt.Optimize2.build.flags.optimize=-O2
+picolume.menu.opt.Optimize3=Optimize Even More (-O3)
+picolume.menu.opt.Optimize3.build.flags.optimize=-O3
+picolume.menu.opt.Fast=Fast (-Ofast) (maybe slower)
+picolume.menu.opt.Fast.build.flags.optimize=-Ofast
+picolume.menu.opt.Debug=Debug (-Og)
+picolume.menu.opt.Debug.build.flags.optimize=-Og
+picolume.menu.opt.Disabled=Disabled (-O0)
+picolume.menu.opt.Disabled.build.flags.optimize=-O0
+picolume.menu.os.none=None
+picolume.menu.os.none.build.os=
+picolume.menu.os.freertos=FreeRTOS SMP
+picolume.menu.os.freertos.build.os=-D__FREERTOS
+picolume.menu.profile.Disabled=Disabled
+picolume.menu.profile.Disabled.build.flags.profile=
+picolume.menu.profile.Enabled=Enabled
+picolume.menu.profile.Enabled.build.flags.profile=-pg -D__PROFILE
+picolume.menu.rtti.Disabled=Disabled
+picolume.menu.rtti.Disabled.build.flags.rtti=-fno-rtti
+picolume.menu.rtti.Enabled=Enabled
+picolume.menu.rtti.Enabled.build.flags.rtti=
+picolume.menu.stackprotect.Disabled=Disabled
+picolume.menu.stackprotect.Disabled.build.flags.stackprotect=
+picolume.menu.stackprotect.Enabled=Enabled
+picolume.menu.stackprotect.Enabled.build.flags.stackprotect=-fstack-protector-all
+picolume.menu.exceptions.Disabled=Disabled
+picolume.menu.exceptions.Disabled.build.flags.exceptions=-fno-exceptions
+picolume.menu.exceptions.Disabled.build.flags.libstdcpp=-lstdc++
+picolume.menu.exceptions.Enabled=Enabled
+picolume.menu.exceptions.Enabled.build.flags.exceptions=-fexceptions
+picolume.menu.exceptions.Enabled.build.flags.libstdcpp=-lstdc++-exc
+picolume.menu.dbgport.Disabled=Disabled
+picolume.menu.dbgport.Disabled.build.debug_port=
+picolume.menu.dbgport.Serial=Serial
+picolume.menu.dbgport.Serial.build.debug_port=-DDEBUG_RP2040_PORT=Serial
+picolume.menu.dbgport.Serial1=Serial1
+picolume.menu.dbgport.Serial1.build.debug_port=-DDEBUG_RP2040_PORT=Serial1
+picolume.menu.dbgport.Serial2=Serial2
+picolume.menu.dbgport.Serial2.build.debug_port=-DDEBUG_RP2040_PORT=Serial2
+picolume.menu.dbgport.SerialSemi=SerialSemi
+picolume.menu.dbgport.SerialSemi.build.debug_port=-DDEBUG_RP2040_PORT=SerialSemi
+picolume.menu.dbglvl.None=None
+picolume.menu.dbglvl.None.build.debug_level=
+picolume.menu.dbglvl.Core=Core
+picolume.menu.dbglvl.Core.build.debug_level=-DDEBUG_RP2040_CORE
+picolume.menu.dbglvl.SPI=SPI
+picolume.menu.dbglvl.SPI.build.debug_level=-DDEBUG_RP2040_SPI
+picolume.menu.dbglvl.Wire=Wire
+picolume.menu.dbglvl.Wire.build.debug_level=-DDEBUG_RP2040_WIRE
+picolume.menu.dbglvl.Bluetooth=Bluetooth
+picolume.menu.dbglvl.Bluetooth.build.debug_level=-DDEBUG_RP2040_BLUETOOTH
+picolume.menu.dbglvl.BLE=BLE
+picolume.menu.dbglvl.BLE.build.debug_level=-DDEBUG_RP2040_BLE
+picolume.menu.dbglvl.LWIP=LWIP
+picolume.menu.dbglvl.LWIP.build.debug_level=-DLWIP_DEBUG=1
+picolume.menu.dbglvl.All=All
+picolume.menu.dbglvl.All.build.debug_level=-DDEBUG_RP2040_WIRE -DDEBUG_RP2040_SPI -DDEBUG_RP2040_CORE -DDEBUG_RP2040_BLUETOOTH -DDEBUG_RP2040_BLE -DLWIP_DEBUG=1
+picolume.menu.dbglvl.NDEBUG=NDEBUG
+picolume.menu.dbglvl.NDEBUG.build.debug_level=-DNDEBUG
+picolume.menu.usbstack.picosdk=Pico SDK
+picolume.menu.usbstack.picosdk.build.usbstack_flags=
+picolume.menu.usbstack.tinyusb=Adafruit TinyUSB
+picolume.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+picolume.menu.usbstack.tinyusb_host=Adafruit TinyUSB Host (native)
+picolume.menu.usbstack.tinyusb_host.build.usbstack_flags=-DUSE_TINYUSB -DUSE_TINYUSB_HOST "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+picolume.menu.usbstack.nousb=No USB
+picolume.menu.usbstack.nousb.build.usbstack_flags="-DNO_USB -DDISABLE_USB_SERIAL -I{runtime.platform.path}/tools/libpico"
+picolume.menu.ipbtstack.ipv4only=IPv4 Only
+picolume.menu.ipbtstack.ipv4only.build.libpicow=liblwip.a
+picolume.menu.ipbtstack.ipv4only.build.libpicowdefs=-DLWIP_IPV6=0 -DLWIP_IPV4=1
+picolume.menu.ipbtstack.ipv4ipv6=IPv4 + IPv6
+picolume.menu.ipbtstack.ipv4ipv6.build.libpicow=liblwip.a
+picolume.menu.ipbtstack.ipv4ipv6.build.libpicowdefs=-DLWIP_IPV6=1 -DLWIP_IPV4=1
+picolume.menu.ipbtstack.ipv4btcble=IPv4 + Bluetooth
+picolume.menu.ipbtstack.ipv4btcble.build.libpicow=liblwip-bt.a
+picolume.menu.ipbtstack.ipv4btcble.build.libpicowdefs=-DLWIP_IPV6=0 -DLWIP_IPV4=1 -DENABLE_CLASSIC=1 -DENABLE_BLE=1 -DCYW43_ENABLE_BLUETOOTH=1
+picolume.menu.ipbtstack.ipv4ipv6btcble=IPv4 + IPv6 + Bluetooth
+picolume.menu.ipbtstack.ipv4ipv6btcble.build.libpicow=liblwip-bt.a
+picolume.menu.ipbtstack.ipv4ipv6btcble.build.libpicowdefs=-DLWIP_IPV6=1 -DLWIP_IPV4=1 -DENABLE_CLASSIC=1 -DENABLE_BLE=1 -DCYW43_ENABLE_BLUETOOTH=1
+picolume.menu.ipbtstack.ipv4onlybig=IPv4 Only - 32K
+picolume.menu.ipbtstack.ipv4onlybig.build.libpicow=liblwip.a
+picolume.menu.ipbtstack.ipv4onlybig.build.libpicowdefs=-DLWIP_IPV6=0 -DLWIP_IPV4=1 -D__LWIP_MEMMULT=2
+picolume.menu.ipbtstack.ipv4ipv6big=IPv4 + IPv6 - 32K
+picolume.menu.ipbtstack.ipv4ipv6big.build.libpicow=liblwip.a
+picolume.menu.ipbtstack.ipv4ipv6big.build.libpicowdefs=-DLWIP_IPV6=1 -DLWIP_IPV4=1 -D__LWIP_MEMMULT=2
+picolume.menu.ipbtstack.ipv4btcblebig=IPv4 + Bluetooth - 32K
+picolume.menu.ipbtstack.ipv4btcblebig.build.libpicow=liblwip-bt.a
+picolume.menu.ipbtstack.ipv4btcblebig.build.libpicowdefs=-DLWIP_IPV6=0 -DLWIP_IPV4=1 -DENABLE_CLASSIC=1 -DENABLE_BLE=1 -DCYW43_ENABLE_BLUETOOTH=1 -D__LWIP_MEMMULT=2
+picolume.menu.ipbtstack.ipv4ipv6btcblebig=IPv4 + IPv6 + Bluetooth - 32K
+picolume.menu.ipbtstack.ipv4ipv6btcblebig.build.libpicow=liblwip-bt.a
+picolume.menu.ipbtstack.ipv4ipv6btcblebig.build.libpicowdefs=-DLWIP_IPV6=1 -DLWIP_IPV4=1 -DENABLE_CLASSIC=1 -DENABLE_BLE=1 -DCYW43_ENABLE_BLUETOOTH=1 -D__LWIP_MEMMULT=2
+picolume.menu.uploadmethod.default=Default (UF2)
+picolume.menu.uploadmethod.default.build.ram_length=256k
+picolume.menu.uploadmethod.default.build.debugscript=picoprobe_cmsis_dap.tcl
+picolume.menu.uploadmethod.default.upload.maximum_data_size=262144
+picolume.menu.uploadmethod.default.upload.tool=uf2conv
+picolume.menu.uploadmethod.default.upload.tool.default=uf2conv
+picolume.menu.uploadmethod.default.upload.tool.network=uf2conv-network
+picolume.menu.uploadmethod.picotool=Picotool
+picolume.menu.uploadmethod.picotool.build.ram_length=256k
+picolume.menu.uploadmethod.picotool.build.debugscript=picoprobe.tcl
+picolume.menu.uploadmethod.picotool.build.picodebugflags=-DENABLE_PICOTOOL_USB
+picolume.menu.uploadmethod.picotool.upload.maximum_data_size=262144
+picolume.menu.uploadmethod.picotool.upload.tool=picotool
+picolume.menu.uploadmethod.picotool.upload.tool.default=picotool
+picolume.menu.uploadmethod.picoprobe_cmsis_dap=Picoprobe/Debugprobe (CMSIS-DAP)
+picolume.menu.uploadmethod.picoprobe_cmsis_dap.build.ram_length=256k
+picolume.menu.uploadmethod.picoprobe_cmsis_dap.build.debugscript=picoprobe_cmsis_dap.tcl
+picolume.menu.uploadmethod.picoprobe_cmsis_dap.upload.maximum_data_size=262144
+picolume.menu.uploadmethod.picoprobe_cmsis_dap.upload.tool=picoprobe_cmsis_dap
+picolume.menu.uploadmethod.picoprobe_cmsis_dap.upload.tool.default=picoprobe_cmsis_dap
+
+# -----------------------------------
 # Pimoroni PGA2040
 # -----------------------------------
 pimoroni_pga2040.name=Pimoroni PGA2040

--- a/package/package_pico_index.template.json
+++ b/package/package_pico_index.template.json
@@ -264,6 +264,9 @@
                      "name": "Olimex RP2040-Pico30"
                   },
                   {
+                     "name": "PicoLume Transceiver"
+                  },
+                  {
                      "name": "Pimoroni PGA2040"
                   },
                   {

--- a/tools/json/picolume.json
+++ b/tools/json/picolume.json
@@ -1,0 +1,56 @@
+{
+    "build": {
+        "arduino": {
+            "earlephilhower": {
+                "boot2_source": "boot2_w25q080_2_padded_checksum.S",
+                "usb_vid": "0x1209",
+                "usb_pid": "0x2008"
+            }
+        },
+        "core": "earlephilhower",
+        "cpu": "cortex-m0plus",
+        "extra_flags": "-DARDUINO_PICOLUME -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=250 ",
+        "f_cpu": "133000000L",
+        "hwids": [
+            [
+                "0x2E8A",
+                "0x00C0"
+            ],
+            [
+                "0x1209",
+                "0x2008"
+            ]
+        ],
+        "mcu": "rp2040",
+        "variant": "picolume"
+    },
+    "debug": {
+        "jlink_device": "RP2040_M0_0",
+        "openocd_target": "rp2040.cfg",
+        "svd_path": "rp2040.svd"
+    },
+    "frameworks": [
+        "arduino",
+        "picosdk"
+    ],
+    "name": "Transceiver",
+    "upload": {
+        "maximum_ram_size": 262144,
+        "maximum_size": 2097152,
+        "require_upload_port": true,
+        "native_usb": true,
+        "use_1200bps_touch": true,
+        "wait_for_upload_port": false,
+        "protocol": "picotool",
+        "protocols": [
+            "blackmagic",
+            "cmsis-dap",
+            "jlink",
+            "raspberrypi-swd",
+            "picotool",
+            "picoprobe"
+        ]
+    },
+    "url": "https://picolume.com",
+    "vendor": "PicoLume"
+}

--- a/tools/makeboards.py
+++ b/tools/makeboards.py
@@ -652,6 +652,9 @@ MakeBoard("olimex_pico2xl", "rp2350", "Olimex", "Pico2XL", "0x15ba", "0x0026", 2
 MakeBoard("olimex_pico2xxl", "rp2350", "Olimex", "Pico2XXL", "0x15ba", "0x0026", 500, "OLIMEX_PICO2XXL", 16, 8, "none")
 MakeBoard("olimex_rp2040pico30", "rp2040", "Olimex", "RP2040-Pico30", "0x15ba", "0x0026", 250, "OLIMEX_RP2040_PICO30", 2, 0, "boot2_w25q080_2_padded_checksum")
 
+# PicoLume
+MakeBoard("picolume", "rp2040", "PicoLume", "Transceiver", "0x1209", "0x2008", 250, "PICOLUME", 2, 0, "boot2_w25q080_2_padded_checksum", None, "https://picolume.com")
+
 # Pimoroni
 MakeBoard("pimoroni_pga2040", "rp2040", "Pimoroni", "PGA2040", "0x2e8a", "0x1008", 250, "PIMORONI_PGA2040", 8, 0, "boot2_w25q64jv_4_padded_checksum")
 MakeBoard("pimoroni_pga2350", "rp2350", "Pimoroni", "PGA2350", "0x2e8a", "0x1018", 250, "PIMORONI_PGA2350", 16, 8, "none")

--- a/variants/picolume/pins_arduino.h
+++ b/variants/picolume/pins_arduino.h
@@ -1,0 +1,35 @@
+#pragma once
+
+// LEDs
+#define PIN_LED        (25u)
+
+// Serial
+#define PIN_SERIAL1_TX (0u)
+#define PIN_SERIAL1_RX (1u)
+
+#define PIN_SERIAL2_TX (8u)
+#define PIN_SERIAL2_RX (9u)
+
+// SPI
+#define PIN_SPI0_MISO  (16u)
+#define PIN_SPI0_MOSI  (19u)
+#define PIN_SPI0_SCK   (18u)
+#define PIN_SPI0_SS    (17u)
+
+#define PIN_SPI1_MISO  (12u)
+#define PIN_SPI1_MOSI  (15u)
+#define PIN_SPI1_SCK   (14u)
+#define PIN_SPI1_SS    (13u)
+
+// Wire
+#define PIN_WIRE0_SDA  (4u)
+#define PIN_WIRE0_SCL  (5u)
+
+#define PIN_WIRE1_SDA  (26u)
+#define PIN_WIRE1_SCL  (27u)
+
+#define SERIAL_HOWMANY (3u)
+#define SPI_HOWMANY    (2u)
+#define WIRE_HOWMANY   (2u)
+
+#include "../generic/common.h"


### PR DESCRIPTION
## Summary
- Add PicoLume Transceiver board support (RP2040, 2MB flash)
- VID: 0x1209, PID: 0x2008 (assigned via pid.codes)
- PicoLume is a wireless LED prop controller for synchronized light shows using RFM69 radio

## Changes
- `tools/makeboards.py`: Added MakeBoard() entry for PicoLume
- `variants/picolume/pins_arduino.h`: Pin definitions (I2C on 4/5, SPI0, standard RP2040 layout)
- `boards.txt`: Auto-generated by makeboards.py
- `tools/json/picolume.json`: Auto-generated by makeboards.py
- `package/package_pico_index.template.json`: Auto-generated by makeboards.py
- `README.md`: Added PicoLume Transceiver to supported boards list

## Product info
- Website: https://picolume.com
- USB IDs: https://pid.codes/1209/2008/