### PR TITLE
Solder Party RP2350 Stamp XL: add support for PSRAM and pin defs for DVI

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -30540,6 +30540,18 @@ solderparty_rp2350_stamp_xl.menu.freq.276=276 MHz (Overclock)
 solderparty_rp2350_stamp_xl.menu.freq.276.build.f_cpu=276000000L
 solderparty_rp2350_stamp_xl.menu.freq.300=300 MHz (Overclock)
 solderparty_rp2350_stamp_xl.menu.freq.300.build.f_cpu=300000000L
+solderparty_rp2350_stamp_xl.menu.psram.0mb=0MByte PSRAM
+solderparty_rp2350_stamp_xl.menu.psram.0mb.build.psram_length=0x000000
+solderparty_rp2350_stamp_xl.menu.psram.2mb=2MByte PSRAM
+solderparty_rp2350_stamp_xl.menu.psram.2mb.build.psram_length=0x200000
+solderparty_rp2350_stamp_xl.menu.psram.4mb=4MByte PSRAM
+solderparty_rp2350_stamp_xl.menu.psram.4mb.build.psram_length=0x400000
+solderparty_rp2350_stamp_xl.menu.psram.8mb=8MByte PSRAM
+solderparty_rp2350_stamp_xl.menu.psram.8mb.build.psram_length=0x800000
+solderparty_rp2350_stamp_xl.menu.psramfreq.freq109=109 MHz
+solderparty_rp2350_stamp_xl.menu.psramfreq.freq109.build.psram_freq=-DRP2350_PSRAM_MAX_SCK_HZ=109000000
+solderparty_rp2350_stamp_xl.menu.psramfreq.freq133=133 MHz
+solderparty_rp2350_stamp_xl.menu.psramfreq.freq133.build.psram_freq=-DRP2350_PSRAM_MAX_SCK_HZ=133000000
 solderparty_rp2350_stamp_xl.menu.opt.Small=Small (-Os) (standard)
 solderparty_rp2350_stamp_xl.menu.opt.Small.build.flags.optimize=-Os
 solderparty_rp2350_stamp_xl.menu.opt.Optimize=Optimize (-O)

--- a/tools/makeboards.py
+++ b/tools/makeboards.py
@@ -376,7 +376,7 @@ def MakeBoard(name, chip, vendor_name, product_name, vid, pid, pwr, boarddefine,
             BuildPSRAMCS(name)
             BuildPSRAM(name)
             BuildPSRAMFreq(name)
-        elif (name == "datanoisetv_picoadk_v2") or (name == "olimex_pico2bb48"):
+        elif (name == "datanoisetv_picoadk_v2") or (name == "olimex_pico2bb48") or (name == "solderparty_rp2350_stamp_xl"):
             # Optional, user needs to solder themselves
             BuildPSRAM(name)
             BuildPSRAMFreq(name)

--- a/variants/solderparty_rp2350_stamp_xl/pins_arduino.h
+++ b/variants/solderparty_rp2350_stamp_xl/pins_arduino.h
@@ -2,8 +2,10 @@
 
 // Pin definitions taken from:
 //    https://rp2xxx-stamp-carrier-xl.solder.party/
+//    https://www.solder.party/docs/rp2xxx-stamp-related/rp2350-stamp-xl/downloads/
 
 #define PICO_RP2350A 0 // RP2350B
+#define RP2350_PSRAM_CS (8u)
 
 // LEDs
 #define PIN_LED        (3u)
@@ -43,5 +45,15 @@
 #define SERIAL_HOWMANY (2u)
 #define SPI_HOWMANY    (2u)
 #define WIRE_HOWMANY   (2u)
+
+// DVI connector
+#define PIN_CKN (15u)
+#define PIN_CKP (14u)
+#define PIN_D0N (13u)
+#define PIN_D0P (12u)
+#define PIN_D1N (19u)
+#define PIN_D1P (18u)
+#define PIN_D2N (17u)
+#define PIN_D2P (16u)
 
 #include "../generic/common.h"


### PR DESCRIPTION
- added PSRAM CS pin definition
- added PSRAM size and speed menu entries
- added pin definitions for DVI connector (to be used with the Adafruit HSTX DVI library)

see also #3388