### PR TITLE
Make Waveshare RP2350 PiZero a 2350B

### DIFF
--- a/variants/waveshare_rp2350_pizero/pins_arduino.h
+++ b/variants/waveshare_rp2350_pizero/pins_arduino.h
@@ -4,7 +4,7 @@
 // https://www.waveshare.com/wiki/RP2350-PiZero
 // https://files.waveshare.com/wiki/RP2350-PiZero/RP2350-PiZero.pdf
 
-#define PICO_RP2350A 1
+#define PICO_RP2350A 0 // RP2350B
 
 // Serial
 #define PIN_SERIAL1_TX (0u)


### PR DESCRIPTION
Original variant was submitted as a RP2350A (30 GPIO), not the RP2350B that's actually onboard.

Fixes #3443