### PR TITLE
Add PCBCupid GLYPH Mini 2040 board support

### DIFF
--- a/boards.txt
+++ b/boards.txt
@@ -43325,3 +43325,289 @@ generic_rp2350.menu.uploadmethod.picoprobe_cmsis_dap.build.debugscript=picoprobe
 generic_rp2350.menu.uploadmethod.picoprobe_cmsis_dap.upload.maximum_data_size=524288
 generic_rp2350.menu.uploadmethod.picoprobe_cmsis_dap.upload.tool=picoprobe_cmsis_dap
 generic_rp2350.menu.uploadmethod.picoprobe_cmsis_dap.upload.tool.default=picoprobe_cmsis_dap
+
+# -----------------------------------
+# PCBCupid Glyph-Mini-2040
+# -----------------------------------
+pcbcupid_glyph_mini_2040.name=PCBCupid GLYPH Mini 2040
+pcbcupid_glyph_mini_2040.vid.0=0x2e8a
+pcbcupid_glyph_mini_2040.pid.0=0x1123
+pcbcupid_glyph_mini_2040.upload_port.0.vid=0x2e8a
+pcbcupid_glyph_mini_2040.upload_port.0.pid=0x1123
+pcbcupid_glyph_mini_2040.build.usbvid=-DUSBD_VID=0x2e8a
+pcbcupid_glyph_mini_2040.build.usbpid=-DUSBD_PID=0x1123
+pcbcupid_glyph_mini_2040.build.usbpwr=-DUSBD_MAX_POWER_MA=250
+pcbcupid_glyph_mini_2040.build.board=PCBCUPID_GLYPH_MINI_2040
+pcbcupid_glyph_mini_2040.build.mcu=cortex-m0plus
+pcbcupid_glyph_mini_2040.build.chip=rp2040
+pcbcupid_glyph_mini_2040.build.led=
+pcbcupid_glyph_mini_2040.build.toolchain=arm-none-eabi
+pcbcupid_glyph_mini_2040.build.toolchainpkg=pqt-gcc
+pcbcupid_glyph_mini_2040.build.toolchainopts=-march=armv6-m -mcpu=cortex-m0plus -mthumb
+pcbcupid_glyph_mini_2040.build.uf2family=--family rp2040
+pcbcupid_glyph_mini_2040.build.variant=Pcbcupid_GLYPH_Mini_2040
+pcbcupid_glyph_mini_2040.upload.maximum_size=8388608
+pcbcupid_glyph_mini_2040.upload.wait_for_upload_port=true
+pcbcupid_glyph_mini_2040.upload.erase_cmd=
+
+pcbcupid_glyph_mini_2040.serial.disableDTR=false
+pcbcupid_glyph_mini_2040.serial.disableRTS=false
+
+pcbcupid_glyph_mini_2040.build.f_cpu=125000000
+pcbcupid_glyph_mini_2040.build.core=rp2040
+pcbcupid_glyph_mini_2040.build.ldscript=memmap_default.ld
+pcbcupid_glyph_mini_2040.build.boot2=boot2_w25q080_2_padded_checksum
+pcbcupid_glyph_mini_2040.build.usb_manufacturer="PCBCupid"
+pcbcupid_glyph_mini_2040.build.usb_product="GLYPH Mini 2040"
+
+pcbcupid_glyph_mini_2040.menu.flash.8388608_0=8MB (no FS)
+pcbcupid_glyph_mini_2040.menu.flash.8388608_0.upload.maximum_size=8384512
+pcbcupid_glyph_mini_2040.menu.flash.8388608_0.build.flash_total=8388608
+pcbcupid_glyph_mini_2040.menu.flash.8388608_0.build.flash_length=8384512
+pcbcupid_glyph_mini_2040.menu.flash.8388608_0.build.eeprom_start=276819968
+pcbcupid_glyph_mini_2040.menu.flash.8388608_0.build.fs_start=276819968
+pcbcupid_glyph_mini_2040.menu.flash.8388608_0.build.fs_end=276819968
+
+pcbcupid_glyph_mini_2040.menu.flash.8388608_65536=8MB (Sketch: 8128KB, FS: 64KB)
+pcbcupid_glyph_mini_2040.menu.flash.8388608_65536.upload.maximum_size=8318976
+pcbcupid_glyph_mini_2040.menu.flash.8388608_65536.build.flash_total=8388608
+pcbcupid_glyph_mini_2040.menu.flash.8388608_65536.build.flash_length=8318976
+pcbcupid_glyph_mini_2040.menu.flash.8388608_65536.build.eeprom_start=276819968
+pcbcupid_glyph_mini_2040.menu.flash.8388608_65536.build.fs_start=276754432
+pcbcupid_glyph_mini_2040.menu.flash.8388608_65536.build.fs_end=276819968
+
+pcbcupid_glyph_mini_2040.menu.flash.8388608_131072=8MB (Sketch: 8064KB, FS: 128KB)
+pcbcupid_glyph_mini_2040.menu.flash.8388608_131072.upload.maximum_size=8253440
+pcbcupid_glyph_mini_2040.menu.flash.8388608_131072.build.flash_total=8388608
+pcbcupid_glyph_mini_2040.menu.flash.8388608_131072.build.flash_length=8253440
+pcbcupid_glyph_mini_2040.menu.flash.8388608_131072.build.eeprom_start=276819968
+pcbcupid_glyph_mini_2040.menu.flash.8388608_131072.build.fs_start=276688896
+pcbcupid_glyph_mini_2040.menu.flash.8388608_131072.build.fs_end=276819968
+
+pcbcupid_glyph_mini_2040.menu.flash.8388608_262144=8MB (Sketch: 7936KB, FS: 256KB)
+pcbcupid_glyph_mini_2040.menu.flash.8388608_262144.upload.maximum_size=8122368
+pcbcupid_glyph_mini_2040.menu.flash.8388608_262144.build.flash_total=8388608
+pcbcupid_glyph_mini_2040.menu.flash.8388608_262144.build.flash_length=8122368
+pcbcupid_glyph_mini_2040.menu.flash.8388608_262144.build.eeprom_start=276819968
+pcbcupid_glyph_mini_2040.menu.flash.8388608_262144.build.fs_start=276557824
+pcbcupid_glyph_mini_2040.menu.flash.8388608_262144.build.fs_end=276819968
+
+pcbcupid_glyph_mini_2040.menu.flash.8388608_524288=8MB (Sketch: 7680KB, FS: 512KB)
+pcbcupid_glyph_mini_2040.menu.flash.8388608_524288.upload.maximum_size=7860224
+pcbcupid_glyph_mini_2040.menu.flash.8388608_524288.build.flash_total=8388608
+pcbcupid_glyph_mini_2040.menu.flash.8388608_524288.build.flash_length=7860224
+pcbcupid_glyph_mini_2040.menu.flash.8388608_524288.build.eeprom_start=276819968
+pcbcupid_glyph_mini_2040.menu.flash.8388608_524288.build.fs_start=276295680
+pcbcupid_glyph_mini_2040.menu.flash.8388608_524288.build.fs_end=276819968
+
+pcbcupid_glyph_mini_2040.menu.flash.8388608_1048576=8MB (Sketch: 7MB, FS: 1MB)
+pcbcupid_glyph_mini_2040.menu.flash.8388608_1048576.upload.maximum_size=7335936
+pcbcupid_glyph_mini_2040.menu.flash.8388608_1048576.build.flash_total=8388608
+pcbcupid_glyph_mini_2040.menu.flash.8388608_1048576.build.flash_length=7335936
+pcbcupid_glyph_mini_2040.menu.flash.8388608_1048576.build.eeprom_start=276819968
+pcbcupid_glyph_mini_2040.menu.flash.8388608_1048576.build.fs_start=275771392
+pcbcupid_glyph_mini_2040.menu.flash.8388608_1048576.build.fs_end=276819968
+
+pcbcupid_glyph_mini_2040.menu.flash.8388608_2097152=8MB (Sketch: 6MB, FS: 2MB)
+pcbcupid_glyph_mini_2040.menu.flash.8388608_2097152.upload.maximum_size=6287360
+pcbcupid_glyph_mini_2040.menu.flash.8388608_2097152.build.flash_total=8388608
+pcbcupid_glyph_mini_2040.menu.flash.8388608_2097152.build.flash_length=6287360
+pcbcupid_glyph_mini_2040.menu.flash.8388608_2097152.build.eeprom_start=276819968
+pcbcupid_glyph_mini_2040.menu.flash.8388608_2097152.build.fs_start=274722816
+pcbcupid_glyph_mini_2040.menu.flash.8388608_2097152.build.fs_end=276819968
+
+pcbcupid_glyph_mini_2040.menu.flash.8388608_3145728=8MB (Sketch: 5MB, FS: 3MB)
+pcbcupid_glyph_mini_2040.menu.flash.8388608_3145728.upload.maximum_size=5238784
+pcbcupid_glyph_mini_2040.menu.flash.8388608_3145728.build.flash_total=8388608
+pcbcupid_glyph_mini_2040.menu.flash.8388608_3145728.build.flash_length=5238784
+pcbcupid_glyph_mini_2040.menu.flash.8388608_3145728.build.eeprom_start=276819968
+pcbcupid_glyph_mini_2040.menu.flash.8388608_3145728.build.fs_start=273674240
+pcbcupid_glyph_mini_2040.menu.flash.8388608_3145728.build.fs_end=276819968
+
+pcbcupid_glyph_mini_2040.menu.flash.8388608_4194304=8MB (Sketch: 4MB, FS: 4MB)
+pcbcupid_glyph_mini_2040.menu.flash.8388608_4194304.upload.maximum_size=4190208
+pcbcupid_glyph_mini_2040.menu.flash.8388608_4194304.build.flash_total=8388608
+pcbcupid_glyph_mini_2040.menu.flash.8388608_4194304.build.flash_length=4190208
+pcbcupid_glyph_mini_2040.menu.flash.8388608_4194304.build.eeprom_start=276819968
+pcbcupid_glyph_mini_2040.menu.flash.8388608_4194304.build.fs_start=272625664
+pcbcupid_glyph_mini_2040.menu.flash.8388608_4194304.build.fs_end=276819968
+
+pcbcupid_glyph_mini_2040.menu.flash.8388608_5242880=8MB (Sketch: 3MB, FS: 5MB)
+pcbcupid_glyph_mini_2040.menu.flash.8388608_5242880.upload.maximum_size=3141632
+pcbcupid_glyph_mini_2040.menu.flash.8388608_5242880.build.flash_total=8388608
+pcbcupid_glyph_mini_2040.menu.flash.8388608_5242880.build.flash_length=3141632
+pcbcupid_glyph_mini_2040.menu.flash.8388608_5242880.build.eeprom_start=276819968
+pcbcupid_glyph_mini_2040.menu.flash.8388608_5242880.build.fs_start=271577088
+pcbcupid_glyph_mini_2040.menu.flash.8388608_5242880.build.fs_end=276819968
+
+pcbcupid_glyph_mini_2040.menu.flash.8388608_6291456=8MB (Sketch: 2MB, FS: 6MB)
+pcbcupid_glyph_mini_2040.menu.flash.8388608_6291456.upload.maximum_size=2093056
+pcbcupid_glyph_mini_2040.menu.flash.8388608_6291456.build.flash_total=8388608
+pcbcupid_glyph_mini_2040.menu.flash.8388608_6291456.build.flash_length=2093056
+pcbcupid_glyph_mini_2040.menu.flash.8388608_6291456.build.eeprom_start=276819968
+pcbcupid_glyph_mini_2040.menu.flash.8388608_6291456.build.fs_start=270528512
+pcbcupid_glyph_mini_2040.menu.flash.8388608_6291456.build.fs_end=276819968
+
+pcbcupid_glyph_mini_2040.menu.flash.8388608_7340032=8MB (Sketch: 1MB, FS: 7MB)
+pcbcupid_glyph_mini_2040.menu.flash.8388608_7340032.upload.maximum_size=1044480
+pcbcupid_glyph_mini_2040.menu.flash.8388608_7340032.build.flash_total=8388608
+pcbcupid_glyph_mini_2040.menu.flash.8388608_7340032.build.flash_length=1044480
+pcbcupid_glyph_mini_2040.menu.flash.8388608_7340032.build.eeprom_start=276819968
+pcbcupid_glyph_mini_2040.menu.flash.8388608_7340032.build.fs_start=269479936
+pcbcupid_glyph_mini_2040.menu.flash.8388608_7340032.build.fs_end=276819968
+
+pcbcupid_glyph_mini_2040.menu.freq.200=200 MHz
+pcbcupid_glyph_mini_2040.menu.freq.200.build.f_cpu=200000000L
+pcbcupid_glyph_mini_2040.menu.freq.50=50 MHz
+pcbcupid_glyph_mini_2040.menu.freq.50.build.f_cpu=50000000L
+pcbcupid_glyph_mini_2040.menu.freq.100=100 MHz
+pcbcupid_glyph_mini_2040.menu.freq.100.build.f_cpu=100000000L
+pcbcupid_glyph_mini_2040.menu.freq.120=120 MHz
+pcbcupid_glyph_mini_2040.menu.freq.120.build.f_cpu=120000000L
+pcbcupid_glyph_mini_2040.menu.freq.125=125 MHz
+pcbcupid_glyph_mini_2040.menu.freq.125.build.f_cpu=125000000L
+pcbcupid_glyph_mini_2040.menu.freq.128=128 MHz
+pcbcupid_glyph_mini_2040.menu.freq.128.build.f_cpu=128000000L
+pcbcupid_glyph_mini_2040.menu.freq.133=133 MHz
+pcbcupid_glyph_mini_2040.menu.freq.133.build.f_cpu=133000000L
+pcbcupid_glyph_mini_2040.menu.freq.150=150 MHz
+pcbcupid_glyph_mini_2040.menu.freq.150.build.f_cpu=150000000L
+pcbcupid_glyph_mini_2040.menu.freq.176=176 MHz
+pcbcupid_glyph_mini_2040.menu.freq.176.build.f_cpu=176000000L
+pcbcupid_glyph_mini_2040.menu.freq.225=225 MHz (Overclock)
+pcbcupid_glyph_mini_2040.menu.freq.225.build.f_cpu=225000000L
+pcbcupid_glyph_mini_2040.menu.freq.240=240 MHz (Overclock)
+pcbcupid_glyph_mini_2040.menu.freq.240.build.f_cpu=240000000L
+pcbcupid_glyph_mini_2040.menu.freq.250=250 MHz (Overclock)
+pcbcupid_glyph_mini_2040.menu.freq.250.build.f_cpu=250000000L
+pcbcupid_glyph_mini_2040.menu.freq.276=276 MHz (Overclock)
+pcbcupid_glyph_mini_2040.menu.freq.276.build.f_cpu=276000000L
+pcbcupid_glyph_mini_2040.menu.freq.300=300 MHz (Overclock)
+pcbcupid_glyph_mini_2040.menu.freq.300.build.f_cpu=300000000L
+
+pcbcupid_glyph_mini_2040.menu.opt.Small=Small (-Os) (standard)
+pcbcupid_glyph_mini_2040.menu.opt.Small.build.flags.optimize=-Os
+pcbcupid_glyph_mini_2040.menu.opt.Optimize=Optimize (-O)
+pcbcupid_glyph_mini_2040.menu.opt.Optimize.build.flags.optimize=-O
+pcbcupid_glyph_mini_2040.menu.opt.Optimize2=Optimize More (-O2)
+pcbcupid_glyph_mini_2040.menu.opt.Optimize2.build.flags.optimize=-O2
+pcbcupid_glyph_mini_2040.menu.opt.Optimize3=Optimize Even More (-O3)
+pcbcupid_glyph_mini_2040.menu.opt.Optimize3.build.flags.optimize=-O3
+pcbcupid_glyph_mini_2040.menu.opt.Fast=Fast (-Ofast) (maybe slower)
+pcbcupid_glyph_mini_2040.menu.opt.Fast.build.flags.optimize=-Ofast
+pcbcupid_glyph_mini_2040.menu.opt.Debug=Debug (-Og)
+pcbcupid_glyph_mini_2040.menu.opt.Debug.build.flags.optimize=-Og
+pcbcupid_glyph_mini_2040.menu.opt.Disabled=Disabled (-O0)
+pcbcupid_glyph_mini_2040.menu.opt.Disabled.build.flags.optimize=-O0
+
+pcbcupid_glyph_mini_2040.menu.os.none=None
+pcbcupid_glyph_mini_2040.menu.os.none.build.os=
+pcbcupid_glyph_mini_2040.menu.os.freertos=FreeRTOS SMP
+pcbcupid_glyph_mini_2040.menu.os.freertos.build.os=-D__FREERTOS
+pcbcupid_glyph_mini_2040.menu.profile.Disabled=Disabled
+pcbcupid_glyph_mini_2040.menu.profile.Disabled.build.flags.profile=
+pcbcupid_glyph_mini_2040.menu.profile.Enabled=Enabled
+pcbcupid_glyph_mini_2040.menu.profile.Enabled.build.flags.profile=-pg -D__PROFILE
+
+pcbcupid_glyph_mini_2040.menu.rtti.Disabled=Disabled
+pcbcupid_glyph_mini_2040.menu.rtti.Disabled.build.flags.rtti=-fno-rtti
+pcbcupid_glyph_mini_2040.menu.rtti.Enabled=Enabled
+pcbcupid_glyph_mini_2040.menu.rtti.Enabled.build.flags.rtti=
+
+pcbcupid_glyph_mini_2040.menu.stackprotect.Disabled=Disabled
+pcbcupid_glyph_mini_2040.menu.stackprotect.Disabled.build.flags.stackprotect=
+pcbcupid_glyph_mini_2040.menu.stackprotect.Enabled=Enabled
+pcbcupid_glyph_mini_2040.menu.stackprotect.Enabled.build.flags.stackprotect=-fstack-protector-all
+
+pcbcupid_glyph_mini_2040.menu.exceptions.Disabled=Disabled
+pcbcupid_glyph_mini_2040.menu.exceptions.Disabled.build.flags.exceptions=-fno-exceptions
+pcbcupid_glyph_mini_2040.menu.exceptions.Disabled.build.flags.libstdcpp=-lstdc++
+pcbcupid_glyph_mini_2040.menu.exceptions.Enabled=Enabled
+pcbcupid_glyph_mini_2040.menu.exceptions.Enabled.build.flags.exceptions=-fexceptions
+pcbcupid_glyph_mini_2040.menu.exceptions.Enabled.build.flags.libstdcpp=-lstdc++-exc
+
+pcbcupid_glyph_mini_2040.menu.dbgport.Disabled=Disabled
+pcbcupid_glyph_mini_2040.menu.dbgport.Disabled.build.debug_port=
+pcbcupid_glyph_mini_2040.menu.dbgport.Serial=Serial
+pcbcupid_glyph_mini_2040.menu.dbgport.Serial.build.debug_port=-DDEBUG_RP2040_PORT=Serial
+pcbcupid_glyph_mini_2040.menu.dbgport.Serial1=Serial1
+pcbcupid_glyph_mini_2040.menu.dbgport.Serial1.build.debug_port=-DDEBUG_RP2040_PORT=Serial1
+pcbcupid_glyph_mini_2040.menu.dbgport.Serial2=Serial2
+pcbcupid_glyph_mini_2040.menu.dbgport.Serial2.build.debug_port=-DDEBUG_RP2040_PORT=Serial2
+pcbcupid_glyph_mini_2040.menu.dbgport.SerialSemi=SerialSemi
+pcbcupid_glyph_mini_2040.menu.dbgport.SerialSemi.build.debug_port=-DDEBUG_RP2040_PORT=SerialSemi
+
+pcbcupid_glyph_mini_2040.menu.dbglvl.None=None
+pcbcupid_glyph_mini_2040.menu.dbglvl.None.build.debug_level=
+pcbcupid_glyph_mini_2040.menu.dbglvl.Core=Core
+pcbcupid_glyph_mini_2040.menu.dbglvl.Core.build.debug_level=-DDEBUG_RP2040_CORE
+pcbcupid_glyph_mini_2040.menu.dbglvl.SPI=SPI
+pcbcupid_glyph_mini_2040.menu.dbglvl.SPI.build.debug_level=-DDEBUG_RP2040_SPI
+pcbcupid_glyph_mini_2040.menu.dbglvl.Wire=Wire
+pcbcupid_glyph_mini_2040.menu.dbglvl.Wire.build.debug_level=-DDEBUG_RP2040_WIRE
+pcbcupid_glyph_mini_2040.menu.dbglvl.Bluetooth=Bluetooth
+pcbcupid_glyph_mini_2040.menu.dbglvl.Bluetooth.build.debug_level=-DDEBUG_RP2040_BLUETOOTH
+pcbcupid_glyph_mini_2040.menu.dbglvl.BLE=BLE
+pcbcupid_glyph_mini_2040.menu.dbglvl.BLE.build.debug_level=-DDEBUG_RP2040_BLE
+pcbcupid_glyph_mini_2040.menu.dbglvl.LWIP=LWIP
+pcbcupid_glyph_mini_2040.menu.dbglvl.LWIP.build.debug_level=-DLWIP_DEBUG=1
+pcbcupid_glyph_mini_2040.menu.dbglvl.All=All
+pcbcupid_glyph_mini_2040.menu.dbglvl.All.build.debug_level=-DDEBUG_RP2040_WIRE -DDEBUG_RP2040_SPI -DDEBUG_RP2040_CORE -DDEBUG_RP2040_BLUETOOTH -DDEBUG_RP2040_BLE -DLWIP_DEBUG=1
+pcbcupid_glyph_mini_2040.menu.dbglvl.NDEBUG=NDEBUG
+pcbcupid_glyph_mini_2040.menu.dbglvl.NDEBUG.build.debug_level=-DNDEBUG
+
+pcbcupid_glyph_mini_2040.menu.usbstack.picosdk=Pico SDK
+pcbcupid_glyph_mini_2040.menu.usbstack.picosdk.build.usbstack_flags=
+
+pcbcupid_glyph_mini_2040.menu.usbstack.tinyusb=Adafruit TinyUSB
+pcbcupid_glyph_mini_2040.menu.usbstack.tinyusb.build.usbstack_flags=-DUSE_TINYUSB "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+pcbcupid_glyph_mini_2040.menu.usbstack.tinyusb_host=Adafruit TinyUSB Host (native)
+pcbcupid_glyph_mini_2040.menu.usbstack.tinyusb_host.build.usbstack_flags=-DUSE_TINYUSB -DUSE_TINYUSB_HOST "-I{runtime.platform.path}/libraries/Adafruit_TinyUSB_Arduino/src/arduino"
+pcbcupid_glyph_mini_2040.menu.usbstack.nousb=No USB
+pcbcupid_glyph_mini_2040.menu.usbstack.nousb.build.usbstack_flags="-DNO_USB -DDISABLE_USB_SERIAL -I{runtime.platform.path}/tools/libpico"
+
+pcbcupid_glyph_mini_2040.menu.ipbtstack.ipv4only=IPv4 Only
+pcbcupid_glyph_mini_2040.menu.ipbtstack.ipv4only.build.libpicow=liblwip.a
+pcbcupid_glyph_mini_2040.menu.ipbtstack.ipv4only.build.libpicowdefs=-DLWIP_IPV6=0 -DLWIP_IPV4=1
+pcbcupid_glyph_mini_2040.menu.ipbtstack.ipv4ipv6=IPv4 + IPv6
+pcbcupid_glyph_mini_2040.menu.ipbtstack.ipv4ipv6.build.libpicow=liblwip.a
+pcbcupid_glyph_mini_2040.menu.ipbtstack.ipv4ipv6.build.libpicowdefs=-DLWIP_IPV6=1 -DLWIP_IPV4=1
+pcbcupid_glyph_mini_2040.menu.ipbtstack.ipv4btcble=IPv4 + Bluetooth
+pcbcupid_glyph_mini_2040.menu.ipbtstack.ipv4btcble.build.libpicow=liblwip-bt.a
+pcbcupid_glyph_mini_2040.menu.ipbtstack.ipv4btcble.build.libpicowdefs=-DLWIP_IPV6=0 -DLWIP_IPV4=1 -DENABLE_CLASSIC=1 -DENABLE_BLE=1 -DCYW43_ENABLE_BLUETOOTH=1
+pcbcupid_glyph_mini_2040.menu.ipbtstack.ipv4ipv6btcble=IPv4 + IPv6 + Bluetooth
+pcbcupid_glyph_mini_2040.menu.ipbtstack.ipv4ipv6btcble.build.libpicow=liblwip-bt.a
+pcbcupid_glyph_mini_2040.menu.ipbtstack.ipv4ipv6btcble.build.libpicowdefs=-DLWIP_IPV6=1 -DLWIP_IPV4=1 -DENABLE_CLASSIC=1 -DENABLE_BLE=1 -DCYW43_ENABLE_BLUETOOTH=1
+pcbcupid_glyph_mini_2040.menu.ipbtstack.ipv4onlybig=IPv4 Only - 32K
+pcbcupid_glyph_mini_2040.menu.ipbtstack.ipv4onlybig.build.libpicow=liblwip.a
+pcbcupid_glyph_mini_2040.menu.ipbtstack.ipv4onlybig.build.libpicowdefs=-DLWIP_IPV6=0 -DLWIP_IPV4=1 -D__LWIP_MEMMULT=2
+pcbcupid_glyph_mini_2040.menu.ipbtstack.ipv4ipv6big=IPv4 + IPv6 - 32K
+pcbcupid_glyph_mini_2040.menu.ipbtstack.ipv4ipv6big.build.libpicow=liblwip.a
+pcbcupid_glyph_mini_2040.menu.ipbtstack.ipv4ipv6big.build.libpicowdefs=-DLWIP_IPV6=1 -DLWIP_IPV4=1 -D__LWIP_MEMMULT=2
+pcbcupid_glyph_mini_2040.menu.ipbtstack.ipv4btcblebig=IPv4 + Bluetooth - 32K
+pcbcupid_glyph_mini_2040.menu.ipbtstack.ipv4btcblebig.build.libpicow=liblwip-bt.a
+pcbcupid_glyph_mini_2040.menu.ipbtstack.ipv4btcblebig.build.libpicowdefs=-DLWIP_IPV6=0 -DLWIP_IPV4=1 -DENABLE_CLASSIC=1 -DENABLE_BLE=1 -DCYW43_ENABLE_BLUETOOTH=1 -D__LWIP_MEMMULT=2
+pcbcupid_glyph_mini_2040.menu.ipbtstack.ipv4ipv6btcblebig=IPv4 + IPv6 + Bluetooth - 32K
+pcbcupid_glyph_mini_2040.menu.ipbtstack.ipv4ipv6btcblebig.build.libpicow=liblwip-bt.a
+pcbcupid_glyph_mini_2040.menu.ipbtstack.ipv4ipv6btcblebig.build.libpicowdefs=-DLWIP_IPV6=1 -DLWIP_IPV4=1 -DENABLE_CLASSIC=1 -DENABLE_BLE=1 -DCYW43_ENABLE_BLUETOOTH=1 -D__LWIP_MEMMULT=2
+
+pcbcupid_glyph_mini_2040.menu.uploadmethod.default=Default (UF2)
+pcbcupid_glyph_mini_2040.menu.uploadmethod.default.build.ram_length=256k
+pcbcupid_glyph_mini_2040.menu.uploadmethod.default.build.debugscript=picoprobe_cmsis_dap.tcl
+pcbcupid_glyph_mini_2040.menu.uploadmethod.default.upload.maximum_data_size=262144
+pcbcupid_glyph_mini_2040.menu.uploadmethod.default.upload.tool=uf2conv
+pcbcupid_glyph_mini_2040.menu.uploadmethod.default.upload.tool.default=uf2conv
+pcbcupid_glyph_mini_2040.menu.uploadmethod.default.upload.tool.network=uf2conv-network
+pcbcupid_glyph_mini_2040.menu.uploadmethod.picotool=Picotool
+pcbcupid_glyph_mini_2040.menu.uploadmethod.picotool.build.ram_length=256k
+pcbcupid_glyph_mini_2040.menu.uploadmethod.picotool.build.debugscript=picoprobe.tcl
+pcbcupid_glyph_mini_2040.menu.uploadmethod.picotool.build.picodebugflags=-DENABLE_PICOTOOL_USB
+pcbcupid_glyph_mini_2040.menu.uploadmethod.picotool.upload.maximum_data_size=262144
+pcbcupid_glyph_mini_2040.menu.uploadmethod.picotool.upload.tool=picotool
+pcbcupid_glyph_mini_2040.menu.uploadmethod.picotool.upload.tool.default=picotool
+pcbcupid_glyph_mini_2040.menu.uploadmethod.picoprobe_cmsis_dap=Picoprobe/Debugprobe (CMSIS-DAP)
+pcbcupid_glyph_mini_2040.menu.uploadmethod.picoprobe_cmsis_dap.build.ram_length=256k
+pcbcupid_glyph_mini_2040.menu.uploadmethod.picoprobe_cmsis_dap.build.debugscript=picoprobe_cmsis_dap.tcl
+pcbcupid_glyph_mini_2040.menu.uploadmethod.picoprobe_cmsis_dap.upload.maximum_data_size=262144
+pcbcupid_glyph_mini_2040.menu.uploadmethod.picoprobe_cmsis_dap.upload.tool=picoprobe_cmsis_dap
+pcbcupid_glyph_mini_2040.menu.uploadmethod.picoprobe_cmsis_dap.upload.tool.default=picoprobe_cmsis_dap

