### PR TITLE
PlatformIO Core, version 6.1.19 expects package.json to be named plat…

### DIFF
--- a/platform.json
+++ b/platform.json
@@ -1,0 +1,17 @@
+{
+  "name": "framework-arduinopico",
+  "version": "1.50600.0",
+  "description": "Arduino Wiring-based Framework (RPi Pico RP2040, RP2350)",
+  "keywords": [
+    "framework",
+    "arduino",
+    "Cortex-M",
+    "Raspberry Pi",
+    "RP2040"
+  ],
+  "homepage": "https://arduino-pico.readthedocs.io/en/latest/",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/earlephilhower/arduino-pico"
+  }
+}


### PR DESCRIPTION
For what ever reason, my version of PlatformIO 6.1.19 requires the package.json file to be named platform.json.

So, I simply copied package.json to platform.json and my project builds without error now.