### PR TITLE
Add clock speed reading before PSRAM direct mode

### DIFF
--- a/cores/rp2040/psram.cpp
+++ b/cores/rp2040/psram.cpp
@@ -165,7 +165,7 @@ size_t __no_inline_not_in_flash_func(psram_init)(uint cs_pin) {
     // unavailable while QMI direct mode is enabled)
     const int max_psram_freq = RP2350_PSRAM_MAX_SCK_HZ;
     const int clock_hz = clock_get_hz(clk_sys);
-    
+
     // Enable direct mode, PSRAM CS, clkdiv of 10.
     qmi_hw->direct_csr = 10 << QMI_DIRECT_CSR_CLKDIV_LSB | \
                          QMI_DIRECT_CSR_EN_BITS | \

--- a/cores/rp2040/psram.cpp
+++ b/cores/rp2040/psram.cpp
@@ -161,6 +161,11 @@ size_t __no_inline_not_in_flash_func(psram_init)(uint cs_pin) {
         return 0;
     }
 
+    // Read clock speed before entering direct mode (flash access is
+    // unavailable while QMI direct mode is enabled)
+    const int max_psram_freq = RP2350_PSRAM_MAX_SCK_HZ;
+    const int clock_hz = clock_get_hz(clk_sys);
+    
     // Enable direct mode, PSRAM CS, clkdiv of 10.
     qmi_hw->direct_csr = 10 << QMI_DIRECT_CSR_CLKDIV_LSB | \
                          QMI_DIRECT_CSR_EN_BITS | \
@@ -180,8 +185,6 @@ size_t __no_inline_not_in_flash_func(psram_init)(uint cs_pin) {
     // Using an rxdelay equal to the divisor isn't enough when running the APS6404 close to 133MHz.
     // So: don't allow running at divisor 1 above 100MHz (because delay of 2 would be too late),
     // and add an extra 1 to the rxdelay if the divided clock is > 100MHz (i.e. sys clock > 200MHz).
-    const int max_psram_freq = RP2350_PSRAM_MAX_SCK_HZ;
-    const int clock_hz = clock_get_hz(clk_sys);
     int divisor = (clock_hz + max_psram_freq - 1) / max_psram_freq;
     if (divisor == 1 && clock_hz > 100000000) {
         divisor = 2;


### PR DESCRIPTION
Read clock speed before enabling direct mode for PSRAM to ensure proper configuration.

Fix PSRAM init crash when system clock differs from default
Move clock_get_hz() call before QMI direct mode is enabled.
Flash access is unavailable during direct mode, causing a bus fault
on the instruction fetch when clock_configure_undivided is not
in the XIP cache. Confirmed via debugprobe on WeAct RP2350A.