### PR TITLE
Remove code/data for exit/atexit

### DIFF
--- a/cores/rp2040/main.cpp
+++ b/cores/rp2040/main.cpp
@@ -249,3 +249,15 @@ extern "C" void __attribute__((__noreturn__)) __wrap___stack_chk_fail() {
 extern "C" void stdio_flush() {
     Serial.flush();
 }
+
+// exit/atexist have no meaning here
+extern "C" void __wrap_exit(int status) {
+    (void) status;
+    panic("exit");
+}
+
+extern "C" int __wrap_atexit(void (*function)(void)) {
+    (void) function;
+    return 0; // We lie, sorry!
+}
+

--- a/lib/core_wrap.txt
+++ b/lib/core_wrap.txt
@@ -5,6 +5,8 @@
 -Wl,--wrap=realloc
 -Wl,--wrap=free
 -Wl,--wrap=mallinfo
+-Wl,--wrap=exit
+-Wl,--wrap=atexit
 
 -Wl,--wrap=lwip_init
 


### PR DESCRIPTION
The exit call is meaningless on the Pico, so just wrap it with a call to panic.  Saves flash and RAM