### PR TITLE
fix: correct NEOPIXEL_POWER to GPIO11, add BAT_EN on GPIO24

### DIFF
--- a/variants/seeed_xiao_rp2040_plus/pins_arduino.h
+++ b/variants/seeed_xiao_rp2040_plus/pins_arduino.h
@@ -14,7 +14,10 @@
 #define PIN_NEOPIXEL         (12u)
 
 // RGB LED power enable (active high)
-#define NEOPIXEL_POWER       (24u)
+#define NEOPIXEL_POWER       (11u)
+
+// Battery charge enable (active high)
+#define BAT_EN               (24u)
 
 // Digital pins
 // ------------


### PR DESCRIPTION
NEOPIXEL_POWER was incorrectly assigned to GPIO24 per the schematic. GPIO11 is the actual RGB LED power enable. GPIO24 is the battery charge enable pin, now defined as BAT_EN.