### PR TITLE
Swap defined WIRE0/WIRE1 i2c pins for Seeed XIAO rp2350

### DIFF
--- a/variants/seeed_xiao_rp2350/pins_arduino.h
+++ b/variants/seeed_xiao_rp2350/pins_arduino.h
@@ -57,16 +57,16 @@ static const uint8_t D18 = (9u);
 
 // Wire
 #define __WIRE0_DEVICE (i2c0)
-#define PIN_WIRE0_SDA  (16u)
-#define PIN_WIRE0_SCL  (17u)
+#define PIN_WIRE0_SDA  (6u)
+#define PIN_WIRE0_SCL  (7u)
 #define SDA            PIN_WIRE0_SDA
 #define SCL            PIN_WIRE0_SCL
 #define I2C_SDA        (SDA)
 #define I2C_SCL        (SCL)
 
 #define __WIRE1_DEVICE (i2c1)
-#define PIN_WIRE1_SDA  (6u)
-#define PIN_WIRE1_SCL  (7u)
+#define PIN_WIRE1_SDA  (16u)
+#define PIN_WIRE1_SCL  (17u)
 
 #define SERIAL_HOWMANY (3u)
 #define SPI_HOWMANY    (2u)

--- a/variants/seeed_xiao_rp2350/pins_arduino.h
+++ b/variants/seeed_xiao_rp2350/pins_arduino.h
@@ -56,7 +56,7 @@ static const uint8_t D18 = (9u);
 
 
 // Wire
-#define __WIRE0_DEVICE (i2c0)
+#define __WIRE0_DEVICE (i2c1)
 #define PIN_WIRE0_SDA  (6u)
 #define PIN_WIRE0_SCL  (7u)
 #define SDA            PIN_WIRE0_SDA
@@ -64,7 +64,7 @@ static const uint8_t D18 = (9u);
 #define I2C_SDA        (SDA)
 #define I2C_SCL        (SCL)
 
-#define __WIRE1_DEVICE (i2c1)
+#define __WIRE1_DEVICE (i2c0)
 #define PIN_WIRE1_SDA  (16u)
 #define PIN_WIRE1_SCL  (17u)
 


### PR DESCRIPTION
Found that default i2c `Wire` wasn't working on some recently purchased Seeed RP2350 XIAOs I've just opened, tracked it down to these pins apparently being swapped.

Can see this was looked at in #2808 and reported working there, so am a bit puzzled why it isn't working now unless I make this change...

Previously I used some RP2350 XIAOs that I had purchased a year or two ago, and I did not notice this issue, but they're not in my possession anymore so cannot re-check.  Almost wonder if there has been a hardware revision that has affected this somehow!

I should note I've tested this with `Wire` but not `Wire1`.  Without this patch, I could not get either `Wire` or `Wire1` to work in my project.