--- a/variants/Pcbcupid_GLYPH_Mini_2040/pins_arduino.h
+++ b/variants/Pcbcupid_GLYPH_Mini_2040/pins_arduino.h
@@ -1,0 +1,71 @@
+/*
+ * pins_arduino.h - PCBCupid GLYPH Mini 2040
+ * RP2040, W25Q64 8MB external flash
+ *
+ * Available GPIOs: GP0–GP15, GP26–GP29
+ * Not broken out: GP16 (LED, internal), GP17, GP18, GP19, GP20, GP21, GP22, GP23, GP24, GP25
+ *
+ * Pin overlap notice:
+ *   GP4/GP5  — shared between SPI0 (MISO/SS) and UART1 (TX/RX) and I2C0 (SDA/SCL)
+ *   GP8/GP9  — shared between SPI1 (RX/CSn) and UART1 alt (TX/RX) and I2C0 (SDA/SCL)
+ *   Use either UART1 or I2C0 on GP4/GP5 or GP8/GP9 — not both simultaneously.
+ */
+
+#pragma once
+
+// LED
+#define PIN_LED        (16u)
+
+// Serial0 (UART0) — GP0/GP1
+#define PIN_SERIAL1_TX (0u)
+#define PIN_SERIAL1_RX (1u)
+
+// Serial1 (UART1) — GP4/GP5
+// NOTE: GP4/GP5 overlap with I2C0 SDA/SCL and SPI0 MISO/SS
+// Use UART1 OR I2C0 on these pins, not both
+#define PIN_SERIAL2_TX (4u)
+#define PIN_SERIAL2_RX (5u)
+
+// SPI0 — GP2/GP3/GP4/GP5
+// NOTE: GP4(MISO) and GP5(SS) overlap with UART1 TX/RX and I2C0 SDA/SCL
+#define PIN_SPI0_MISO  (4u)
+#define PIN_SPI0_MOSI  (3u)
+#define PIN_SPI0_SCK   (2u)
+#define PIN_SPI0_SS    (5u)
+
+// SPI1 — GP10/GP11/GP12/GP13
+#define PIN_SPI1_MISO  (12u)
+#define PIN_SPI1_MOSI  (11u)
+#define PIN_SPI1_SCK   (10u)
+#define PIN_SPI1_SS    (13u)
+
+// Wire0 (I2C0) — GP8/GP9
+// NOTE: GP8/GP9 overlap with UART1 alternate TX/RX
+// Use I2C0 OR UART1 alt on these pins, not both
+#define PIN_WIRE0_SDA  (8u)
+#define PIN_WIRE0_SCL  (9u)
+
+// Wire1 (I2C1) — GP26/GP27
+#define PIN_WIRE1_SDA  (26u)
+#define PIN_WIRE1_SCL  (27u)
+
+// ADC — GP26/GP27/GP28/GP29
+#define PIN_A0         (26u)
+#define PIN_A1         (27u)
+#define PIN_A2         (28u)
+#define PIN_A3         (29u)
+
+#define PINS_COUNT          (30u)
+#define NUM_DIGITAL_PINS    (30u)
+#define NUM_ANALOG_INPUTS   (4u)
+#define NUM_ANALOG_OUTPUTS  (0u)
+
+#define ADC_RESOLUTION      (12u)
+
+#define SERIAL_HOWMANY      (3u)
+#define SPI_HOWMANY         (2u)
+#define WIRE_HOWMANY        (2u)
+
+// No NEOPIXEL on this board
+
+#include "../generic/common.h"


### PR DESCRIPTION
## Description of Change

Adding new board called GLYPH Mini 2040 based on rp2040
Shop : https://shop.pcbcupid.com/product/gdm001

---
## Test Scenarios

I have tested my Pull Request on Arduino-rp2040 core v5.6.0 with rp2040 (GLYPH Mini 2040)

---
## Related links

We have added required document for the product here : https://learn.pcbcupid.com/documentation/modules/glyph-mini/glyph-mini-2040/overview