### PR TITLE
[BLEClient] Fix ignoring timeout parameter

### DIFF
--- a/libraries/BLE/src/BLEClient.cpp
+++ b/libraries/BLE/src/BLEClient.cpp
@@ -135,7 +135,7 @@ bool BLEClient::connect(BLEAddress a, uint32_t timeout) {
 }
 
 bool BLEClient::connect(BLEAdvertising &device, uint32_t timeoutsec) {
-    return connect(device.getAddress());
+    return connect(device.getAddress(), timeoutsec);
 }
 
 void BLEClient::disconnect() {


### PR DESCRIPTION
Currently, the passed `timeoutsec` parameter is ignored when connecting to a BLE device found by scanning. This PR passes the value to the "real" connection method so it can actually be used.