### PR TITLE
feat: Add Soldered NULA Ethernet W55RP20 pin definitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ Read the [Contributing Guide](https://github.com/earlephilhower/arduino-pico/blo
 * Solder Party RP2040 Stamp
 * Solder Party RP2350 Stamp
 * Solder Party RP2350 Stamp XL
+* Soldered Electronics NULA Ethernet W55RP20
 * Soldered Electronics NULA RP2350
 * SparkFun IoT RedBoard RP2350
 * SparkFun MicroMod RP2040

--- a/boards.txt
+++ b/boards.txt
@@ -31321,6 +31321,236 @@ soldered_nula_rp2350.menu.uploadmethod.picoprobe_cmsis_dap.upload.tool=picoprobe
 soldered_nula_rp2350.menu.uploadmethod.picoprobe_cmsis_dap.upload.tool.default=picoprobe_cmsis_dap
 
 # -----------------------------------
+# Soldered Electronics NULA Ethernet W55RP20
+# -----------------------------------
+soldered_nula_ethernet_w55rp20.name=Soldered Electronics NULA Ethernet W55RP20
+soldered_nula_ethernet_w55rp20.vid.0=0x2e8a
+soldered_nula_ethernet_w55rp20.pid.0=0x1122
+soldered_nula_ethernet_w55rp20.vid.1=0x2e8a
+soldered_nula_ethernet_w55rp20.pid.1=0x5122
+soldered_nula_ethernet_w55rp20.vid.2=0x2e8a
+soldered_nula_ethernet_w55rp20.pid.2=0x9122
+soldered_nula_ethernet_w55rp20.vid.3=0x2e8a
+soldered_nula_ethernet_w55rp20.pid.3=0xd122
+soldered_nula_ethernet_w55rp20.upload_port.0.vid=0x2e8a
+soldered_nula_ethernet_w55rp20.upload_port.0.pid=0x1122
+soldered_nula_ethernet_w55rp20.upload_port.1.vid=0x2e8a
+soldered_nula_ethernet_w55rp20.upload_port.1.pid=0x5122
+soldered_nula_ethernet_w55rp20.upload_port.2.vid=0x2e8a
+soldered_nula_ethernet_w55rp20.upload_port.2.pid=0x9122
+soldered_nula_ethernet_w55rp20.upload_port.3.vid=0x2e8a
+soldered_nula_ethernet_w55rp20.upload_port.3.pid=0xd122
+soldered_nula_ethernet_w55rp20.build.usbvid=-DUSBD_VID=0x2e8a
+soldered_nula_ethernet_w55rp20.build.usbpid=-DUSBD_PID=0x1122
+soldered_nula_ethernet_w55rp20.build.usbpwr=-DUSBD_MAX_POWER_MA=250
+soldered_nula_ethernet_w55rp20.build.board=SOLDERED_NULA_ETHERNET
+soldered_nula_ethernet_w55rp20.build.mcu=cortex-m0plus
+soldered_nula_ethernet_w55rp20.build.chip=rp2040
+soldered_nula_ethernet_w55rp20.build.toolchain=arm-none-eabi
+soldered_nula_ethernet_w55rp20.build.toolchainpkg=pqt-gcc
+soldered_nula_ethernet_w55rp20.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
+soldered_nula_ethernet_w55rp20.build.uf2family=--family rp2040
+soldered_nula_ethernet_w55rp20.build.variant=soldered_nula_ethernet_w55rp20
+soldered_nula_ethernet_w55rp20.upload.maximum_size=2097152
+soldered_nula_ethernet_w55rp20.upload.wait_for_upload_port=true
+soldered_nula_ethernet_w55rp20.upload.erase_cmd=
+soldered_nula_ethernet_w55rp20.serial.disableDTR=false
+soldered_nula_ethernet_w55rp20.serial.disableRTS=false
+soldered_nula_ethernet_w55rp20.build.f_cpu=125000000
+soldered_nula_ethernet_w55rp20.build.led=
+soldered_nula_ethernet_w55rp20.build.core=rp2040
+soldered_nula_ethernet_w55rp20.build.ldscript=memmap_default.ld
+soldered_nula_ethernet_w55rp20.build.boot2=boot2_w25q080_2_padded_checksum
+soldered_nula_ethernet_w55rp20.build.usb_manufacturer="Soldered Electronics"
+soldered_nula_ethernet_w55rp20.build.usb_product="NULA Ethernet W55RP20"
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_0=2MB (no FS)
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_0.upload.maximum_size=2093056
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_0.build.flash_total=2097152
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_0.build.flash_length=2093056
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_0.build.eeprom_start=270528512
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_0.build.fs_start=270528512
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_0.build.fs_end=270528512
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_65536=2MB (Sketch: 1984KB, FS: 64KB)
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_65536.upload.maximum_size=2027520
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_65536.build.flash_total=2097152
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_65536.build.flash_length=2027520
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_65536.build.eeprom_start=270528512
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_65536.build.fs_start=270462976
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_65536.build.fs_end=270528512
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_131072=2MB (Sketch: 1920KB, FS: 128KB)
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_131072.upload.maximum_size=1961984
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_131072.build.flash_total=2097152
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_131072.build.flash_length=1961984
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_131072.build.eeprom_start=270528512
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_131072.build.fs_start=270397440
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_131072.build.fs_end=270528512
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_262144=2MB (Sketch: 1792KB, FS: 256KB)
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_262144.upload.maximum_size=1830912
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_262144.build.flash_total=2097152
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_262144.build.flash_length=1830912
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_262144.build.eeprom_start=270528512
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_262144.build.fs_start=270266368
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_262144.build.fs_end=270528512
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_524288=2MB (Sketch: 1536KB, FS: 512KB)
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_524288.upload.maximum_size=1568768
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_524288.build.flash_total=2097152
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_524288.build.flash_length=1568768
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_524288.build.eeprom_start=270528512
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_524288.build.fs_start=270004224
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_524288.build.fs_end=270528512
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_1048576=2MB (Sketch: 1MB, FS: 1MB)
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_1048576.upload.maximum_size=1044480
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_1048576.build.flash_total=2097152
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_1048576.build.flash_length=1044480
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_1048576.build.eeprom_start=270528512
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_1048576.build.fs_start=269479936
+soldered_nula_ethernet_w55rp20.menu.flash.2097152_1048576.build.fs_end=270528512
+soldered_nula_ethernet_w55rp20.menu.freq.200=200 MHz
+soldered_nula_ethernet_w55rp20.menu.freq.200.build.f_cpu=200000000L
+soldered_nula_ethernet_w55rp20.menu.freq.50=50 MHz
+soldered_nula_ethernet_w55rp20.menu.freq.50.build.f_cpu=50000000L
+soldered_nula_ethernet_w55rp20.menu.freq.100=100 MHz
+soldered_nula_ethernet_w55rp20.menu.freq.100.build.f_cpu=100000000L
+soldered_nula_ethernet_w55rp20.menu.freq.120=120 MHz
+soldered_nula_ethernet_w55rp20.menu.freq.120.build.f_cpu=120000000L
+soldered_nula_ethernet_w55rp20.menu.freq.125=125 MHz
+soldered_nula_ethernet_w55rp20.menu.freq.125.build.f_cpu=125000000L
+soldered_nula_ethernet_w55rp20.menu.freq.128=128 MHz
+soldered_nula_ethernet_w55rp20.menu.freq.128.build.f_cpu=128000000L
+soldered_nula_ethernet_w55rp20.menu.freq.133=133 MHz
+soldered_nula_ethernet_w55rp20.menu.freq.133.build.f_cpu=133000000L
+soldered_nula_ethernet_w55rp20.menu.freq.150=150 MHz
+soldered_nula_ethernet_w55rp20.menu.freq.150.build.f_cpu=150000000L
+soldered_nula_ethernet_w55rp20.menu.freq.176=176 MHz
+soldered_nula_ethernet_w55rp20.menu.freq.176.build.f_cpu=176000000L
+soldered_nula_ethernet_w55rp20.menu.freq.225=225 MHz (Overclock)
+soldered_nula_ethernet_w55rp20.menu.freq.225.build.f_cpu=225000000L
+soldered_nula_ethernet_w55rp20.menu.freq.240=240 MHz (Overclock)
+soldered_nula_ethernet_w55rp20.menu.freq.240.build.f_cpu=240000000L
+soldered_nula_ethernet_w55rp20.menu.freq.250=250 MHz (Overclock)
+soldered_nula_ethernet_w55rp20.menu.freq.250.build.f_cpu=250000000L
+soldered_nula_ethernet_w55rp20.menu.freq.276=276 MHz (Overclock)
+soldered_nula_ethernet_w55rp20.menu.freq.276.build.f_cpu=276000000L
+soldered_nula_ethernet_w55rp20.menu.freq.300=300 MHz (Overclock)
+soldered_nula_ethernet_w55rp20.menu.freq.300.build.f_cpu=300000000L
+soldered_nula_ethernet_w55rp20.menu.opt.Small=Small (-Os) (standard)
+soldered_nula_ethernet_w55rp20.menu.opt.Small.build.flags.optimize=-Os
+soldered_nula_ethernet_w55rp20.menu.opt.Optimize=Optimize (-O)
+soldered_nula_ethernet_w55rp20.menu.opt.Optimize.build.flags.optimize=-O
+soldered_nula_ethernet_w55rp20.menu.opt.Optimize2=Optimize More (-O2)
+soldered_nula_ethernet_w55rp20.menu.opt.Optimize2.build.flags.optimize=-O2
+soldered_nula_ethernet_w55rp20.menu.opt.Optimize3=Optimize Even More (-O3)
+soldered_nula_ethernet_w55rp20.menu.opt.Optimize3.build.flags.optimize=-O3
+soldered_nula_ethernet_w55rp20.menu.opt.Fast=Fast (-Ofast) (maybe slower)
+soldered_nula_ethernet_w55rp20.menu.opt.Fast.build.flags.optimize=-Ofast
+soldered_nula_ethernet_w55rp20.menu.opt.Debug=Debug (-Og)
+soldered_nula_ethernet_w55rp20.menu.opt.Debug.build.flags.optimize=-Og
+soldered_nula_ethernet_w55rp20.menu.opt.Disabled=Disabled (-O0)
+soldered_nula_ethernet_w55rp20.menu.opt.Disabled.build.flags.optimize=-O0
+soldered_nula_ethernet_w55rp20.menu.os.none=None
+soldered_nula_ethernet_w55rp20.menu.os.none.build.os=
+soldered_nula_ethernet_w55rp20.menu.os.freertos=FreeRTOS SMP
+soldered_nula_ethernet_w55rp20.menu.os.freertos.build.os=-D__FREERTOS
+soldered_nula_ethernet_w55rp20.menu.profile.Disabled=Disabled
+soldered_nula_ethernet_w55rp20.menu.profile.Disabled.build.flags.profile=
+soldered_nula_ethernet_w55rp20.menu.profile.Enabled=Enabled
+soldered_nula_ethernet_w55rp20.menu.profile.Enabled.build.flags.profile=-pg -D__PROFILE
+soldered_nula_ethernet_w55rp20.menu.rtti.Disabled=Disabled
+soldered_nula_ethernet_w55rp20.menu.rtti.Disabled.build.flags.rtti=-fno-rtti
+soldered_nula_ethernet_w55rp20.menu.rtti.Enabled=Enabled
+soldered_nula_ethernet_w55rp20.menu.rtti.Enabled.build.flags.rtti=
+soldered_nula_ethernet_w55rp20.menu.stackprotect.Disabled=Disabled
+soldered_nula_ethernet_w55rp20.menu.stackprotect.Disabled.build.flags.stackprotect=
+soldered_nula_ethernet_w55rp20.menu.stackprotect.Enabled=Enabled
+soldered_nula_ethernet_w55rp20.menu.stackprotect.Enabled.build.flags.stackprotect=-fstack-protector-all
+soldered_nula_ethernet_w55rp20.menu.exceptions.Disabled=Disabled
+soldered_nula_ethernet_w55rp20.menu.exceptions.Disabled.build.flags.exceptions=-fno-exceptions
+soldered_nula_ethernet_w55rp20.menu.exceptions.Disabled.build.flags.libstdcpp=-lstdc++
+soldered_nula_ethernet_w55rp20.menu.exceptions.Enabled=Enabled
+soldered_nula_ethernet_w55rp20.menu.exceptions.Enabled.build.flags.exceptions=-fexceptions
+soldered_nula_ethernet_w55rp20.menu.exceptions.Enabled.build.flags.libstdcpp=-lstdc++-exc
+soldered_nula_ethernet_w55rp20.menu.dbgport.Disabled=Disabled
+soldered_nula_ethernet_w55rp20.menu.dbgport.Disabled.build.debug_port=
+soldered_nula_ethernet_w55rp20.menu.dbgport.Serial=Serial
+soldered_nula_ethernet_w55rp20.menu.dbgport.Serial.build.debug_port=-DDEBUG_RP2040_PORT=Serial
+soldered_nula_ethernet_w55rp20.menu.dbgport.Serial1=Serial1
+soldered_nula_ethernet_w55rp20.menu.dbgport.Serial1.build.debug_port=-DDEBUG_RP2040_PORT=Serial1
+soldered_nula_ethernet_w55rp20.menu.dbgport.Serial2=Serial2
+soldered_nula_ethernet_w55rp20.menu.dbgport.Serial2.build.debug_port=-DDEBUG_RP2040_PORT=Serial2
+soldered_nula_ethernet_w55rp20.menu.dbgport.SerialSemi=SerialSemi
+soldered_nula_ethernet_w55rp20.menu.dbgport.SerialSemi.build.debug_port=-DDEBUG_RP2040_PORT=SerialSemi
+soldered_nula_ethernet_w55rp20.menu.dbglvl.None=None
+soldered_nula_ethernet_w55rp20.menu.dbglvl.None.build.debug_level=
+soldered_nula_ethernet_w55rp20.menu.dbglvl.Core=Core
+soldered_nula_ethernet_w55rp20.menu.dbglvl.Core.build.debug_level=-DDEBUG_RP2040_CORE
+soldered_nula_ethernet_w55rp20.menu.dbglvl.SPI=SPI
+soldered_nula_ethernet_w55rp20.menu.dbglvl.SPI.build.debug_level=-DDEBUG_RP2040_SPI
+soldered_nula_ethernet_w55rp20.menu.dbglvl.Wire=Wire
+soldered_nula_ethernet_w55rp20.menu.dbglvl.Wire.build.debug_level=-DDEBUG_RP2040_WIRE
+soldered_nula_ethernet_w55rp20.menu.dbglvl.Bluetooth=Bluetooth
+soldered_nula_ethernet_w55rp20.menu.dbglvl.Bluetooth.build.debug_level=-DDEBUG_RP2040_BLUETOOTH
+soldered_nula_ethernet_w55rp20.menu.dbglvl.BLE=BLE
+soldered_nula_ethernet_w55rp20.menu.dbglvl.BLE.build.debug_level=-DDEBUG_RP2040_BLE
+soldered_nula_ethernet_w55rp20.menu.dbglvl.LWIP=LWIP
+soldered_nula_ethernet_w55rp20.menu.dbglvl.LWIP.build.debug_level=-DLWIP_DEBUG=1
+soldered_nula_ethernet_w55rp20.menu.dbglvl.All=All
+soldered_nula_ethernet_w55rp20.menu.dbglvl.All.build.debug_level=-DDEBUG_RP2040_WIRE -DDEBUG_RP2040_SPI -DDEBUG_RP2040_CORE -DDEBUG_RP2040_BLUETOOTH -DDEBUG_RP2040_BLE -DLWIP_DEBUG=1
+soldered_nula_ethernet_w55rp20.menu.dbglvl.NDEBUG=NDEBUG
+soldered_nula_ethernet_w55rp20.menu.dbglvl.NDEBUG.build.debug_level=-DNDEBUG
+soldered_nula_ethernet_w55rp20.menu.usbstack.picosdk=Pico SDK
+soldered_nula_ethernet_w55rp20.menu.usbstack.picosdk.build.usbstack_flags=
+soldered_nula_ethernet_w55rp20.menu.usbstack.tinyusb=Adafruit TinyUSB
+soldered_nula_ethernet_w55rp20.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+soldered_nula_ethernet_w55rp20.menu.usbstack.tinyusb_host=Adafruit TinyUSB Host (native)
+soldered_nula_ethernet_w55rp20.menu.usbstack.tinyusb_host.build.usbstack_flags=-DUSE_TINYUSB -DUSE_TINYUSB_HOST "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+soldered_nula_ethernet_w55rp20.menu.usbstack.nousb=No USB
+soldered_nula_ethernet_w55rp20.menu.usbstack.nousb.build.usbstack_flags="-DNO_USB -DDISABLE_USB_SERIAL -I{runtime.platform.path}/tools/libpico"
+soldered_nula_ethernet_w55rp20.menu.ipbtstack.ipv4only=IPv4 Only
+soldered_nula_ethernet_w55rp20.menu.ipbtstack.ipv4only.build.libpicow=liblwip.a
+soldered_nula_ethernet_w55rp20.menu.ipbtstack.ipv4only.build.libpicowdefs=-DLWIP_IPV6=0 -DLWIP_IPV4=1
+soldered_nula_ethernet_w55rp20.menu.ipbtstack.ipv4ipv6=IPv4 + IPv6
+soldered_nula_ethernet_w55rp20.menu.ipbtstack.ipv4ipv6.build.libpicow=liblwip.a
+soldered_nula_ethernet_w55rp20.menu.ipbtstack.ipv4ipv6.build.libpicowdefs=-DLWIP_IPV6=1 -DLWIP_IPV4=1
+soldered_nula_ethernet_w55rp20.menu.ipbtstack.ipv4btcble=IPv4 + Bluetooth
+soldered_nula_ethernet_w55rp20.menu.ipbtstack.ipv4btcble.build.libpicow=liblwip-bt.a
+soldered_nula_ethernet_w55rp20.menu.ipbtstack.ipv4btcble.build.libpicowdefs=-DLWIP_IPV6=0 -DLWIP_IPV4=1 -DENABLE_CLASSIC=1 -DENABLE_BLE=1 -DCYW43_ENABLE_BLUETOOTH=1
+soldered_nula_ethernet_w55rp20.menu.ipbtstack.ipv4ipv6btcble=IPv4 + IPv6 + Bluetooth
+soldered_nula_ethernet_w55rp20.menu.ipbtstack.ipv4ipv6btcble.build.libpicow=liblwip-bt.a
+soldered_nula_ethernet_w55rp20.menu.ipbtstack.ipv4ipv6btcble.build.libpicowdefs=-DLWIP_IPV6=1 -DLWIP_IPV4=1 -DENABLE_CLASSIC=1 -DENABLE_BLE=1 -DCYW43_ENABLE_BLUETOOTH=1
+soldered_nula_ethernet_w55rp20.menu.ipbtstack.ipv4onlybig=IPv4 Only - 32K
+soldered_nula_ethernet_w55rp20.menu.ipbtstack.ipv4onlybig.build.libpicow=liblwip.a
+soldered_nula_ethernet_w55rp20.menu.ipbtstack.ipv4onlybig.build.libpicowdefs=-DLWIP_IPV6=0 -DLWIP_IPV4=1 -D__LWIP_MEMMULT=2
+soldered_nula_ethernet_w55rp20.menu.ipbtstack.ipv4ipv6big=IPv4 + IPv6 - 32K
+soldered_nula_ethernet_w55rp20.menu.ipbtstack.ipv4ipv6big.build.libpicow=liblwip.a
+soldered_nula_ethernet_w55rp20.menu.ipbtstack.ipv4ipv6big.build.libpicowdefs=-DLWIP_IPV6=1 -DLWIP_IPV4=1 -D__LWIP_MEMMULT=2
+soldered_nula_ethernet_w55rp20.menu.ipbtstack.ipv4btcblebig=IPv4 + Bluetooth - 32K
+soldered_nula_ethernet_w55rp20.menu.ipbtstack.ipv4btcblebig.build.libpicow=liblwip-bt.a
+soldered_nula_ethernet_w55rp20.menu.ipbtstack.ipv4btcblebig.build.libpicowdefs=-DLWIP_IPV6=0 -DLWIP_IPV4=1 -DENABLE_CLASSIC=1 -DENABLE_BLE=1 -DCYW43_ENABLE_BLUETOOTH=1 -D__LWIP_MEMMULT=2
+soldered_nula_ethernet_w55rp20.menu.ipbtstack.ipv4ipv6btcblebig=IPv4 + IPv6 + Bluetooth - 32K
+soldered_nula_ethernet_w55rp20.menu.ipbtstack.ipv4ipv6btcblebig.build.libpicow=liblwip-bt.a
+soldered_nula_ethernet_w55rp20.menu.ipbtstack.ipv4ipv6btcblebig.build.libpicowdefs=-DLWIP_IPV6=1 -DLWIP_IPV4=1 -DENABLE_CLASSIC=1 -DENABLE_BLE=1 -DCYW43_ENABLE_BLUETOOTH=1 -D__LWIP_MEMMULT=2
+soldered_nula_ethernet_w55rp20.menu.uploadmethod.default=Default (UF2)
+soldered_nula_ethernet_w55rp20.menu.uploadmethod.default.build.ram_length=256k
+soldered_nula_ethernet_w55rp20.menu.uploadmethod.default.build.debugscript=picoprobe_cmsis_dap.tcl
+soldered_nula_ethernet_w55rp20.menu.uploadmethod.default.upload.maximum_data_size=262144
+soldered_nula_ethernet_w55rp20.menu.uploadmethod.default.upload.tool=uf2conv
+soldered_nula_ethernet_w55rp20.menu.uploadmethod.default.upload.tool.default=uf2conv
+soldered_nula_ethernet_w55rp20.menu.uploadmethod.default.upload.tool.network=uf2conv-network
+soldered_nula_ethernet_w55rp20.menu.uploadmethod.picotool=Picotool
+soldered_nula_ethernet_w55rp20.menu.uploadmethod.picotool.build.ram_length=256k
+soldered_nula_ethernet_w55rp20.menu.uploadmethod.picotool.build.debugscript=picoprobe.tcl
+soldered_nula_ethernet_w55rp20.menu.uploadmethod.picotool.build.picodebugflags=-DENABLE_PICOTOOL_USB
+soldered_nula_ethernet_w55rp20.menu.uploadmethod.picotool.upload.maximum_data_size=262144
+soldered_nula_ethernet_w55rp20.menu.uploadmethod.picotool.upload.tool=picotool
+soldered_nula_ethernet_w55rp20.menu.uploadmethod.picotool.upload.tool.default=picotool
+soldered_nula_ethernet_w55rp20.menu.uploadmethod.picoprobe_cmsis_dap=Picoprobe/Debugprobe (CMSIS-DAP)
+soldered_nula_ethernet_w55rp20.menu.uploadmethod.picoprobe_cmsis_dap.build.ram_length=256k
+soldered_nula_ethernet_w55rp20.menu.uploadmethod.picoprobe_cmsis_dap.build.debugscript=picoprobe_cmsis_dap.tcl
+soldered_nula_ethernet_w55rp20.menu.uploadmethod.picoprobe_cmsis_dap.upload.maximum_data_size=262144
+soldered_nula_ethernet_w55rp20.menu.uploadmethod.picoprobe_cmsis_dap.upload.tool=picoprobe_cmsis_dap
+soldered_nula_ethernet_w55rp20.menu.uploadmethod.picoprobe_cmsis_dap.upload.tool.default=picoprobe_cmsis_dap
+
+# -----------------------------------
 # SparkFun IoT RedBoard RP2350
 # -----------------------------------
 sparkfun_iotredboard_rp2350.name=SparkFun IoT RedBoard RP2350

--- a/package/package_pico_index.template.json
+++ b/package/package_pico_index.template.json
@@ -333,6 +333,9 @@
                      "name": "Soldered Electronics NULA RP2350"
                   },
                   {
+                     "name": "Soldered Electronics NULA Ethernet W55RP20"
+                  },
+                  {
                      "name": "SparkFun IoT RedBoard RP2350"
                   },
                   {

--- a/tools/json/soldered_nula_ethernet_w55rp20.json
+++ b/tools/json/soldered_nula_ethernet_w55rp20.json
@@ -1,0 +1,56 @@
+{
+    "build": {
+        "arduino": {
+            "earlephilhower": {
+                "boot2_source": "boot2_w25q080_2_padded_checksum.S",
+                "usb_vid": "0x2E8A",
+                "usb_pid": "0x1122"
+            }
+        },
+        "core": "earlephilhower",
+        "cpu": "cortex-m0plus",
+        "extra_flags": "-DARDUINO_SOLDERED_NULA_ETHERNET -DARDUINO_ARCH_RP2040 -DUSBD_MAX_POWER_MA=250 ",
+        "f_cpu": "133000000L",
+        "hwids": [
+            [
+                "0x2E8A",
+                "0x00C0"
+            ],
+            [
+                "0x2E8A",
+                "0x1122"
+            ]
+        ],
+        "mcu": "rp2040",
+        "variant": "soldered_nula_ethernet_w55rp20"
+    },
+    "debug": {
+        "jlink_device": "RP2040_M0_0",
+        "openocd_target": "rp2040.cfg",
+        "svd_path": "rp2040.svd"
+    },
+    "frameworks": [
+        "arduino",
+        "picosdk"
+    ],
+    "name": "NULA Ethernet W55RP20",
+    "upload": {
+        "maximum_ram_size": 262144,
+        "maximum_size": 2097152,
+        "require_upload_port": true,
+        "native_usb": true,
+        "use_1200bps_touch": true,
+        "wait_for_upload_port": false,
+        "protocol": "picotool",
+        "protocols": [
+            "blackmagic",
+            "cmsis-dap",
+            "jlink",
+            "raspberrypi-swd",
+            "picotool",
+            "picoprobe"
+        ]
+    },
+    "url": "https://www.raspberrypi.org/products/raspberry-pi-pico/",
+    "vendor": "Soldered Electronics"
+}

--- a/tools/makeboards.py
+++ b/tools/makeboards.py
@@ -692,6 +692,7 @@ MakeBoard("solderparty_rp2350_stamp_xl", "rp2350", "Solder Party", "RP2350 Stamp
 
 # Soldered Electronics
 MakeBoard("soldered_nula_rp2350", "rp2350", "Soldered Electronics", "NULA RP2350", "0x2e8a", "0x10ec", 500, "SOLDERED_NULA_RP2350", 16, 0, "none", ["PICO_CYW43_SUPPORTED=1", "CYW43_PIN_WL_DYNAMIC=1"])
+MakeBoard("soldered_nula_ethernet_w55rp20", "rp2040", "Soldered Electronics", "NULA Ethernet W55RP20", "0x2e8a", "0x1122", 250, "SOLDERED_NULA_ETHERNET", 2, 0, "boot2_w25q080_2_padded_checksum")
 
 # SparkFun
 MakeBoard("sparkfun_iotredboard_rp2350", "rp2350", "SparkFun", "IoT RedBoard RP2350", "0x1b4f", "0x0047", 250, "SPARKFUN_IOTREDBOARD_RP2350", 16, 8, "none", ["PICO_CYW43_SUPPORTED=1", "CYW43_PIN_WL_DYNAMIC=1"], "https://www.sparkfun.com/sparkfun-iot-redboard-rp2350.html")

--- a/variants/soldered_nula_ethernet_w55rp20/pins_arduino.h
+++ b/variants/soldered_nula_ethernet_w55rp20/pins_arduino.h
@@ -12,9 +12,9 @@
 #define PIN_SERIAL2_RX (5u)
 
 // SPI
-#define PIN_SPI0_MISO  (4u) 
-#define PIN_SPI0_MOSI  (7u) 
-#define PIN_SPI0_SCK   (6u) 
+#define PIN_SPI0_MISO  (4u)
+#define PIN_SPI0_MOSI  (7u)
+#define PIN_SPI0_SCK   (6u)
 #define PIN_SPI0_SS    (5u)
 
 // SD Card SPI

--- a/variants/soldered_nula_ethernet_w55rp20/pins_arduino.h
+++ b/variants/soldered_nula_ethernet_w55rp20/pins_arduino.h
@@ -1,0 +1,43 @@
+#pragma once
+
+//LEDs
+#define PIN_NEOPIXEL   (1u)
+#define NUM_NEOPIXEL   (1u)
+
+// Serial
+#define PIN_SERIAL1_TX (0u)
+#define PIN_SERIAL1_RX (1u)
+
+#define PIN_SERIAL2_TX (4u)
+#define PIN_SERIAL2_RX (5u)
+
+// SPI
+#define PIN_SPI0_MISO  (4u) 
+#define PIN_SPI0_MOSI  (7u) 
+#define PIN_SPI0_SCK   (6u) 
+#define PIN_SPI0_SS    (5u)
+
+// SD Card SPI
+#define PIN_SPI1_MISO  (12u)
+#define PIN_SPI1_MOSI  (11u)
+#define PIN_SPI1_SCK   (10u)
+#define PIN_SPI1_SS    (13u)
+
+// Wire
+#define __WIRE0_DEVICE (i2c1)
+#define PIN_WIRE0_SDA  (2u)
+#define PIN_WIRE0_SCL  (3u)
+
+#define __WIRE1_DEVICE (i2c0)
+#define PIN_WIRE1_SDA  (28u)
+#define PIN_WIRE1_SCL  (29u)
+
+#define SERIAL_HOWMANY (2u)
+#define SPI_HOWMANY    (2u)
+#define WIRE_HOWMANY   (2u)
+
+// SD Card detect - Active Low
+static const uint8_t SD_ENABLE = (9u);
+
+
+#include "../generic/common.h"


### PR DESCRIPTION
Add pin definitions for the upcoming Soldered NULA Ethernet W55RP20 board by Soldered Electronics
The board is currently still being developed, so I will be attaching the schematic as well as the product image (Note that both the image and schematic call it the "NULA Ether", this will be changed to Ethernet in the final release)
<img width="1618" height="1626" alt="20260519_142832" src="https://github.com/user-attachments/assets/0498c240-1608-4ea9-bfe3-c710875c1f85" />
[NULA Ethernet W55RP20 Schematic.pdf](https://github.com/user-attachments/files/28091426/NULA.Ethernet.W55RP20.Schematic.pdf)
