### PR TITLE
Wake up USB host if it's asleep for Serial sending

### DIFF
--- a/cores/rp2040/SerialUSB.cpp
+++ b/cores/rp2040/SerialUSB.cpp
@@ -146,6 +146,11 @@ size_t SerialUSB::write(const uint8_t *buf, size_t length) {
         return 0;
     }
 
+    // If the remote has gone to sleep (laptop), tickle it so they will get the message
+    if (tud_suspended()) {
+        tud_remote_wakeup();
+    }
+
     static uint64_t last_avail_time;
     int written = 0;
     if (tud_cdc_connected() || _ss.ignoreFlowControl) {


### PR DESCRIPTION
Fixes #3436 where a laptop using an aggressive power saving mode was letting the USB port go to sleep while the Pico was idle.