### PR TITLE
[BLE]: add flag for advertising service UUID.

### DIFF
--- a/docs/ble.rst
+++ b/docs/ble.rst
@@ -224,12 +224,13 @@ This call returns the current advertising object for any defined servers.  In ge
 sketches do not need to work with this call or ``BLEAdvertising`` at all, but this
 call lets you do things like add URLs or appearance information.
 
-BLE.startAdvertising()
+BLE.startAdvertising(bool advertiseServiceUUID)
 ----------------------
 
 After all services are created (see below) the sketch needs to use this call to start broadcasting
 for BLE clients to find it.  Call this after all services are defined, or after ``BLE.stopAdvertising()``
-and changing services or characteristics.  Without this call, your Pico won't be discoverable.
+and changing services or characteristics.  Without this call, your Pico won't be discoverable. The Boolean
+flag ``advertiseServiceUUID`` controls inclusion of the service UUID in the advertising data.
 
 BLE.stopAdvertising()
 ---------------------

--- a/libraries/BLE/src/BLE.cpp
+++ b/libraries/BLE/src/BLE.cpp
@@ -106,9 +106,9 @@ BLEAdvertising *BLEClass::advertising() {
     return &_advertising;
 }
 
-void BLEClass::startAdvertising() {
+void BLEClass::startAdvertising(bool advertiseServiceUUID) {
     if (_server) {
-        _server->prepareAdvertising(&_advertising);
+        _server->prepareAdvertising(&_advertising, advertiseServiceUUID);
     } else {
         // Build ATT with only the name
         att_db_util_init();

--- a/libraries/BLE/src/BLE.h
+++ b/libraries/BLE/src/BLE.h
@@ -52,7 +52,7 @@ public:
     BLEAddress address();
 
     // Advertising (31-byte broadcast)
-    void startAdvertising();
+    void startAdvertising(bool advertiseServiceUUID = true);
     void stopAdvertising();
 
     // All real work happens in a BLEServer or BLEClient

--- a/libraries/BLE/src/BLEServer.cpp
+++ b/libraries/BLE/src/BLEServer.cpp
@@ -40,7 +40,7 @@ void BLEServer::addService(BLEService *s) {
     _svc.push_back(s);
 }
 
-void BLEServer::prepareAdvertising(BLEAdvertising *adv) {
+void BLEServer::prepareAdvertising(BLEAdvertising *adv, bool advertiseServiceUUID) {
     att_db_util_init();
     att_db_util_hash_init();
 
@@ -56,7 +56,7 @@ void BLEServer::prepareAdvertising(BLEAdvertising *adv) {
         uuid = s->_svc;
         //        }
     }
-    if (uuid) {
+    if (uuid && advertiseServiceUUID) {
         adv->setPartialUUID(uuid);
     }
 

--- a/libraries/BLE/src/BLEServer.h
+++ b/libraries/BLE/src/BLEServer.h
@@ -61,7 +61,7 @@ protected:
 
     // Only BLEClass can make me
     BLEServer();
-    void prepareAdvertising(BLEAdvertising *adv);
+    void prepareAdvertising(BLEAdvertising *adv, bool advertiseServiceUUID = true);
     void setSecurity(BLESecurityMode m);
 
     uint16_t readHandler(uint16_t con_handle, uint16_t attribute_handle, uint16_t offset, uint8_t *buffer, uint16_t buffer_size);


### PR DESCRIPTION
Hi,

When using the BLE library with a 128-bit service UUID, the advertised name is limited to 8 letters due to the length of the advertised service data, thereby potentially truncating the name. This commit adds a boolean flag to control whether the service UUID is included in the advertising data.

This is achieved by conditionally setting the BLEAdvertising UUID so that it is only included in the data when enabled. Not sure if this is the most elegant solution, but it seems to work.

Best regards,
Dominic