### PR TITLE
Add common PowerManager header location to include list

### DIFF
--- a/lib/core_inc.txt
+++ b/lib/core_inc.txt
@@ -33,6 +33,7 @@
 -iwithprefixbefore/pico-sdk/src/rp2_common/hardware_rtc/include
 -iwithprefixbefore/pico-sdk/src/rp2_common/hardware_pio/include
 -iwithprefixbefore/pico-sdk/src/rp2_common/hardware_pll/include
+-iwithprefixbefore/pico-sdk/src/rp2_common/hardware_powman/include
 -iwithprefixbefore/pico-sdk/src/rp2_common/hardware_pwm/include
 -iwithprefixbefore/pico-sdk/src/rp2_common/hardware_resets/include
 -iwithprefixbefore/pico-sdk/src/rp2_common/hardware_spi/include


### PR DESCRIPTION
Makes `#include "hardware/powman.h"` accessible.

Usefull for working with low power functionality as requested in https://github.com/earlephilhower/arduino-pico/issues/2528.

This is RP2350-only hardware but still in the "rp2_common" header. Code like https://github.com/raspberrypi/pico-extras/blob/master/src/rp2_common/pico_sleep/sleep.c makes a compile time decision to use the powman timer (always-on-timer / lposc) or RTC for RP2040.