### PR TITLE
fixed typo for variantchip:RP2350B

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -42617,8 +42617,8 @@ generic_rp2350.menu.freq.300=300 MHz (Overclock)
 generic_rp2350.menu.freq.300.build.f_cpu=300000000L
 generic_rp2350.menu.variantchip.RP2350A=RP2350A
 generic_rp2350.menu.variantchip.RP2350A.build.variantdefines=-D__PICO_RP2350A=1
-generic_rp2350.menu.variantchip.RP2530B=RP2530B
-generic_rp2350.menu.variantchip.RP2530B.build.variantdefines=-D__PICO_RP2350A=0
+generic_rp2350.menu.variantchip.RP2350B=RP2350B
+generic_rp2350.menu.variantchip.RP2350B.build.variantdefines=-D__PICO_RP2350A=0
 generic_rp2350.menu.psramcs.GPIOnone=None
 generic_rp2350.menu.psramcs.GPIOnone.build.psram_cs=
 generic_rp2350.menu.psramcs.GPIO0=GPIO 0

--- a/docs/contrib.rst
+++ b/docs/contrib.rst
@@ -89,7 +89,7 @@ code that only runs on this core, use the following define.
         ~~~ your changes ~~~
         #endif
 
-Identifying RP2040, RP2530A, or RP2350B
+Identifying RP2040, RP2350A, or RP2350B
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To check if a board is an original RP2040

--- a/tools/makeboards.py
+++ b/tools/makeboards.py
@@ -85,7 +85,7 @@ def BuildPSRAMFreq(name):
         print("%s.menu.psramfreq.freq%d.build.psram_freq=-DRP2350_PSRAM_MAX_SCK_HZ=%d" % (name, s, s * 1000000))
 
 def BuildRP2350Variant(name):
-    for l in [ ("RP2350A", "-D__PICO_RP2350A=1"), ("RP2530B", "-D__PICO_RP2350A=0") ]:
+    for l in [ ("RP2350A", "-D__PICO_RP2350A=1"), ("RP2350B", "-D__PICO_RP2350A=0") ]:
         print("%s.menu.variantchip.%s=%s" % (name, l[0], l[0]))
         print("%s.menu.variantchip.%s.build.variantdefines=%s" % (name, l[0], l[1]))
 

--- a/variants/pimoroni_pico_plus_2w/pins_arduino.h
+++ b/variants/pimoroni_pico_plus_2w/pins_arduino.h
@@ -51,7 +51,7 @@
 #define RP2350_PSRAM_CS         (47u)
 #define RP2350_PSRAM_MAX_SCK_HZ (109*1000*1000)
 
-#define PICO_RP2350A 0 // RP2530B
+#define PICO_RP2350A 0 // RP2350B
 
 // DVI connector
 #define PIN_CKN (15u)


### PR DESCRIPTION
There is a typo for variantchip RP2350B for the RP2350.