### PR TITLE
Make DEBUGV & friends append a newline, remove newlines from call sites

### DIFF
--- a/cores/rp2040/CoreMutex.cpp
+++ b/cores/rp2040/CoreMutex.cpp
@@ -46,7 +46,7 @@ CoreMutex::CoreMutex(mutex_t *mutex, uint8_t option) {
     if (!mutex_try_enter(_mutex, &owner)) {
         if (owner == get_core_num()) { // Deadlock!
             if (_option & DebugEnable) {
-                DEBUGCORE("CoreMutex - Deadlock detected!\n");
+                DEBUGCORE("CoreMutex - Deadlock detected!");
             }
             return;
         }

--- a/cores/rp2040/FS.cpp
+++ b/cores/rp2040/FS.cpp
@@ -248,7 +248,7 @@ File Dir::openFile(const char* mode) {
     OpenMode om;
     AccessMode am;
     if (!sflags(mode, om, am)) {
-        DEBUGV("Dir::openFile: invalid mode `%s`\r\n", mode);
+        DEBUGV("Dir::openFile: invalid mode `%s`", mode);
         return File();
     }
 
@@ -343,7 +343,7 @@ bool FS::begin() {
     }
     _impl->setTimeCallback(_timeCallback);
     bool ret = _impl->begin();
-    DEBUGV("%s\n", ret ? "" : "#error: FS could not start");
+    DEBUGV("%s", ret ? "" : "#error: FS could not start");
     return ret;
 }
 
@@ -393,7 +393,7 @@ File FS::open(const char* path, const char* mode) {
     OpenMode om;
     AccessMode am;
     if (!sflags(mode, om, am)) {
-        DEBUGV("FS::open: invalid mode `%s`\r\n", mode);
+        DEBUGV("FS::open: invalid mode `%s`", mode);
         return File();
     }
     File f(_impl->open(path, om, am), this);
@@ -556,7 +556,7 @@ template<>
 bool mount<FS>(FS& fs, const char* mountPoint) {
     FSImplPtr p = fs._impl;
     if (!p || !p->mount()) {
-        DEBUGV("FSImpl mount failed\r\n");
+        DEBUGV("FSImpl mount failed");
         return false;
     }
 
@@ -578,7 +578,7 @@ File open(const char* path, const char* mode) {
     OpenMode om;
     AccessMode am;
     if (!sflags(mode, om, am)) {
-        DEBUGV("open: invalid mode `%s`\r\n", mode);
+        DEBUGV("open: invalid mode `%s`", mode);
         return File();
     }
 

--- a/cores/rp2040/PIOProgram.cpp
+++ b/cores/rp2040/PIOProgram.cpp
@@ -54,7 +54,7 @@ bool PIOProgram::prepare(PIO *pio, int *sm, int *offset, int start, int cnt) {
     PIO pi[PIOCNT] = { PIOS };
 
     uint gpioBaseNeeded = ((start + cnt) >= 32) ? 16 : 0;
-    DEBUGV("PIOProgram %p: Searching for base=%d, pins %d-%d\n", _pgm, gpioBaseNeeded, start, start + cnt - 1);
+    DEBUGV("PIOProgram %p: Searching for base=%d, pins %d-%d", _pgm, gpioBaseNeeded, start, start + cnt - 1);
 
     // If it's already loaded into PIO IRAM, try and allocate in that specific PIO
     for (int o = 0; o < PIOCNT; o++) {
@@ -62,7 +62,7 @@ bool PIOProgram::prepare(PIO *pio, int *sm, int *offset, int start, int cnt) {
         if ((p != __pioMap[o].end()) && (pio_get_gpio_base(pio_get_instance(o)) == gpioBaseNeeded)) {
             int idx = pio_claim_unused_sm(pi[o], false);
             if (idx >= 0) {
-                DEBUGV("PIOProgram %p: Reusing IMEM ON PIO %p(base=%d) for pins %d-%d\n", _pgm, pi[o], pio_get_gpio_base(pio_get_instance(o)), start, start + cnt - 1);
+                DEBUGV("PIOProgram %p: Reusing IMEM ON PIO %p(base=%d) for pins %d-%d", _pgm, pi[o], pio_get_gpio_base(pio_get_instance(o)), start, start + cnt - 1);
                 _pio = pi[o];
                 _sm = idx;
                 *pio = pi[o];
@@ -76,11 +76,11 @@ bool PIOProgram::prepare(PIO *pio, int *sm, int *offset, int start, int cnt) {
     // Not in any PIO IRAM, so try and add
     for (int o = 0; o < PIOCNT; o++) {
         if (__pioAllocated[o] && (pio_get_gpio_base(pio_get_instance(o)) == gpioBaseNeeded)) {
-            DEBUGV("PIOProgram: Checking PIO %p\n", pi[o]);
+            DEBUGV("PIOProgram: Checking PIO %p", pi[o]);
             if (pio_can_add_program(pi[o], _pgm)) {
                 int idx = pio_claim_unused_sm(pi[o], false);
                 if (idx >= 0) {
-                    DEBUGV("PIOProgram %p: Adding IMEM ON PIO %p(base=%d) for pins %d-%d\n", _pgm, pi[o], pio_get_gpio_base(pio_get_instance(o)), start, start + cnt - 1);
+                    DEBUGV("PIOProgram %p: Adding IMEM ON PIO %p(base=%d) for pins %d-%d", _pgm, pi[o], pio_get_gpio_base(pio_get_instance(o)), start, start + cnt - 1);
                     int off = pio_add_program(pi[o], _pgm);
                     __pioMap[o].insert({_pgm, off});
                     _pio = pi[o];
@@ -90,13 +90,13 @@ bool PIOProgram::prepare(PIO *pio, int *sm, int *offset, int start, int cnt) {
                     *offset = off;
                     return true;
                 } else {
-                    DEBUGV("PIOProgram: can't claim unused SM\n");
+                    DEBUGV("PIOProgram: can't claim unused SM");
                 }
             } else {
-                DEBUGV("PIOProgram: can't add program\n");
+                DEBUGV("PIOProgram: can't add program");
             }
         } else {
-            DEBUGV("PIOProgram: Skipping PIO %p, wrong allocated/needhi\n", pi[o]);
+            DEBUGV("PIOProgram: Skipping PIO %p, wrong allocated/needhi", pi[o]);
         }
     }
 
@@ -112,7 +112,7 @@ bool PIOProgram::prepare(PIO *pio, int *sm, int *offset, int start, int cnt) {
         }
         assert(!__pioAllocated[o]);
         __pioAllocated[o]  = true;
-        DEBUGV("PIOProgram %p: Allocating new PIO %p(base=%d) for pins %d-%d\n", _pgm, pi[o], pio_get_gpio_base(pio_get_instance(o)), start, start + cnt - 1);
+        DEBUGV("PIOProgram %p: Allocating new PIO %p(base=%d) for pins %d-%d", _pgm, pi[o], pio_get_gpio_base(pio_get_instance(o)), start, start + cnt - 1);
         __pioMap[o].insert({_pgm, off});
         _pio = pi[o];
         _sm = idx;

--- a/cores/rp2040/SemiFS.h
+++ b/cores/rp2040/SemiFS.h
@@ -127,7 +127,7 @@ public:
 
     const char* name() const override {
         if (!_opened) {
-            DEBUGV("SemiFSFileImpl::name: file not opened\n");
+            DEBUGV("SemiFSFileImpl::name: file not opened");
             return nullptr;
         } else {
             const char *p = _name.get();
@@ -177,7 +177,7 @@ public:
 
     FileImplPtr open(const char* path, OpenMode openMode, AccessMode accessMode) override {
         if (!path || !path[0]) {
-            DEBUGV("SemiFSImpl::open() called with invalid filename\n");
+            DEBUGV("SemiFSImpl::open() called with invalid filename");
             return FileImplPtr();
         }
         // Mode conversion https://developer.arm.com/documentation/dui0471/m/what-is-semihosting-/sys-open--0x01-?lang=en

--- a/cores/rp2040/SerialPIO.cpp
+++ b/cores/rp2040/SerialPIO.cpp
@@ -197,7 +197,7 @@ void SerialPIO::begin(unsigned long baud, uint16_t config) {
     }
 
     if ((_tx == NOPIN) && (_rx == NOPIN)) {
-        DEBUGCORE("ERROR: No pins specified for SerialPIO\n");
+        DEBUGCORE("ERROR: No pins specified for SerialPIO");
         return;
     }
 
@@ -206,7 +206,7 @@ void SerialPIO::begin(unsigned long baud, uint16_t config) {
         _txPgm = _getTxProgram(_txBits);
         int off;
         if (!_txPgm->prepare(&_txPIO, &_txSM, &off, _tx, 1)) {
-            DEBUGCORE("ERROR: Unable to allocate PIO TX UART, out of PIO resources\n");
+            DEBUGCORE("ERROR: Unable to allocate PIO TX UART, out of PIO resources");
             // ERROR, no free slots
             return;
         }
@@ -233,7 +233,7 @@ void SerialPIO::begin(unsigned long baud, uint16_t config) {
         _rxPgm = _getRxProgram(_rxBits);
         int off;
         if (!_rxPgm->prepare(&_rxPIO, &_rxSM, &off, _rx, 1)) {
-            DEBUGCORE("ERROR: Unable to allocate PIO RX UART, out of PIO resources\n");
+            DEBUGCORE("ERROR: Unable to allocate PIO RX UART, out of PIO resources");
             return;
         }
         // Stash away the created RX port for the IRQ handler

--- a/cores/rp2040/Tone.cpp
+++ b/cores/rp2040/Tone.cpp
@@ -57,7 +57,7 @@ static int64_t _stopTonePIO(alarm_id_t id, void *user_data) {
 
 void tone(uint8_t pin, unsigned int frequency, unsigned long duration) {
     if (pin >= __GPIOCNT) {
-        DEBUGCORE("ERROR: Illegal pin in tone (%d)\n", pin);
+        DEBUGCORE("ERROR: Illegal pin in tone (%d)", pin);
         return;
     }
     if (!frequency) {
@@ -79,7 +79,7 @@ void tone(uint8_t pin, unsigned int frequency, unsigned long duration) {
         newTone->pin = pin;
         pinMode(pin, OUTPUT);
         if (!_tone2Pgm.prepare(&newTone->pio, &newTone->sm, &newTone->off, pin, 1)) {
-            DEBUGCORE("ERROR: tone unable to start, out of PIO resources\n");
+            DEBUGCORE("ERROR: tone unable to start, out of PIO resources");
             // ERROR, no free slots
             delete newTone;
             return;
@@ -108,7 +108,7 @@ void tone(uint8_t pin, unsigned int frequency, unsigned long duration) {
         if (ret > 0) {
             newTone->alarm = ret;
         } else {
-            DEBUGCORE("ERROR: Unable to allocate timer for tone(%d, %d, %lu)\n",
+            DEBUGCORE("ERROR: Unable to allocate timer for tone(%d, %d, %lu)",
                       pin, frequency, duration);
         }
     }
@@ -118,7 +118,7 @@ void noTone(uint8_t pin) {
     CoreMutex m(&_toneMutex);
 
     if ((pin > __GPIOCNT) || !m) {
-        DEBUGCORE("ERROR: Illegal pin in tone (%d)\n", pin);
+        DEBUGCORE("ERROR: Illegal pin in tone (%d)", pin);
         return;
     }
     auto entry = _toneMap.find(pin);

--- a/cores/rp2040/debug_internal.h
+++ b/cores/rp2040/debug_internal.h
@@ -26,22 +26,22 @@
 #define DEBUGWIRE(...) do { } while(0)
 #define DEBUGSPI(...) do { } while(0)
 #else
-#define DEBUGV(fmt, ...) do { DEBUG_RP2040_PORT.printf(fmt, ## __VA_ARGS__); DEBUG_RP2040_PORT.flush(); } while (0)
+#define DEBUGV(fmt, ...) do { DEBUG_RP2040_PORT.printf(fmt "\r\n", ## __VA_ARGS__); DEBUG_RP2040_PORT.flush(); } while (0)
 
 #if defined(DEBUG_RP2040_CORE)
-#define DEBUGCORE(fmt, ...) do { DEBUG_RP2040_PORT.printf(fmt, ## __VA_ARGS__); DEBUG_RP2040_PORT.flush(); } while (0)
+#define DEBUGCORE(fmt, ...) do { DEBUG_RP2040_PORT.printf(fmt "\r\n", ## __VA_ARGS__); DEBUG_RP2040_PORT.flush(); } while (0)
 #else
 #define DEBUGCORE(...) do { } while(0)
 #endif
 
 #if defined(DEBUG_RP2040_WIRE)
-#define DEBUGWIRE(fmt, ...) do { DEBUG_RP2040_PORT.printf(fmt, ## __VA_ARGS__); DEBUG_RP2040_PORT.flush(); } while (0)
+#define DEBUGWIRE(fmt, ...) do { DEBUG_RP2040_PORT.printf(fmt "\r\n", ## __VA_ARGS__); DEBUG_RP2040_PORT.flush(); } while (0)
 #else
 #define DEBUGWIRE(...) do { } while(0)
 #endif
 
 #if defined(DEBUG_RP2040_SPI)
-#define DEBUGSPI(fmt, ...) do { DEBUG_RP2040_PORT.printf(fmt, ## __VA_ARGS__); DEBUG_RP2040_PORT.flush(); } while (0)
+#define DEBUGSPI(fmt, ...) do { DEBUG_RP2040_PORT.printf(fmt "\r\n", ## __VA_ARGS__); DEBUG_RP2040_PORT.flush(); } while (0)
 #else
 #define DEBUGSPI(...) do { } while(0)
 #endif

--- a/cores/rp2040/wiring_analog.cpp
+++ b/cores/rp2040/wiring_analog.cpp
@@ -43,10 +43,10 @@ extern "C" void analogWriteFreq(uint32_t freq) {
         return;
     }
     if (freq < 100) {
-        DEBUGCORE("ERROR: analogWriteFreq too low (%lu)\n", freq);
+        DEBUGCORE("ERROR: analogWriteFreq too low (%lu)", freq);
         analogFreq = 100;
     } else if (freq > 10'000'000) {
-        DEBUGCORE("ERROR: analogWriteFreq too high (%lu)\n", freq);
+        DEBUGCORE("ERROR: analogWriteFreq too high (%lu)", freq);
         analogFreq = 10'000'000;
     } else {
         analogFreq = freq;
@@ -64,7 +64,7 @@ extern "C" void analogWriteRange(uint32_t range) {
         pwmInitted = 0;
         scaleInitted = false;
     } else {
-        DEBUGCORE("ERROR: analogWriteRange out of range (%lu)\n", range);
+        DEBUGCORE("ERROR: analogWriteRange out of range (%lu)", range);
     }
 }
 
@@ -72,7 +72,7 @@ extern "C" void analogWriteResolution(int res) {
     if ((res >= 2) && (res <= 16)) {
         analogWriteRange((1 << res) - 1);
     } else {
-        DEBUGCORE("ERROR: analogWriteResolution out of range (%d)\n", res);
+        DEBUGCORE("ERROR: analogWriteResolution out of range (%d)", res);
     }
 }
 
@@ -80,7 +80,7 @@ extern "C" void analogWrite(pin_size_t pin, int val) {
     CoreMutex m(&_dacMutex);
 
     if ((pin >= __GPIOCNT) || !m) {
-        DEBUGCORE("ERROR: Illegal analogWrite pin (%d)\n", pin);
+        DEBUGCORE("ERROR: Illegal analogWrite pin (%d)", pin);
         return;
     }
     __clearADCPin(pin);
@@ -90,14 +90,14 @@ extern "C" void analogWrite(pin_size_t pin, int val) {
         while (((clock_get_hz(clk_sys) / ((float)analogScale * analogFreq)) > 255.0f) && (analogScale < 32678)) {
             analogWritePseudoScale++;
             analogScale *= 2;
-            DEBUGCORE("Adjusting analogWrite values PS=%d, scale=%lu\n", analogWritePseudoScale, analogScale);
+            DEBUGCORE("Adjusting analogWrite values PS=%d, scale=%lu", analogWritePseudoScale, analogScale);
         }
         // For high frequencies, we need to scale the output max value down to actually hit the frequency target
         analogWriteSlowScale = 1;
         while (((clock_get_hz(clk_sys) / ((float)analogScale * analogFreq)) < 1.0f) && (analogScale >= 6)) {
             analogWriteSlowScale++;
             analogScale /= 2;
-            DEBUGCORE("Adjusting analogWrite values SS=%d, scale=%lu\n", analogWriteSlowScale, analogScale);
+            DEBUGCORE("Adjusting analogWrite values SS=%d, scale=%lu", analogWriteSlowScale, analogScale);
         }
         scaleInitted = true;
     }
@@ -138,7 +138,7 @@ extern "C" int analogRead(pin_size_t pin) {
     pin_size_t minPin = __FIRSTANALOGGPIO;
 
     if ((pin < minPin) || (pin > maxPin) || !m) {
-        DEBUGCORE("ERROR: Illegal analogRead pin (%d)\n", pin);
+        DEBUGCORE("ERROR: Illegal analogRead pin (%d)", pin);
         return 0;
     }
     if (!adcInitted) {

--- a/cores/rp2040/wiring_digital.cpp
+++ b/cores/rp2040/wiring_digital.cpp
@@ -28,7 +28,7 @@ static PinMode _pm[__GPIOCNT];
 extern "C" void pinMode(pin_size_t ulPin, PinMode ulMode) __attribute__((weak, alias("__pinMode")));
 extern "C" void __pinMode(pin_size_t ulPin, PinMode ulMode) {
     if (ulPin >= __GPIOCNT) {
-        DEBUGCORE("ERROR: Illegal pin in pinMode (%d)\n", ulPin);
+        DEBUGCORE("ERROR: Illegal pin in pinMode (%d)", ulPin);
         return;
     }
 
@@ -72,7 +72,7 @@ extern "C" void __pinMode(pin_size_t ulPin, PinMode ulMode) {
         gpio_set_dir(ulPin, true);
         break;
     default:
-        DEBUGCORE("ERROR: Illegal pinMode mode (%d)\n", ulMode);
+        DEBUGCORE("ERROR: Illegal pinMode mode (%d)", ulMode);
         // Error
         return;
     }
@@ -87,7 +87,7 @@ extern "C" void __pinMode(pin_size_t ulPin, PinMode ulMode) {
 extern "C" void digitalWrite(pin_size_t ulPin, PinStatus ulVal) __attribute__((weak, alias("__digitalWrite")));
 extern "C" void __digitalWrite(pin_size_t ulPin, PinStatus ulVal) {
     if (ulPin >= __GPIOCNT) {
-        DEBUGCORE("ERROR: Illegal pin in pinMode (%d)\n", ulPin);
+        DEBUGCORE("ERROR: Illegal pin in pinMode (%d)", ulPin);
         return;
     }
     gpio_set_function(ulPin, GPIO_FUNC_SIO);
@@ -111,7 +111,7 @@ extern "C" void __digitalWrite(pin_size_t ulPin, PinStatus ulVal) {
 extern "C" PinStatus digitalRead(pin_size_t ulPin) __attribute__((weak, alias("__digitalRead")));
 extern "C" PinStatus __digitalRead(pin_size_t ulPin) {
     if (ulPin >= __GPIOCNT) {
-        DEBUGCORE("ERROR: Illegal pin in digitalRead (%d)\n", ulPin);
+        DEBUGCORE("ERROR: Illegal pin in digitalRead (%d)", ulPin);
         return LOW;
     }
     return gpio_get(ulPin) ? HIGH : LOW;

--- a/cores/rp2040/wiring_pulse.cpp
+++ b/cores/rp2040/wiring_pulse.cpp
@@ -27,7 +27,7 @@ extern "C" unsigned long pulseIn(uint8_t pin, uint8_t state, unsigned long timeo
     uint64_t abort = start + timeout;
 
     if (pin >= __GPIOCNT) {
-        DEBUGCORE("ERROR: Illegal pin in pulseIn (%d)\n", pin);
+        DEBUGCORE("ERROR: Illegal pin in pulseIn (%d)", pin);
         return 0;
     }
 

--- a/cores/rp2040/wiring_shift.cpp
+++ b/cores/rp2040/wiring_shift.cpp
@@ -25,11 +25,11 @@ extern "C" uint8_t shiftIn(pin_size_t dataPin, pin_size_t clockPin, BitOrder bit
     uint8_t value = 0;
     uint8_t i;
     if (dataPin >= __GPIOCNT) {
-        DEBUGCORE("ERROR: Illegal dataPin in shiftIn (%d)\n", dataPin);
+        DEBUGCORE("ERROR: Illegal dataPin in shiftIn (%d)", dataPin);
         return 0;
     }
     if (clockPin >= __GPIOCNT) {
-        DEBUGCORE("ERROR: Illegal clockPin in shiftIn (%d)\n", clockPin);
+        DEBUGCORE("ERROR: Illegal clockPin in shiftIn (%d)", clockPin);
         return 0;
     }
     for (i = 0; i < 8; ++i) {
@@ -47,11 +47,11 @@ extern "C" uint8_t shiftIn(pin_size_t dataPin, pin_size_t clockPin, BitOrder bit
 extern "C" void shiftOut(pin_size_t dataPin, pin_size_t clockPin, BitOrder bitOrder, uint8_t val) {
     uint8_t i;
     if (dataPin >= __GPIOCNT) {
-        DEBUGCORE("ERROR: Illegal dataPin in shiftOut (%d)\n", dataPin);
+        DEBUGCORE("ERROR: Illegal dataPin in shiftOut (%d)", dataPin);
         return;
     }
     if (clockPin >= __GPIOCNT) {
-        DEBUGCORE("ERROR: Illegal clockPin in shiftOut (%d)\n", clockPin);
+        DEBUGCORE("ERROR: Illegal clockPin in shiftOut (%d)", clockPin);
         return;
     }
     for (i = 0; i < 8; i++)  {

--- a/libraries/ADCInput/src/ADCInput.cpp
+++ b/libraries/ADCInput/src/ADCInput.cpp
@@ -131,7 +131,7 @@ bool ADCInput::begin() {
     // For 4 inputs we need to have a multiple of 2 words, same reason.  See #2991
     // Data = [ADC0:ADC1, ADC2:ADC3] [ADC0:ADC1, ADC2:ADC3]
     if (((cnt == 3) && (_bufferWords % 3)) || ((cnt == 4) && (_bufferWords % 2))) {
-        DEBUGV("ADCInput: bufferWords needs to be a multiple of 3 for 3 inputs, 2 for 4 inputs\n");
+        DEBUGV("ADCInput: bufferWords needs to be a multiple of 3 for 3 inputs, 2 for 4 inputs");
         return false;
     }
 

--- a/libraries/BLE/src/BLE.cpp
+++ b/libraries/BLE/src/BLE.cpp
@@ -237,44 +237,44 @@ void BLEClass::packetHandler(uint8_t type, uint16_t channel, uint8_t *packet, ui
             break;
 
         case SM_EVENT_JUST_WORKS_REQUEST:
-            DEBUGBLE("Just Works requested\n");
+            DEBUGBLE("Just Works requested");
             sm_just_works_confirm(sm_event_just_works_request_get_handle(packet));
             break;
         case SM_EVENT_NUMERIC_COMPARISON_REQUEST:
-            DEBUGBLE("Confirming numeric comparison: %" PRIu32 "\n", sm_event_numeric_comparison_request_get_passkey(packet));
+            DEBUGBLE("Confirming numeric comparison: %" PRIu32 "", sm_event_numeric_comparison_request_get_passkey(packet));
             sm_numeric_comparison_confirm(sm_event_passkey_display_number_get_handle(packet));
             break;
         case SM_EVENT_PASSKEY_DISPLAY_NUMBER:
-            DEBUGBLE("Display Passkey: %" PRIu32 "\n", sm_event_passkey_display_number_get_passkey(packet));
+            DEBUGBLE("Display Passkey: %" PRIu32 "", sm_event_passkey_display_number_get_passkey(packet));
             break;
         case SM_EVENT_IDENTITY_CREATED:
             sm_event_identity_created_get_identity_address(packet, addr);
-            DEBUGBLE("Identity created: type %u address %s\n", sm_event_identity_created_get_identity_addr_type(packet), bd_addr_to_str(addr));
+            DEBUGBLE("Identity created: type %u address %s", sm_event_identity_created_get_identity_addr_type(packet), bd_addr_to_str(addr));
             break;
         case SM_EVENT_IDENTITY_RESOLVING_SUCCEEDED:
             sm_event_identity_resolving_succeeded_get_identity_address(packet, addr);
-            DEBUGBLE("Identity resolved: type %u address %s\n", sm_event_identity_resolving_succeeded_get_identity_addr_type(packet), bd_addr_to_str(addr));
+            DEBUGBLE("Identity resolved: type %u address %s", sm_event_identity_resolving_succeeded_get_identity_addr_type(packet), bd_addr_to_str(addr));
             break;
         case SM_EVENT_IDENTITY_RESOLVING_FAILED:
             sm_event_identity_created_get_address(packet, addr);
-            DEBUGBLE("Identity resolving failed\n");
+            DEBUGBLE("Identity resolving failed");
             break;
         case SM_EVENT_PAIRING_STARTED:
-            DEBUGBLE("Pairing started\n");
+            DEBUGBLE("Pairing started");
             break;
         case SM_EVENT_PAIRING_COMPLETE:
             switch (sm_event_pairing_complete_get_status(packet)) {
             case ERROR_CODE_SUCCESS:
-                DEBUGBLE("Pairing complete, success\n");
+                DEBUGBLE("Pairing complete, success");
                 break;
             case ERROR_CODE_CONNECTION_TIMEOUT:
-                DEBUGBLE("Pairing failed, timeout\n");
+                DEBUGBLE("Pairing failed, timeout");
                 break;
             case ERROR_CODE_REMOTE_USER_TERMINATED_CONNECTION:
-                DEBUGBLE("Pairing failed, disconnected\n");
+                DEBUGBLE("Pairing failed, disconnected");
                 break;
             case ERROR_CODE_AUTHENTICATION_FAILURE:
-                DEBUGBLE("Pairing failed, authentication failure with reason = %u\n", sm_event_pairing_complete_get_reason(packet));
+                DEBUGBLE("Pairing failed, authentication failure with reason = %u", sm_event_pairing_complete_get_reason(packet));
                 break;
             default:
                 break;
@@ -381,7 +381,7 @@ void BLEClass::advertisementHandler(uint8_t *packet) {
             break;
 
         default:
-            // DEBUGV("Advertising Data Type 0x%02x not handled yet\n", data_type);
+            // DEBUGV("Advertising Data Type 0x%02x not handled yet", data_type);
             break;
         }
     }

--- a/libraries/BLE/src/BLECharacteristic.h
+++ b/libraries/BLE/src/BLECharacteristic.h
@@ -51,12 +51,12 @@ public:
 
     virtual void onRead(BLECharacteristic *pCharacteristic) {
         (void) pCharacteristic;
-        DEBUGBLE("onRead %p\n", pCharacteristic);
+        DEBUGBLE("onRead %p", pCharacteristic);
     }
 
     virtual void onWrite(BLECharacteristic *pCharacteristic) {
         (void) pCharacteristic;
-        DEBUGBLE("onWrite %p\n", pCharacteristic);
+        DEBUGBLE("onWrite %p", pCharacteristic);
     }
 };
 

--- a/libraries/BLE/src/BLEClient.cpp
+++ b/libraries/BLE/src/BLEClient.cpp
@@ -192,14 +192,14 @@ void BLEClient::packetHandler(uint8_t type, uint16_t channel, uint8_t *packet, u
     }
     switch (hci_event_packet_get_type(packet)) {
     case HCI_EVENT_META_GAP:
-        DEBUGBLE("HCI_EVENT_META_GAP\n");
+        DEBUGBLE("HCI_EVENT_META_GAP");
         if (hci_event_gap_meta_get_subevent_code(packet) != GAP_SUBEVENT_LE_CONNECTION_COMPLETE) {
             break;
         }
         con_handle = hci_subevent_le_connection_complete_get_connection_handle(packet);
         break;
     case HCI_EVENT_DISCONNECTION_COMPLETE:
-        DEBUGBLE("HCI_EVENT_DISCONNECTION_COMPLETE\n");
+        DEBUGBLE("HCI_EVENT_DISCONNECTION_COMPLETE");
         for (auto &s : _service) {
             s->disconnect();
             delete s;
@@ -210,7 +210,7 @@ void BLEClient::packetHandler(uint8_t type, uint16_t channel, uint8_t *packet, u
         }
         break;
     case GATT_EVENT_SERVICE_QUERY_RESULT:
-        DEBUGBLE("GATT_EVENT_SERVICE_QUERY_RESULT\n");
+        DEBUGBLE("GATT_EVENT_SERVICE_QUERY_RESULT");
         gatt_event_service_query_result_get_service(packet, &service);
         if (service.uuid16) {
             _service.push_back(new BLERemoteService(con_handle, BLEUUID(service.uuid16), (void *)&service));
@@ -219,11 +219,11 @@ void BLEClient::packetHandler(uint8_t type, uint16_t channel, uint8_t *packet, u
         }
         break;
     case GATT_EVENT_CHARACTERISTIC_QUERY_RESULT:
-        DEBUGBLE("GATT_EVENT_CHARACTERISTIC_QUERY_RESULT\n");
+        DEBUGBLE("GATT_EVENT_CHARACTERISTIC_QUERY_RESULT");
         gatt_event_characteristic_query_result_get_characteristic(packet, &characteristic);
         break;
     case GATT_EVENT_QUERY_COMPLETE:
-        DEBUGBLE("GATT_EVENT_QUERY_COMPLETE\n");
+        DEBUGBLE("GATT_EVENT_QUERY_COMPLETE");
         _waitingForCB = false;
         break;
     }

--- a/libraries/BLE/src/BLEDebug.h
+++ b/libraries/BLE/src/BLEDebug.h
@@ -5,6 +5,6 @@
 #if !defined(DEBUG_RP2040_PORT) || !defined(DEBUG_RP2040_BLE)
 #define DEBUGBLE(...) do { } while(0)
 #else
-#define DEBUGBLE(fmt, ...) do { DEBUG_RP2040_PORT.printf(fmt, ## __VA_ARGS__); DEBUG_RP2040_PORT.flush(); } while (0)
+#define DEBUGBLE(fmt, ...) do { DEBUG_RP2040_PORT.printf(fmt "\r\n", ## __VA_ARGS__); DEBUG_RP2040_PORT.flush(); } while (0)
 #endif
 

--- a/libraries/BLE/src/BLERemoteCharacteristic.cpp
+++ b/libraries/BLE/src/BLERemoteCharacteristic.cpp
@@ -34,7 +34,7 @@ BLERemoteCharacteristic::BLERemoteCharacteristic(uint16_t con, const void /*gatt
     con_handle = con;
     gatt_client_characteristic_t *ch = (gatt_client_characteristic_t *)cha;
     _uuid = ch->uuid16 ? BLEUUID(ch->uuid16) : BLEUUID(ch->uuid128);
-    DEBUGBLE("%s\n", _uuid.toString().c_str());
+    DEBUGBLE("%s", _uuid.toString().c_str());
     memcpy(_gcc, cha, sizeof(gatt_client_characteristic_t));
 }
 
@@ -70,26 +70,26 @@ void BLERemoteCharacteristic::packetHandler(uint8_t type, uint16_t channel, uint
 
     switch (hci_event_packet_get_type(packet)) {
     case GATT_EVENT_CHARACTERISTIC_VALUE_QUERY_RESULT:
-        DEBUGBLE("GATT_EVENT_CHARACTERISTIC_VALUE_QUERY_RESULT\n");
+        DEBUGBLE("GATT_EVENT_CHARACTERISTIC_VALUE_QUERY_RESULT");
         _remoteValueLen = gatt_event_characteristic_value_query_result_get_value_length(packet);
         _remoteValue = realloc(_remoteValue, _remoteValueLen);
         memcpy(_remoteValue, gatt_event_characteristic_value_query_result_get_value(packet), _remoteValueLen);
         break;
 
     case GATT_EVENT_ALL_CHARACTERISTIC_DESCRIPTORS_QUERY_RESULT:
-        DEBUGBLE("GATT_EVENT_ALL_CHARACTERISTIC_DESCRIPTORS_QUERY_RESULT\n");
+        DEBUGBLE("GATT_EVENT_ALL_CHARACTERISTIC_DESCRIPTORS_QUERY_RESULT");
         gatt_event_all_characteristic_descriptors_query_result_get_characteristic_descriptor(packet, &_gattDescriptor[_gattDescriptors++]);
         break;
 
     case GATT_EVENT_CHARACTERISTIC_DESCRIPTOR_QUERY_RESULT:
-        DEBUGBLE("GATT_EVENT_CHARACTERISTIC_DESCRIPTOR_QUERY_RESULT\n");
+        DEBUGBLE("GATT_EVENT_CHARACTERISTIC_DESCRIPTOR_QUERY_RESULT");
         _description = (char *)malloc(gatt_event_characteristic_descriptor_query_result_get_descriptor_length(packet) + 1);
         memcpy(_description, gatt_event_characteristic_descriptor_query_result_get_descriptor(packet), gatt_event_characteristic_descriptor_query_result_get_descriptor_length(packet));
         _description[gatt_event_characteristic_descriptor_query_result_get_descriptor_length(packet)] = 0;
         break;
 
     case GATT_EVENT_NOTIFICATION:
-        DEBUGBLE("GATT_EVENT_NOTIFICATION\n");
+        DEBUGBLE("GATT_EVENT_NOTIFICATION");
         if (gatt_event_notification_get_value_handle(packet) == _gattCharacteristic->value_handle) {
             if (_charCB) {
                 _charCB->onNotify(this, gatt_event_notification_get_value(packet), gatt_event_notification_get_value_length(packet));
@@ -98,12 +98,12 @@ void BLERemoteCharacteristic::packetHandler(uint8_t type, uint16_t channel, uint
                 (_cbFn)(this, gatt_event_notification_get_value(packet), gatt_event_notification_get_value_length(packet));
             }
         } else {
-            DEBUGBLE("Got unexpected notification CB!\n");
+            DEBUGBLE("Got unexpected notification CB!");
         }
         break;
 
     case GATT_EVENT_QUERY_COMPLETE:
-        DEBUGBLE("GATT_EVENT_QUERY_COMPLETE\n");
+        DEBUGBLE("GATT_EVENT_QUERY_COMPLETE");
         *_cbflag = false;
         break;
     }
@@ -162,7 +162,7 @@ void *BLERemoteCharacteristic::valueData() {
 String BLERemoteCharacteristic::description() {
     gatt_client_characteristic_descriptor_t *d = (gatt_client_characteristic_descriptor_t *)gattDescription();
     if (!d || !con_handle) {
-        DEBUGBLE("no secrription descriptor found\n");
+        DEBUGBLE("no secrription descriptor found");
         free(_description);
         _description = nullptr;
         return String("");
@@ -190,7 +190,7 @@ bool BLERemoteCharacteristic::_waitForCompletion(volatile bool &waitForCB) {
         delay(50);
     }
     if (waitForCB) {
-        DEBUGBLE("timeout\n");
+        DEBUGBLE("timeout");
     }
     return !waitForCB;
 }
@@ -250,11 +250,11 @@ bool BLERemoteCharacteristic::setValue(double data64) {
 
 bool BLERemoteCharacteristic::enableNotifications() {
     if (!canNotify()) {
-        DEBUGBLE("can't notify\n");
+        DEBUGBLE("can't notify");
         return false;
     }
     if (_notifyOn) {
-        DEBUGBLE("notify already on\n");
+        DEBUGBLE("notify already on");
         return true;
     }
     volatile bool waitForCB = true;

--- a/libraries/BLE/src/BLERemoteCharacteristic.h
+++ b/libraries/BLE/src/BLERemoteCharacteristic.h
@@ -43,7 +43,7 @@ public:
         (void) p;
         (void) data;
         (void) len;
-        DEBUGBLE("onNotify %p\n", p);
+        DEBUGBLE("onNotify %p", p);
     }
 };
 

--- a/libraries/BLE/src/BLEServer.cpp
+++ b/libraries/BLE/src/BLEServer.cpp
@@ -137,7 +137,7 @@ void BLEServer::packetHandler(uint8_t type, uint16_t channel, uint8_t *packet, u
         switch (hci_event_gap_meta_get_subevent_code(packet)) {
         case GAP_SUBEVENT_LE_CONNECTION_COMPLETE:
             con_handle = gap_subevent_le_connection_complete_get_connection_handle(packet);
-            DEBUGV("Connection complete %04x\n", con_handle);
+            DEBUGV("Connection complete %04x", con_handle);
             for (auto s : _svc) {
                 s->setConHandle(con_handle);
             }

--- a/libraries/BLE/src/BLEServer.h
+++ b/libraries/BLE/src/BLEServer.h
@@ -32,11 +32,11 @@ class BLEServerCallbacks {
 public:
     virtual void onConnect(BLEServer *p) {
         (void) p;
-        DEBUGBLE("BLEServer connect: %p\n", p);
+        DEBUGBLE("BLEServer connect: %p", p);
     }
     virtual void onDisconnect(BLEServer *p) {
         (void) p;
-        DEBUGBLE("BLEServer disconnect: %p\n", p);
+        DEBUGBLE("BLEServer disconnect: %p", p);
     }
 };
 

--- a/libraries/BluetoothAudio/src/A2DPSink.cpp
+++ b/libraries/BluetoothAudio/src/A2DPSink.cpp
@@ -113,7 +113,7 @@ bool A2DPSink::begin() {
             AVDTP_CODEC_SBC, media_sbc_codec_capabilities, sizeof(media_sbc_codec_capabilities),
             stream_endpoint->media_sbc_codec_configuration, sizeof(stream_endpoint->media_sbc_codec_configuration));
     if (!local_stream_endpoint) {
-        DEBUGV("A2DP Source: not enough memory to create local stream endpoint\n");
+        DEBUGV("A2DP Source: not enough memory to create local stream endpoint");
         return false;
     }
     // - Store stream enpoint's SEP ID, as it is used by A2DP API to identify the stream endpoint
@@ -261,7 +261,7 @@ void A2DPSink::handle_pcm_data(int16_t * data, int num_audio_frames, int num_cha
     if (frames_to_store) {
         int status = btstack_ring_buffer_write(&decoded_audio_ring_buffer, (uint8_t *)&output_buffer[frames_to_copy * NUM_CHANNELS], frames_to_store * BYTES_PER_FRAME);
         if (status) {
-            DEBUGV("Error storing samples in PCM ring buffer!!!\n");
+            DEBUGV("Error storing samples in PCM ring buffer!!!");
         }
     }
 
@@ -351,7 +351,7 @@ void A2DPSink::handle_l2cap_media_data_packet(uint8_t seid, uint8_t *packet, uin
     sbc_frame_size = packet_length / sbc_header.num_frames;
     int status = btstack_ring_buffer_write(&sbc_frame_ring_buffer, packet_begin, packet_length);
     if (status != ERROR_CODE_SUCCESS) {
-        DEBUGV("Error storing samples in SBC ring buffer!!!\n");
+        DEBUGV("Error storing samples in SBC ring buffer!!!");
     }
 
     // decide on audio sync drift based on number of sbc frames in queue
@@ -384,7 +384,7 @@ int A2DPSink::read_sbc_header(uint8_t * packet, int size, int * offset, avdtp_sb
     int pos = *offset;
 
     if (size - pos < sbc_header_len) {
-        DEBUGV("Not enough data to read SBC header, expected %d, received %d\n", sbc_header_len, size - pos);
+        DEBUGV("Not enough data to read SBC header, expected %d, received %d", sbc_header_len, size - pos);
         return 0;
     }
 
@@ -402,7 +402,7 @@ int A2DPSink::read_media_data_header(uint8_t *packet, int size, int *offset, avd
     int pos = *offset;
 
     if (size - pos < media_header_len) {
-        DEBUGV("Not enough data to read media packet header, expected %d, received %d\n", media_header_len, size - pos);
+        DEBUGV("Not enough data to read media packet header, expected %d, received %d", media_header_len, size - pos);
         return 0;
     }
 
@@ -448,14 +448,14 @@ void A2DPSink::avrcp_packet_handler(uint8_t packet_type, uint16_t channel, uint8
         local_cid = avrcp_subevent_connection_established_get_avrcp_cid(packet);
         status = avrcp_subevent_connection_established_get_status(packet);
         if (status != ERROR_CODE_SUCCESS) {
-            DEBUGV("AVRCP: Connection failed, status 0x%02x\n", status);
+            DEBUGV("AVRCP: Connection failed, status 0x%02x", status);
             connection->avrcp_cid = 0;
             return;
         }
 
         connection->avrcp_cid = local_cid;
         avrcp_subevent_connection_established_get_bd_addr(packet, address);
-        DEBUGV("AVRCP: Connected to %s, cid 0x%02x\n", bd_addr_to_str(address), connection->avrcp_cid);
+        DEBUGV("AVRCP: Connected to %s, cid 0x%02x", bd_addr_to_str(address), connection->avrcp_cid);
 
         avrcp_target_support_event(connection->avrcp_cid, AVRCP_NOTIFICATION_EVENT_VOLUME_CHANGED);
         avrcp_target_support_event(connection->avrcp_cid, AVRCP_NOTIFICATION_EVENT_BATT_STATUS_CHANGED);
@@ -467,7 +467,7 @@ void A2DPSink::avrcp_packet_handler(uint8_t packet_type, uint16_t channel, uint8
     }
 
     case AVRCP_SUBEVENT_CONNECTION_RELEASED:
-        DEBUGV("AVRCP: Channel released: cid 0x%02x\n", avrcp_subevent_connection_released_get_avrcp_cid(packet));
+        DEBUGV("AVRCP: Channel released: cid 0x%02x", avrcp_subevent_connection_released_get_avrcp_cid(packet));
         connection->avrcp_cid = 0;
         connection->notifications_supported_by_target = 0;
         return;
@@ -504,13 +504,13 @@ void A2DPSink::avrcp_controller_packet_handler(uint8_t packet_type, uint16_t cha
         break;
     case AVRCP_SUBEVENT_GET_CAPABILITY_EVENT_ID_DONE:
 
-        DEBUGV("AVRCP Controller: supported notifications by target:\n");
+        DEBUGV("AVRCP Controller: supported notifications by target:");
         for (event_id = (uint8_t) AVRCP_NOTIFICATION_EVENT_FIRST_INDEX; event_id < (uint8_t) AVRCP_NOTIFICATION_EVENT_LAST_INDEX; event_id++) {
-            DEBUGV("   - [%s] %s\n",
+            DEBUGV("   - [%s] %s",
                    (avrcp_connection->notifications_supported_by_target & (1 << event_id)) != 0 ? "X" : " ",
                    avrcp_notification2str((avrcp_notification_event_id_t)event_id));
         }
-        DEBUGV("\n\n");
+        DEBUGV("");
 
         // automatically enable notifications
         avrcp_controller_enable_notification(avrcp_connection->avrcp_cid, AVRCP_NOTIFICATION_EVENT_PLAYBACK_STATUS_CHANGED);
@@ -520,14 +520,14 @@ void A2DPSink::avrcp_controller_packet_handler(uint8_t packet_type, uint16_t cha
 
     case AVRCP_SUBEVENT_NOTIFICATION_STATE:
         event_id = (avrcp_notification_event_id_t)avrcp_subevent_notification_state_get_event_id(packet);
-        DEBUGV("AVRCP Controller: %s notification registered\n", avrcp_notification2str((avrcp_notification_event_id_t)event_id));
+        DEBUGV("AVRCP Controller: %s notification registered", avrcp_notification2str((avrcp_notification_event_id_t)event_id));
         break;
 
     case AVRCP_SUBEVENT_NOTIFICATION_PLAYBACK_POS_CHANGED:
-        DEBUGV("AVRCP Controller: Playback position changed, position %d ms\n", (unsigned int) avrcp_subevent_notification_playback_pos_changed_get_playback_position_ms(packet));
+        DEBUGV("AVRCP Controller: Playback position changed, position %d ms", (unsigned int) avrcp_subevent_notification_playback_pos_changed_get_playback_position_ms(packet));
         break;
     case AVRCP_SUBEVENT_NOTIFICATION_PLAYBACK_STATUS_CHANGED:
-        DEBUGV("AVRCP Controller: Playback status changed %s\n", avrcp_play_status2str(avrcp_subevent_notification_playback_status_changed_get_play_status(packet)));
+        DEBUGV("AVRCP Controller: Playback status changed %s", avrcp_play_status2str(avrcp_subevent_notification_playback_status_changed_get_play_status(packet)));
         play_status = avrcp_subevent_notification_playback_status_changed_get_play_status(packet);
         switch (play_status) {
         case AVRCP_PLAYBACK_STATUS_PLAYING:
@@ -555,7 +555,7 @@ void A2DPSink::avrcp_controller_packet_handler(uint8_t packet_type, uint16_t cha
         break;
 
     case AVRCP_SUBEVENT_NOTIFICATION_NOW_PLAYING_CONTENT_CHANGED:
-        DEBUGV("AVRCP Controller: Playing content changed\n");
+        DEBUGV("AVRCP Controller: Playing content changed");
         break;
 
     case AVRCP_SUBEVENT_NOTIFICATION_TRACK_CHANGED:
@@ -567,11 +567,11 @@ void A2DPSink::avrcp_controller_packet_handler(uint8_t packet_type, uint16_t cha
         if (_trackChangedCB) {
             _trackChangedCB(_trackChangedData);
         }
-        DEBUGV("AVRCP Controller: Track changed\n");
+        DEBUGV("AVRCP Controller: Track changed");
         break;
 
     case AVRCP_SUBEVENT_NOTIFICATION_AVAILABLE_PLAYERS_CHANGED:
-        DEBUGV("AVRCP Controller: Available Players Changed\n");
+        DEBUGV("AVRCP Controller: Available Players Changed");
         break;
 
     case AVRCP_SUBEVENT_SHUFFLE_AND_REPEAT_MODE: {
@@ -579,15 +579,15 @@ void A2DPSink::avrcp_controller_packet_handler(uint8_t packet_type, uint16_t cha
         uint8_t repeat_mode  = avrcp_subevent_shuffle_and_repeat_mode_get_repeat_mode(packet);
         (void) shuffle_mode;
         (void) repeat_mode;
-        DEBUGV("AVRCP Controller: %s, %s\n", avrcp_shuffle2str(shuffle_mode), avrcp_repeat2str(repeat_mode));
+        DEBUGV("AVRCP Controller: %s, %s", avrcp_shuffle2str(shuffle_mode), avrcp_repeat2str(repeat_mode));
         break;
     }
     case AVRCP_SUBEVENT_NOW_PLAYING_TRACK_INFO:
-        DEBUGV("AVRCP Controller: Track %d\n", avrcp_subevent_now_playing_track_info_get_track(packet));
+        DEBUGV("AVRCP Controller: Track %d", avrcp_subevent_now_playing_track_info_get_track(packet));
         break;
 
     case AVRCP_SUBEVENT_NOW_PLAYING_TOTAL_TRACKS_INFO:
-        DEBUGV("AVRCP Controller: Total Tracks %d\n", avrcp_subevent_now_playing_total_tracks_info_get_total_tracks(packet));
+        DEBUGV("AVRCP Controller: Total Tracks %d", avrcp_subevent_now_playing_total_tracks_info_get_total_tracks(packet));
         break;
 
     case AVRCP_SUBEVENT_NOW_PLAYING_TITLE_INFO:
@@ -595,7 +595,7 @@ void A2DPSink::avrcp_controller_packet_handler(uint8_t packet_type, uint16_t cha
             memcpy(avrcp_subevent_value, avrcp_subevent_now_playing_title_info_get_value(packet), avrcp_subevent_now_playing_title_info_get_value_len(packet));
             strncpy(_title, (char *)avrcp_subevent_value, sizeof(_title));
             _title[sizeof(_title) - 1] = 0;
-            DEBUGV("AVRCP Controller: Title %s\n", avrcp_subevent_value);
+            DEBUGV("AVRCP Controller: Title %s", avrcp_subevent_value);
         }
         break;
 
@@ -604,7 +604,7 @@ void A2DPSink::avrcp_controller_packet_handler(uint8_t packet_type, uint16_t cha
             memcpy(avrcp_subevent_value, avrcp_subevent_now_playing_artist_info_get_value(packet), avrcp_subevent_now_playing_artist_info_get_value_len(packet));
             strncpy(_artist, (char *)avrcp_subevent_value, sizeof(_artist));
             _artist[sizeof(_artist) - 1] = 0;
-            DEBUGV("AVRCP Controller: Artist %s\n", avrcp_subevent_value);
+            DEBUGV("AVRCP Controller: Artist %s", avrcp_subevent_value);
         }
         break;
 
@@ -613,7 +613,7 @@ void A2DPSink::avrcp_controller_packet_handler(uint8_t packet_type, uint16_t cha
             memcpy(avrcp_subevent_value, avrcp_subevent_now_playing_album_info_get_value(packet), avrcp_subevent_now_playing_album_info_get_value_len(packet));
             strncpy(_album, (char *)avrcp_subevent_value, sizeof(_album));
             _album[sizeof(_album) - 1] = 0;
-            DEBUGV("AVRCP Controller: Album %s\n", avrcp_subevent_value);
+            DEBUGV("AVRCP Controller: Album %s", avrcp_subevent_value);
         }
         break;
 
@@ -622,31 +622,31 @@ void A2DPSink::avrcp_controller_packet_handler(uint8_t packet_type, uint16_t cha
             memcpy(avrcp_subevent_value, avrcp_subevent_now_playing_genre_info_get_value(packet), avrcp_subevent_now_playing_genre_info_get_value_len(packet));
             strncpy(_genre, (char *)avrcp_subevent_value, sizeof(_genre));
             _genre[sizeof(_genre) - 1] = 0;
-            DEBUGV("AVRCP Controller: Genre %s\n", avrcp_subevent_value);
+            DEBUGV("AVRCP Controller: Genre %s", avrcp_subevent_value);
         }
         break;
 
     case AVRCP_SUBEVENT_PLAY_STATUS:
-        DEBUGV("AVRCP Controller: Song length %" PRIu32 " ms, Song position %" PRIu32 " ms, Play status %s\n",
+        DEBUGV("AVRCP Controller: Song length %" PRIu32 " ms, Song position %" PRIu32 " ms, Play status %s",
                avrcp_subevent_play_status_get_song_length(packet),
                avrcp_subevent_play_status_get_song_position(packet),
                avrcp_play_status2str(avrcp_subevent_play_status_get_play_status(packet)));
         break;
 
     case AVRCP_SUBEVENT_OPERATION_COMPLETE:
-        DEBUGV("AVRCP Controller: %s complete\n", avrcp_operation2str(avrcp_subevent_operation_complete_get_operation_id(packet)));
+        DEBUGV("AVRCP Controller: %s complete", avrcp_operation2str(avrcp_subevent_operation_complete_get_operation_id(packet)));
         break;
 
     case AVRCP_SUBEVENT_OPERATION_START:
-        DEBUGV("AVRCP Controller: %s start\n", avrcp_operation2str(avrcp_subevent_operation_start_get_operation_id(packet)));
+        DEBUGV("AVRCP Controller: %s start", avrcp_operation2str(avrcp_subevent_operation_start_get_operation_id(packet)));
         break;
 
     case AVRCP_SUBEVENT_NOTIFICATION_EVENT_TRACK_REACHED_END:
-        DEBUGV("AVRCP Controller: Track reached end\n");
+        DEBUGV("AVRCP Controller: Track reached end");
         break;
 
     case AVRCP_SUBEVENT_PLAYER_APPLICATION_VALUE_RESPONSE:
-        DEBUGV("AVRCP Controller: Set Player App Value %s\n", avrcp_ctype2str(avrcp_subevent_player_application_value_response_get_command_type(packet)));
+        DEBUGV("AVRCP Controller: Set Player App Value %s", avrcp_ctype2str(avrcp_subevent_player_application_value_response_get_command_type(packet)));
         break;
 
     default:
@@ -674,7 +674,7 @@ void A2DPSink::avrcp_target_packet_handler(uint8_t packet_type, uint16_t channel
     case AVRCP_SUBEVENT_NOTIFICATION_VOLUME_CHANGED:
         volume = avrcp_subevent_notification_volume_changed_get_absolute_volume(packet);
         volume_percentage = volume * 100 / 127;
-        DEBUGV("AVRCP Target    : Volume set to %d%% (%d)\n", volume_percentage, volume);
+        DEBUGV("AVRCP Target    : Volume set to %d%% (%d)", volume_percentage, volume);
         _consumer->setVolume(volume);
         if (_volumeCB) {
             _volumeCB(_volumeData, volume);
@@ -684,23 +684,23 @@ void A2DPSink::avrcp_target_packet_handler(uint8_t packet_type, uint16_t channel
     case AVRCP_SUBEVENT_OPERATION:
         operation_id = (avrcp_operation_id_t)avrcp_subevent_operation_get_operation_id(packet);
         button_state = avrcp_subevent_operation_get_button_pressed(packet) > 0 ? "PRESS" : "RELEASE";
-        DEBUGV("AVRCP Target: operation %s (%s)\n", avrcp_operation2str(operation_id), button_state);
+        DEBUGV("AVRCP Target: operation %s (%s)", avrcp_operation2str(operation_id), button_state);
         if (_avrcpCB) {
             _avrcpCB(_avrcpData, operation_id, avrcp_subevent_operation_get_button_pressed(packet) > 0);
         }
         switch (operation_id) {
         case AVRCP_OPERATION_ID_VOLUME_UP:
-            DEBUGV("AVRCP Target    : VOLUME UP (%s)\n", button_state);
+            DEBUGV("AVRCP Target    : VOLUME UP (%s)", button_state);
             break;
         case AVRCP_OPERATION_ID_VOLUME_DOWN:
-            DEBUGV("AVRCP Target    : VOLUME DOWN (%s)\n", button_state);
+            DEBUGV("AVRCP Target    : VOLUME DOWN (%s)", button_state);
             break;
         default:
             return;
         }
         break;
     default:
-        DEBUGV("AVRCP Target    : Event 0x%02x is not parsed\n", packet[2]);
+        DEBUGV("AVRCP Target    : Event 0x%02x is not parsed", packet[2]);
         break;
     }
 }
@@ -723,10 +723,10 @@ void A2DPSink::a2dp_sink_packet_handler(uint8_t packet_type, uint16_t channel, u
 
     switch (packet[2]) {
     case A2DP_SUBEVENT_SIGNALING_MEDIA_CODEC_OTHER_CONFIGURATION:
-        DEBUGV("A2DP  Sink      : Received non SBC codec - not implemented\n");
+        DEBUGV("A2DP  Sink      : Received non SBC codec - not implemented");
         break;
     case A2DP_SUBEVENT_SIGNALING_MEDIA_CODEC_SBC_CONFIGURATION: {
-        DEBUGV("A2DP  Sink      : Received SBC codec configuration\n");
+        DEBUGV("A2DP  Sink      : Received SBC codec configuration");
         a2dp_conn->sbc_configuration.reconfigure = a2dp_subevent_signaling_media_codec_sbc_configuration_get_reconfigure(packet);
         a2dp_conn->sbc_configuration.num_channels = a2dp_subevent_signaling_media_codec_sbc_configuration_get_num_channels(packet);
         a2dp_conn->sbc_configuration.sampling_frequency = a2dp_subevent_signaling_media_codec_sbc_configuration_get_sampling_frequency(packet);
@@ -764,7 +764,7 @@ void A2DPSink::a2dp_sink_packet_handler(uint8_t packet_type, uint16_t channel, u
     case A2DP_SUBEVENT_STREAM_ESTABLISHED:
         status = a2dp_subevent_stream_established_get_status(packet);
         if (status != ERROR_CODE_SUCCESS) {
-            DEBUGV("A2DP  Sink      : Streaming connection failed, status 0x%02x\n", status);
+            DEBUGV("A2DP  Sink      : Streaming connection failed, status 0x%02x", status);
             break;
         }
 
@@ -773,7 +773,7 @@ void A2DPSink::a2dp_sink_packet_handler(uint8_t packet_type, uint16_t channel, u
         a2dp_conn->a2dp_local_seid = a2dp_subevent_stream_established_get_local_seid(packet);
         a2dp_conn->stream_state = STREAM_STATE_OPEN;
 
-        DEBUGV("A2DP  Sink      : Streaming connection is established, address %s, cid 0x%02x, local seid %d\n",
+        DEBUGV("A2DP  Sink      : Streaming connection is established, address %s, cid 0x%02x, local seid %d",
                bd_addr_to_str(a2dp_conn->addr), a2dp_conn->a2dp_cid, a2dp_conn->a2dp_local_seid);
         memcpy(_sourceAddress, a2dp_conn->addr, sizeof(_sourceAddress));
 
@@ -784,7 +784,7 @@ void A2DPSink::a2dp_sink_packet_handler(uint8_t packet_type, uint16_t channel, u
         break;
 
     case A2DP_SUBEVENT_STREAM_STARTED:
-        DEBUGV("A2DP  Sink      : Stream started\n");
+        DEBUGV("A2DP  Sink      : Stream started");
         a2dp_conn->stream_state = STREAM_STATE_PLAYING;
         if (a2dp_conn->sbc_configuration.reconfigure) {
             media_processing_close();
@@ -795,19 +795,19 @@ void A2DPSink::a2dp_sink_packet_handler(uint8_t packet_type, uint16_t channel, u
         break;
 
     case A2DP_SUBEVENT_STREAM_SUSPENDED:
-        DEBUGV("A2DP  Sink      : Stream paused\n");
+        DEBUGV("A2DP  Sink      : Stream paused");
         a2dp_conn->stream_state = STREAM_STATE_PAUSED;
         media_processing_pause();
         break;
 
     case A2DP_SUBEVENT_STREAM_RELEASED:
-        DEBUGV("A2DP  Sink      : Stream released\n");
+        DEBUGV("A2DP  Sink      : Stream released");
         a2dp_conn->stream_state = STREAM_STATE_CLOSED;
         media_processing_close();
         break;
 
     case A2DP_SUBEVENT_SIGNALING_CONNECTION_RELEASED:
-        DEBUGV("A2DP  Sink      : Signaling connection released\n");
+        DEBUGV("A2DP  Sink      : Signaling connection released");
         a2dp_conn->a2dp_cid = 0;
         media_processing_close();
         _connected = false;

--- a/libraries/BluetoothAudio/src/A2DPSource.cpp
+++ b/libraries/BluetoothAudio/src/A2DPSource.cpp
@@ -80,7 +80,7 @@ bool A2DPSource::begin() {
 
     _pcmBuffer = (int16_t *)malloc(_pcmBufferSize * sizeof(int16_t));
     if (!_pcmBuffer) {
-        DEBUGV("A2DPSource: OOM for pcm buffer\n");
+        DEBUGV("A2DPSource: OOM for pcm buffer");
         return false;
     }
     _pcmWriter = 0;
@@ -105,7 +105,7 @@ bool A2DPSource::begin() {
     // Create stream endpoint
     avdtp_stream_endpoint_t * local_stream_endpoint = a2dp_source_create_stream_endpoint(AVDTP_AUDIO, AVDTP_CODEC_SBC, media_sbc_codec_capabilities, sizeof(media_sbc_codec_capabilities), media_sbc_codec_configuration, sizeof(media_sbc_codec_configuration));
     if (!local_stream_endpoint) {
-        DEBUGV("A2DP Source: not enough memory to create local stream endpoint\n");
+        DEBUGV("A2DP Source: not enough memory to create local stream endpoint");
         return false;
     }
 
@@ -185,13 +185,13 @@ bool A2DPSource::connect(const uint8_t *addr) {
         clearPairing();
         auto l = scan();
         for (auto e : l) {
-            DEBUGV("Scan connecting %s at %s ... ", e.name(), e.addressString());
+            DEBUGV("Scan connecting %s at %s ...", e.name(), e.addressString());
             memcpy(a, e.address(), sizeof(a));
             if (!a2dp_source_establish_stream(a, &media_tracker.a2dp_cid)) {
-                DEBUGV("Connection established\n");
+                DEBUGV("Connection established");
                 return true;
             }
-            DEBUGV("Failed\n");
+            DEBUGV("Connection failed");
         }
         return false;
     }
@@ -399,14 +399,14 @@ void A2DPSource::a2dp_source_packet_handler(uint8_t packet_type, uint16_t channe
         status = a2dp_subevent_signaling_connection_established_get_status(packet);
 
         if (status != ERROR_CODE_SUCCESS) {
-            DEBUGV("A2DP Source: Connection failed, status 0x%02x, cid 0x%02x, a2dp_cid 0x%02x \n", status, cid, media_tracker.a2dp_cid);
+            DEBUGV("A2DP Source: Connection failed, status 0x%02x, cid 0x%02x, a2dp_cid 0x%02x", status, cid, media_tracker.a2dp_cid);
             media_tracker.a2dp_cid = 0;
             break;
         }
         media_tracker.a2dp_cid = cid;
         media_tracker.volume = 32;
         memcpy(_sinkAddress, address, sizeof(_sinkAddress));
-        DEBUGV("A2DP Source: Connected to address %s, a2dp cid 0x%02x, local seid 0x%02x.\n", bd_addr_to_str(address), media_tracker.a2dp_cid, media_tracker.local_seid);
+        DEBUGV("A2DP Source: Connected to address %s, a2dp cid 0x%02x, local seid 0x%02x.", bd_addr_to_str(address), media_tracker.a2dp_cid, media_tracker.local_seid);
         break;
 
     case A2DP_SUBEVENT_SIGNALING_MEDIA_CODEC_SBC_CONFIGURATION: {
@@ -428,7 +428,7 @@ void A2DPSource::a2dp_source_packet_handler(uint8_t packet_type, uint16_t channe
         channel_mode = (avdtp_channel_mode_t) a2dp_subevent_signaling_media_codec_sbc_configuration_get_channel_mode(packet);
         allocation_method = a2dp_subevent_signaling_media_codec_sbc_configuration_get_allocation_method(packet);
 
-        DEBUGV("A2DP Source: Received SBC codec configuration, sampling frequency %u, a2dp_cid 0x%02x, local seid 0x%02x, remote seid 0x%02x.\n",
+        DEBUGV("A2DP Source: Received SBC codec configuration, sampling frequency %u, a2dp_cid 0x%02x, local seid 0x%02x, remote seid 0x%02x.",
                sbc_configuration.sampling_frequency, cid,
                a2dp_subevent_signaling_media_codec_sbc_configuration_get_local_seid(packet),
                a2dp_subevent_signaling_media_codec_sbc_configuration_get_remote_seid(packet));
@@ -463,16 +463,16 @@ void A2DPSource::a2dp_source_packet_handler(uint8_t packet_type, uint16_t channe
     }
 
     case A2DP_SUBEVENT_SIGNALING_DELAY_REPORTING_CAPABILITY:
-        DEBUGV("A2DP Source: remote supports delay report, remote seid %d\n",
+        DEBUGV("A2DP Source: remote supports delay report, remote seid %d",
                avdtp_subevent_signaling_delay_reporting_capability_get_remote_seid(packet));
         break;
     case A2DP_SUBEVENT_SIGNALING_CAPABILITIES_DONE:
-        DEBUGV("A2DP Source: All capabilities reported, remote seid %d\n",
+        DEBUGV("A2DP Source: All capabilities reported, remote seid %d",
                avdtp_subevent_signaling_capabilities_done_get_remote_seid(packet));
         break;
 
     case A2DP_SUBEVENT_SIGNALING_DELAY_REPORT:
-        DEBUGV("A2DP Source: Received delay report of %d.%0d ms, local seid %d\n",
+        DEBUGV("A2DP Source: Received delay report of %d.%0d ms, local seid %d",
                avdtp_subevent_signaling_delay_report_get_delay_100us(packet) / 10, avdtp_subevent_signaling_delay_report_get_delay_100us(packet) % 10,
                avdtp_subevent_signaling_delay_report_get_local_seid(packet));
         break;
@@ -481,14 +481,14 @@ void A2DPSource::a2dp_source_packet_handler(uint8_t packet_type, uint16_t channe
         a2dp_subevent_stream_established_get_bd_addr(packet, address);
         status = a2dp_subevent_stream_established_get_status(packet);
         if (status != ERROR_CODE_SUCCESS) {
-            DEBUGV("A2DP Source: Stream failed, status 0x%02x.\n", status);
+            DEBUGV("A2DP Source: Stream failed, status 0x%02x.", status);
             break;
         }
 
         local_seid = a2dp_subevent_stream_established_get_local_seid(packet);
         cid = a2dp_subevent_stream_established_get_a2dp_cid(packet);
         (void) local_seid;
-        DEBUGV("A2DP Source: Stream established a2dp_cid 0x%02x, local_seid 0x%02x, remote_seid 0x%02x\n", cid, local_seid, a2dp_subevent_stream_established_get_remote_seid(packet));
+        DEBUGV("A2DP Source: Stream established a2dp_cid 0x%02x, local_seid 0x%02x, remote_seid 0x%02x", cid, local_seid, a2dp_subevent_stream_established_get_remote_seid(packet));
 
         media_tracker.stream_opened = 1;
         status = a2dp_source_start_stream(media_tracker.a2dp_cid, media_tracker.local_seid);
@@ -500,11 +500,11 @@ void A2DPSource::a2dp_source_packet_handler(uint8_t packet_type, uint16_t channe
         cid = a2dp_subevent_stream_reconfigured_get_a2dp_cid(packet);
 
         if (status != ERROR_CODE_SUCCESS) {
-            DEBUGV("A2DP Source: Stream reconfiguration failed, status 0x%02x\n", status);
+            DEBUGV("A2DP Source: Stream reconfiguration failed, status 0x%02x", status);
             break;
         }
 
-        DEBUGV("A2DP Source: Stream reconfigured a2dp_cid 0x%02x, local_seid 0x%02x\n", cid, local_seid);
+        DEBUGV("A2DP Source: Stream reconfigured a2dp_cid 0x%02x, local_seid 0x%02x", cid, local_seid);
         status = a2dp_source_start_stream(media_tracker.a2dp_cid, media_tracker.local_seid);
         break;
 
@@ -518,7 +518,7 @@ void A2DPSource::a2dp_source_packet_handler(uint8_t packet_type, uint16_t channe
             avrcp_target_set_playback_status(media_tracker.avrcp_cid, AVRCP_PLAYBACK_STATUS_PLAYING);
         }
         a2dp_timer_start(&media_tracker);
-        DEBUGV("A2DP Source: Stream started, a2dp_cid 0x%02x, local_seid 0x%02x\n", cid, local_seid);
+        DEBUGV("A2DP Source: Stream started, a2dp_cid 0x%02x, local_seid 0x%02x", cid, local_seid);
         _connected = true;
         if (_connectCB) {
             _connectCB(_connectData, true);
@@ -539,7 +539,7 @@ void A2DPSource::a2dp_source_packet_handler(uint8_t packet_type, uint16_t channe
         if (media_tracker.avrcp_cid) {
             avrcp_target_set_playback_status(media_tracker.avrcp_cid, AVRCP_PLAYBACK_STATUS_PAUSED);
         }
-        DEBUGV("A2DP Source: Stream paused, a2dp_cid 0x%02x, local_seid 0x%02x\n", cid, local_seid);
+        DEBUGV("A2DP Source: Stream paused, a2dp_cid 0x%02x, local_seid 0x%02x", cid, local_seid);
 
         a2dp_timer_stop(&media_tracker);
         break;
@@ -549,11 +549,11 @@ void A2DPSource::a2dp_source_packet_handler(uint8_t packet_type, uint16_t channe
         cid = a2dp_subevent_stream_released_get_a2dp_cid(packet);
         local_seid = a2dp_subevent_stream_released_get_local_seid(packet);
 
-        DEBUGV("A2DP Source: Stream released, a2dp_cid 0x%02x, local_seid 0x%02x\n", cid, local_seid);
+        DEBUGV("A2DP Source: Stream released, a2dp_cid 0x%02x, local_seid 0x%02x", cid, local_seid);
 
         if (cid == media_tracker.a2dp_cid) {
             media_tracker.stream_opened = 0;
-            DEBUGV("A2DP Source: Stream released.\n");
+            DEBUGV("A2DP Source: Stream released.");
         }
         if (media_tracker.avrcp_cid) {
             avrcp_target_set_now_playing_info(media_tracker.avrcp_cid, NULL, _tracks);
@@ -566,7 +566,7 @@ void A2DPSource::a2dp_source_packet_handler(uint8_t packet_type, uint16_t channe
         if (cid == media_tracker.a2dp_cid) {
             media_tracker.avrcp_cid = 0;
             media_tracker.a2dp_cid = 0;
-            DEBUGV("A2DP Source: Signaling released.\n\n");
+            DEBUGV("A2DP Source: Signaling released.");
             _connected = false;
             if (_connectCB) {
                 _connectCB(_connectData, false);
@@ -597,27 +597,27 @@ void A2DPSource::avrcp_packet_handler(uint8_t packet_type, uint16_t channel, uin
         local_cid = avrcp_subevent_connection_established_get_avrcp_cid(packet);
         status = avrcp_subevent_connection_established_get_status(packet);
         if (status != ERROR_CODE_SUCCESS) {
-            DEBUGV("AVRCP: Connection failed, local cid 0x%02x, status 0x%02x\n", local_cid, status);
+            DEBUGV("AVRCP: Connection failed, local cid 0x%02x, status 0x%02x", local_cid, status);
             return;
         }
         media_tracker.avrcp_cid = local_cid;
         avrcp_subevent_connection_established_get_bd_addr(packet, event_addr);
 
-        DEBUGV("AVRCP: Channel to %s successfully opened, avrcp_cid 0x%02x\n", bd_addr_to_str(event_addr), media_tracker.avrcp_cid);
+        DEBUGV("AVRCP: Channel to %s successfully opened, avrcp_cid 0x%02x", bd_addr_to_str(event_addr), media_tracker.avrcp_cid);
 
         avrcp_target_support_event(media_tracker.avrcp_cid, AVRCP_NOTIFICATION_EVENT_PLAYBACK_STATUS_CHANGED);
         avrcp_target_support_event(media_tracker.avrcp_cid, AVRCP_NOTIFICATION_EVENT_TRACK_CHANGED);
         avrcp_target_support_event(media_tracker.avrcp_cid, AVRCP_NOTIFICATION_EVENT_NOW_PLAYING_CONTENT_CHANGED);
         avrcp_target_set_now_playing_info(media_tracker.avrcp_cid, NULL, _tracks);
 
-        DEBUGV("Enable Volume Change notification\n");
+        DEBUGV("Enable Volume Change notification");
         avrcp_controller_enable_notification(media_tracker.avrcp_cid, AVRCP_NOTIFICATION_EVENT_VOLUME_CHANGED);
-        DEBUGV("Enable Battery Status Change notification\n");
+        DEBUGV("Enable Battery Status Change notification");
         avrcp_controller_enable_notification(media_tracker.avrcp_cid, AVRCP_NOTIFICATION_EVENT_BATT_STATUS_CHANGED);
         return;
 
     case AVRCP_SUBEVENT_CONNECTION_RELEASED:
-        DEBUGV("AVRCP Target: Disconnected, avrcp_cid 0x%02x\n", avrcp_subevent_connection_released_get_avrcp_cid(packet));
+        DEBUGV("AVRCP Target: Disconnected, avrcp_cid 0x%02x", avrcp_subevent_connection_released_get_avrcp_cid(packet));
         media_tracker.avrcp_cid = 0;
         return;
     default:
@@ -625,7 +625,7 @@ void A2DPSource::avrcp_packet_handler(uint8_t packet_type, uint16_t channel, uin
     }
 
     if (status != ERROR_CODE_SUCCESS) {
-        DEBUGV("Responding to event 0x%02x failed, status 0x%02x\n", packet[2], status);
+        DEBUGV("Responding to event 0x%02x failed, status 0x%02x", packet[2], status);
     }
 }
 
@@ -657,7 +657,7 @@ void A2DPSource::avrcp_target_packet_handler(uint8_t packet_type, uint16_t chann
         button_pressed = avrcp_subevent_operation_get_button_pressed(packet) > 0;
         button_state = button_pressed ? "PRESS" : "RELEASE";
         (void) button_state;
-        DEBUGV("AVRCP Target: operation %s (%s)\n", avrcp_operation2str(operation_id), button_state);
+        DEBUGV("AVRCP Target: operation %s (%s)", avrcp_operation2str(operation_id), button_state);
         if (_avrcpCB) {
             _avrcpCB(_avrcpData, operation_id, button_pressed);
         }
@@ -683,7 +683,7 @@ void A2DPSource::avrcp_target_packet_handler(uint8_t packet_type, uint16_t chann
     }
 
     if (status != ERROR_CODE_SUCCESS) {
-        DEBUGV("Responding to event 0x%02x failed, status 0x%02x\n", packet[2], status);
+        DEBUGV("Responding to event 0x%02x failed, status 0x%02x", packet[2], status);
     }
 }
 
@@ -703,20 +703,20 @@ void A2DPSource::avrcp_controller_packet_handler(uint8_t packet_type, uint16_t c
 
     switch (packet[2]) {
     case AVRCP_SUBEVENT_NOTIFICATION_VOLUME_CHANGED:
-        DEBUGV("AVRCP Controller: Notification Absolute Volume %d %%\n", avrcp_subevent_notification_volume_changed_get_absolute_volume(packet) * 100 / 127);
+        DEBUGV("AVRCP Controller: Notification Absolute Volume %d %%", avrcp_subevent_notification_volume_changed_get_absolute_volume(packet) * 100 / 127);
         if (_volumeCB) {
             _volumeCB(_volumeData, avrcp_subevent_notification_volume_changed_get_absolute_volume(packet) * 100 / 127);
         }
         break;
     case AVRCP_SUBEVENT_NOTIFICATION_EVENT_BATT_STATUS_CHANGED:
         // see avrcp_battery_status_t
-        DEBUGV("AVRCP Controller: Notification Battery Status 0x%02x\n", avrcp_subevent_notification_event_batt_status_changed_get_battery_status(packet));
+        DEBUGV("AVRCP Controller: Notification Battery Status 0x%02x", avrcp_subevent_notification_event_batt_status_changed_get_battery_status(packet));
         if (_batteryCB) {
             _batteryCB(_batteryData, (avrcp_battery_status_t)avrcp_subevent_notification_event_batt_status_changed_get_battery_status(packet));
         }
         break;
     case AVRCP_SUBEVENT_NOTIFICATION_STATE:
-        DEBUGV("AVRCP Controller: Notification %s - %s\n",
+        DEBUGV("AVRCP Controller: Notification %s - %s",
                avrcp_event2str(avrcp_subevent_notification_state_get_event_id(packet)),
                avrcp_subevent_notification_state_get_enabled(packet) != 0 ? "enabled" : "disabled");
         break;

--- a/libraries/BluetoothAudio/src/BluetoothMediaConfigurationSBC.h
+++ b/libraries/BluetoothAudio/src/BluetoothMediaConfigurationSBC.h
@@ -35,13 +35,13 @@ public:
     btstack_sbc_allocation_method_t allocation_method;
 
     void dump() {
-        DEBUGV("    - num_channels: %d\n", num_channels);
-        DEBUGV("    - sampling_frequency: %d\n", sampling_frequency);
-        DEBUGV("    - channel_mode: %d\n", channel_mode);
-        DEBUGV("    - block_length: %d\n", block_length);
-        DEBUGV("    - subbands: %d\n", subbands);
-        DEBUGV("    - allocation_method: %d\n", allocation_method);
-        DEBUGV("    - bitpool_value [%d, %d] \n", min_bitpool_value, max_bitpool_value);
-        DEBUGV("\n");
+        DEBUGV("    - num_channels: %d", num_channels);
+        DEBUGV("    - sampling_frequency: %d", sampling_frequency);
+        DEBUGV("    - channel_mode: %d", channel_mode);
+        DEBUGV("    - block_length: %d", block_length);
+        DEBUGV("    - subbands: %d", subbands);
+        DEBUGV("    - allocation_method: %d", allocation_method);
+        DEBUGV("    - bitpool_value [%d, %d]", min_bitpool_value, max_bitpool_value);
+        DEBUGV("");
     }
 };

--- a/libraries/BluetoothHCI/src/BluetoothHCI.cpp
+++ b/libraries/BluetoothHCI/src/BluetoothHCI.cpp
@@ -65,11 +65,15 @@ void BluetoothHCI::setBLEName(const char *name) {
     *ptr++ = 0x00;
     *ptr++ = 0x00;
 
-    DEBUGV("ATTDB: ");
+#if defined(DEBUG_RP2040_PORT)
+    String attHex;
     for (size_t i = 0; i < 1 + 0x0a + 0x0d + 0x08 + strlen(name) + 0x02; i++) {
-        DEBUGV("%02X ", _att[i]);
+        char hex[4];
+        snprintf(hex, sizeof(hex), "%02X ", _att[i]);
+        attHex += hex;
     }
-    DEBUGV("\n");
+    DEBUGV("ATTDB: %s", attHex.c_str());
+#endif
 }
 
 void BluetoothHCI::install() {
@@ -116,14 +120,14 @@ std::vector<BTDeviceInfo> BluetoothHCI::scan(uint32_t mask, int scanTimeSec, boo
     }
     _scanning = true;
     while (!_hciRunning) {
-        DEBUGV("HCI::scan(): Waiting for HCI to come up\n");
+        DEBUGV("HCI::scan(): Waiting for HCI to come up");
         delay(10);
     }
     int inquiryTime = (scanTimeSec * 1000) / 1280; // divide by 1.280
     if (!inquiryTime) {
         inquiryTime = 1;
     }
-    DEBUGV("HCI::scan(): inquiry start\n");
+    DEBUGV("HCI::scan(): inquiry start");
     // Only need to lock around the inquiry start command, not the wait
     {
         BluetoothLock b;
@@ -139,7 +143,7 @@ std::vector<BTDeviceInfo> BluetoothHCI::scan(uint32_t mask, int scanTimeSec, boo
         }
         delay(10);
     }
-    DEBUGV("HCI::scan(): inquiry end, start name requests\n");
+    DEBUGV("HCI::scan(): inquiry end, start name requests");
     for (auto &e : _btdList) {
         if (!e.name()[0]) {
             _requested = &e;
@@ -153,7 +157,7 @@ std::vector<BTDeviceInfo> BluetoothHCI::scan(uint32_t mask, int scanTimeSec, boo
             }
         }
     }
-    DEBUGV("HCI::scan() end name requests\n");
+    DEBUGV("HCI::scan() end name requests");
     return _btdList;
 }
 
@@ -166,14 +170,14 @@ std::vector<BTDeviceInfo> BluetoothHCI::scanBLE(uint32_t uuid, int scanTimeSec, 
     }
     _scanning = true;
     while (!_hciRunning) {
-        DEBUGV("HCI::scanBLE(): Waiting for HCI to come up\n");
+        DEBUGV("HCI::scanBLE(): Waiting for HCI to come up");
         delay(10);
     }
     uint32_t inquiryTime = scanTimeSec * 1000;
     if (!inquiryTime) {
         inquiryTime = 1000;
     }
-    DEBUGV("HCI::scan(): BLE advertise inquiry start\n");
+    DEBUGV("HCI::scan(): BLE advertise inquiry start");
     // Only need to lock around the inquiry start command, not the wait
     do {
         BluetoothLock b;
@@ -188,7 +192,7 @@ std::vector<BTDeviceInfo> BluetoothHCI::scanBLE(uint32_t uuid, int scanTimeSec, 
         }
         delay(10);
     }
-    DEBUGV("HCI::scanBLE(): inquiry end\n");
+    DEBUGV("HCI::scanBLE(): inquiry end");
     do {
         BluetoothLock l;
         gap_stop_scan();
@@ -295,7 +299,7 @@ void BluetoothHCI::parse_advertisement_data(uint8_t *packet) {
         case BLUETOOTH_DATA_TYPE_DEVICE_ID:
         case BLUETOOTH_DATA_TYPE_SECURITY_MANAGER_OUT_OF_BAND_FLAGS:
         default:
-            DEBUGV("Advertising Data Type 0x%2x not handled yet\n", data_type);
+            DEBUGV("Advertising Data Type 0x%2x not handled yet", data_type);
             break;
         }
     }
@@ -363,7 +367,7 @@ void BluetoothHCI::hci_packet_handler(uint8_t packet_type, uint16_t channel, uin
         }
         pageScanRepetitionMode = gap_event_inquiry_result_get_page_scan_repetition_mode(packet);
         clockOffset = gap_event_inquiry_result_get_clock_offset(packet);
-        DEBUGV("HCI: Scan found '%s', COD 0x%08X, RSSI %d, MAC %02X:%02X:%02X:%02X:%02X:%02X\n", name, (unsigned int)cod, rssi, address[0], address[1], address[2], address[3], address[4], address[5]);
+        DEBUGV("HCI: Scan found '%s', COD 0x%08X, RSSI %d, MAC %02X:%02X:%02X:%02X:%02X:%02X", name, (unsigned int)cod, rssi, address[0], address[1], address[2], address[3], address[4], address[5]);
         if ((_scanMask & cod) == _scanMask) {
             // Sometimes we get multiple reports for the same MAC, so remove any old reports since newer will have newer RSSI
             bool updated = false;
@@ -385,22 +389,22 @@ void BluetoothHCI::hci_packet_handler(uint8_t packet_type, uint16_t channel, uin
         break;
 
     case GAP_EVENT_INQUIRY_COMPLETE:
-        DEBUGV("GAP_EVENT_INQUIRY_COMPLETE\n");
+        DEBUGV("GAP_EVENT_INQUIRY_COMPLETE");
         _scanning = false;
         break;
 
     case HCI_EVENT_REMOTE_NAME_REQUEST_COMPLETE:
         if (!_requested) {
-            DEBUGV("Error: HCI_EVENT_REMOTE_NAME_REQUEST_COMPLETE without active request\n");
+            DEBUGV("Error: HCI_EVENT_REMOTE_NAME_REQUEST_COMPLETE without active request");
             return; // How'd we get here?
         }
         reverse_bd_addr(&packet[3], address);
         if (!memcmp(_requested->address(), address, 6)) {
             if (packet[2] == 0) {
-                DEBUGV("Received name: '%s'\n", &packet[9]);
+                DEBUGV("Received name: '%s'", &packet[9]);
                 strcpy(_requested->_name, (char *)packet + 9);
             } else {
-                DEBUGV("Failed to get name: page timeout\n");
+                DEBUGV("Failed to get name: page timeout");
             }
         }
         _requested = nullptr;
@@ -418,7 +422,7 @@ void BluetoothHCI::hci_packet_handler(uint8_t packet_type, uint16_t channel, uin
             _disconnectCB();
         }
         _hciConn = HCI_CON_HANDLE_INVALID;
-        DEBUGV("HCI Disconnected\n");
+        DEBUGV("HCI Disconnected");
         break;
 
     case HCI_EVENT_META_GAP:
@@ -426,10 +430,10 @@ void BluetoothHCI::hci_packet_handler(uint8_t packet_type, uint16_t channel, uin
         if (hci_event_gap_meta_get_subevent_code(packet) != GAP_SUBEVENT_LE_CONNECTION_COMPLETE) {
             break;
         }
-        DEBUGV("HCI Connected\n");
+        DEBUGV("HCI Connected");
         _hciConn =  gap_subevent_le_connection_complete_get_connection_handle(packet);
         if (_smPair) {
-            DEBUGV("Requesting pairing\n");
+            DEBUGV("Requesting pairing");
             sm_request_pairing(_hciConn);
         }
         break;

--- a/libraries/BluetoothHIDMaster/src/BluetoothHIDMaster.cpp
+++ b/libraries/BluetoothHIDMaster/src/BluetoothHIDMaster.cpp
@@ -221,7 +221,7 @@ bool BluetoothHIDMaster::connectCOD(uint32_t cod) {
     clearPairing();
     auto l = scan(cod);
     for (auto e : l) {
-        DEBUGV("Scan connecting %s at %s ...\n", e.name(), e.addressString());
+        DEBUGV("Scan connecting %s at %s ...", e.name(), e.addressString());
         memcpy(a, e.address(), sizeof(a));
         int ret;
         do {
@@ -229,16 +229,16 @@ bool BluetoothHIDMaster::connectCOD(uint32_t cod) {
             ret = hid_host_connect(a, HID_PROTOCOL_MODE_REPORT, &_hid_host_cid);
         } while (0);
         if (ERROR_CODE_SUCCESS == ret) {
-            DEBUGV("Connection established\n");
+            DEBUGV("Connection established");
             memcpy(_lastAddr, e.address(), sizeof(_lastAddr));
             _lastAddrType = e.addressType();
             while (!_hid_host_descriptor_available) {
-                DEBUGV("Waiting for HID descriptor\n");
+                DEBUGV("Waiting for HID descriptor");
                 delay(50);
             }
             return true;
         }
-        DEBUGV("Connection failed %02x\n", ret);
+        DEBUGV("Connection failed %02x", ret);
     }
     return false;
 }
@@ -260,7 +260,7 @@ bool BluetoothHIDMaster::connectBLE(const uint8_t *addr, int addrType, void (*id
         ret = gap_connect(a, (bd_addr_type_t)addrType);
     } while (0);
     if (ERROR_CODE_SUCCESS != ret) {
-        DEBUGV("gap_connect failed %d\n", ret);
+        DEBUGV("gap_connect failed %d", ret);
         return false;
     }
     // GAP connection running async.  Wait for HCI connect
@@ -297,14 +297,14 @@ bool BluetoothHIDMaster::connectBLE(void (*idleFcn)(void *), void *idleFcnData) 
     clearPairing();
     auto l = _hci.scanBLE(0x1812 /* HID */, 5, idleFcn, idleFcnData);
     for (auto e : l) {
-        DEBUGV("Scan connecting %s at %s ... ", e.name(), e.addressString());
+        DEBUGV("Scan connecting %s at %s ...", e.name(), e.addressString());
         if (connectBLE(e.address(), e.addressType(), idleFcn, idleFcnData)) {
-            DEBUGV("Connection established\n");
+            DEBUGV("Connection established");
             memcpy(_lastAddr, e.address(), sizeof(_lastAddr));
             _lastAddrType = e.addressType();
             return true;
         }
-        DEBUGV("Failed\n");
+        DEBUGV("Connection failed");
     }
     memset(_lastAddr, 0, sizeof(_lastAddr));
     _lastAddrType = 0;
@@ -507,7 +507,7 @@ void BluetoothHIDMaster::hid_packet_handler(uint8_t packet_type, uint16_t channe
     switch (hci_event_hid_meta_get_subevent_code(packet)) {
 
     case HID_SUBEVENT_INCOMING_CONNECTION:
-        DEBUGV("HID_SUBEVENT_INCOMING_CONNECTION\n");
+        DEBUGV("HID_SUBEVENT_INCOMING_CONNECTION");
         // There is an incoming connection: we can accept it or decline it.
         // The hid_host_report_mode in the hid_host_accept_connection function
         // allows the application to request a protocol mode.
@@ -516,12 +516,12 @@ void BluetoothHIDMaster::hid_packet_handler(uint8_t packet_type, uint16_t channe
         break;
 
     case HID_SUBEVENT_CONNECTION_OPENED:
-        DEBUGV("HID_SUBEVENT_CONNECTION_OPENED\n");
+        DEBUGV("HID_SUBEVENT_CONNECTION_OPENED");
         // The status field of this event indicates if the control and interrupt
         // connections were opened successfully.
         status = hid_subevent_connection_opened_get_status(packet);
         if (status != ERROR_CODE_SUCCESS) {
-            DEBUGV("Connection failed, status 0x%02x\n", status);
+            DEBUGV("Connection failed, status 0x%02x", status);
             _hidConnected = false;
             _hid_host_cid = 0;
             return;
@@ -529,11 +529,11 @@ void BluetoothHIDMaster::hid_packet_handler(uint8_t packet_type, uint16_t channe
         _hidConnected = true;
         _hid_host_descriptor_available = false;
         _hid_host_cid = hid_subevent_connection_opened_get_hid_cid(packet);
-        DEBUGV("HID Host connected.\n");
+        DEBUGV("HID Host connected.");
         break;
 
     case HID_SUBEVENT_DESCRIPTOR_AVAILABLE:
-        DEBUGV("HID_SUBEVENT_DESCRIPTOR_AVAILABLE\n");
+        DEBUGV("HID_SUBEVENT_DESCRIPTOR_AVAILABLE");
         // This event will follows HID_SUBEVENT_CONNECTION_OPENED event.
         // For incoming connections, i.e. HID Device initiating the connection,
         // the HID_SUBEVENT_DESCRIPTOR_AVAILABLE is delayed, and some HID
@@ -544,7 +544,7 @@ void BluetoothHIDMaster::hid_packet_handler(uint8_t packet_type, uint16_t channe
         if (status == ERROR_CODE_SUCCESS) {
             _hid_host_descriptor_available = true;
         } else {
-            DEBUGV("Cannot handle input report, HID Descriptor is not available, status 0x%02x\n", status);
+            DEBUGV("Cannot handle input report, HID Descriptor is not available, status 0x%02x", status);
         }
         break;
 
@@ -572,29 +572,29 @@ void BluetoothHIDMaster::hid_packet_handler(uint8_t packet_type, uint16_t channe
         // this event will occur only if the established report mode is boot mode.
         status = hid_subevent_set_protocol_response_get_handshake_status(packet);
         if (status != HID_HANDSHAKE_PARAM_TYPE_SUCCESSFUL) {
-            DEBUGV("Error set protocol, status 0x%02x\n", status);
+            DEBUGV("Error set protocol, status 0x%02x", status);
             break;
         }
         switch ((hid_protocol_mode_t)hid_subevent_set_protocol_response_get_protocol_mode(packet)) {
         case HID_PROTOCOL_MODE_BOOT:
-            DEBUGV("Protocol mode set: BOOT.\n");
+            DEBUGV("Protocol mode set: BOOT.");
             break;
         case HID_PROTOCOL_MODE_REPORT:
-            DEBUGV("Protocol mode set: REPORT.\n");
+            DEBUGV("Protocol mode set: REPORT.");
             break;
         default:
-            DEBUGV("Unknown protocol mode.\n");
+            DEBUGV("Unknown protocol mode.");
             break;
         }
         break;
 
     case HID_SUBEVENT_CONNECTION_CLOSED:
-        DEBUGV("HID_SUBEVENT_CONNECTION_CLOSED\n");
+        DEBUGV("HID_SUBEVENT_CONNECTION_CLOSED");
         // The connection was closed.
         _hidConnected = false;
         _hid_host_cid = 0;
         _hid_host_descriptor_available = false;
-        DEBUGV("HID Host disconnected.\n");
+        DEBUGV("HID Host disconnected.");
         break;
 
     default:
@@ -614,66 +614,66 @@ void BluetoothHIDMaster::sm_packet_handler(uint8_t packet_type, uint16_t channel
 
     switch (hci_event_packet_get_type(packet)) {
     case SM_EVENT_JUST_WORKS_REQUEST:
-        DEBUGV("Just works requested\n");
+        DEBUGV("Just works requested");
         sm_just_works_confirm(sm_event_just_works_request_get_handle(packet));
         break;
     case SM_EVENT_NUMERIC_COMPARISON_REQUEST:
-        DEBUGV("Confirming numeric comparison: %" PRIu32 "\n", sm_event_numeric_comparison_request_get_passkey(packet));
+        DEBUGV("Confirming numeric comparison: %" PRIu32 "", sm_event_numeric_comparison_request_get_passkey(packet));
         sm_numeric_comparison_confirm(sm_event_passkey_display_number_get_handle(packet));
         break;
     case SM_EVENT_PASSKEY_DISPLAY_NUMBER:
-        DEBUGV("Display Passkey: %" PRIu32 "\n", sm_event_passkey_display_number_get_passkey(packet));
+        DEBUGV("Display Passkey: %" PRIu32 "", sm_event_passkey_display_number_get_passkey(packet));
         break;
     case SM_EVENT_PAIRING_COMPLETE:
         switch (sm_event_pairing_complete_get_status(packet)) {
         case ERROR_CODE_SUCCESS:
-            DEBUGV("Pairing complete, success\n");
+            DEBUGV("Pairing complete, success");
             // continue - query primary services
-            DEBUGV("Search for HID service.\n");
+            DEBUGV("Search for HID service.");
             //app_state = W4_HID_CLIENT_CONNECTED;
             hids_host_connect(_hci.getHCIConn(), PACKETHANDLERCB(BluetoothHIDMaster, handle_gatt_client_event), HID_PROTOCOL_MODE_REPORT, &_hid_host_cid);
             break;
         case ERROR_CODE_CONNECTION_TIMEOUT:
-            DEBUGV("Pairing failed, timeout\n");
+            DEBUGV("Pairing failed, timeout");
             break;
         case ERROR_CODE_REMOTE_USER_TERMINATED_CONNECTION:
-            DEBUGV("Pairing failed, disconnected\n");
+            DEBUGV("Pairing failed, disconnected");
             break;
         case ERROR_CODE_AUTHENTICATION_FAILURE:
-            DEBUGV("Pairing failed, reason = %u\n", sm_event_pairing_complete_get_reason(packet));
+            DEBUGV("Pairing failed, reason = %u", sm_event_pairing_complete_get_reason(packet));
             break;
         default:
-            DEBUGV("Unknown sm_event_pairing_complete_get_status: %02x\n", sm_event_pairing_complete_get_status(packet));
+            DEBUGV("Unknown sm_event_pairing_complete_get_status: %02x", sm_event_pairing_complete_get_status(packet));
             break;
         }
         break;
     case SM_EVENT_IDENTITY_RESOLVING_STARTED:
-        DEBUGV("Starting search of TLV for precious connection\n");
+        DEBUGV("Starting search of TLV for precious connection");
         break;
     case SM_EVENT_IDENTITY_RESOLVING_FAILED:
-        DEBUGV("Peer not found in TLV\n");
+        DEBUGV("Peer not found in TLV");
         break;
     case SM_EVENT_IDENTITY_RESOLVING_SUCCEEDED:
-        DEBUGV("Peer found in TLV\n");
+        DEBUGV("Peer found in TLV");
         break;
     case SM_EVENT_IDENTITY_CREATED:
-        DEBUGV("Storing peer in TLV\n");
+        DEBUGV("Storing peer in TLV");
         break;
     case SM_EVENT_PAIRING_STARTED:
-        DEBUGV("Pairing started\n");
+        DEBUGV("Pairing started");
         break;
     case SM_EVENT_REENCRYPTION_STARTED:
-        DEBUGV("Starting re-encryption\n");
+        DEBUGV("Starting re-encryption");
         break;
     case SM_EVENT_REENCRYPTION_COMPLETE:
-        DEBUGV("Re-encryption complete, success, searching for HID\n");
+        DEBUGV("Re-encryption complete, success, searching for HID");
         if (!_hid_host_descriptor_available) {
-            DEBUGV("Connecting to HID service\n");
+            DEBUGV("Connecting to HID service");
             hids_host_connect(_hci.getHCIConn(), PACKETHANDLERCB(BluetoothHIDMaster, handle_gatt_client_event), HID_PROTOCOL_MODE_REPORT, &_hid_host_cid);
         }
         break;
     default:
-        DEBUGV("Unknown hci_event_packet_get_type %02x\n", hci_event_packet_get_type(packet));
+        DEBUGV("Unknown hci_event_packet_get_type %02x", hci_event_packet_get_type(packet));
         break;
     }
 }
@@ -696,12 +696,12 @@ void BluetoothHIDMaster::handle_gatt_client_event(uint8_t packet_type, uint16_t 
         status = gattservice_subevent_hid_service_connected_get_status(packet);
         switch (status) {
         case ERROR_CODE_SUCCESS:
-            DEBUGV("HID service client connected, found %d services\n", gattservice_subevent_hid_service_connected_get_num_instances(packet));
+            DEBUGV("HID service client connected, found %d services", gattservice_subevent_hid_service_connected_get_num_instances(packet));
             _hidConnected = true;
             _hid_host_descriptor_available = true;
             break;
         default:
-            DEBUGV("HID service client connection failed, status 0x%02x.\n", status);
+            DEBUGV("HID service client connection failed, status 0x%02x.", status);
             gap_disconnect(_hci.getHCIConn());
             //handle_outgoing_connection_error();
             break;

--- a/libraries/FatFS/src/FatFS.cpp
+++ b/libraries/FatFS/src/FatFS.cpp
@@ -85,11 +85,11 @@ time_t (*__fatfs_timeCallback)(void) = nullptr;
 
 FileImplPtr FatFSImpl::open(const char* path, OpenMode openMode, AccessMode accessMode) {
     if (!_mounted) {
-        DEBUGV("FatFSImpl::open() called on unmounted FS\n");
+        DEBUGV("FatFSImpl::open() called on unmounted FS");
         return FileImplPtr();
     }
     if (!path || !path[0]) {
-        DEBUGV("FatFSImpl::open() called with invalid filename\n");
+        DEBUGV("FatFSImpl::open() called with invalid filename");
         return FileImplPtr();
     }
     BYTE flags = _getFlags(openMode, accessMode);
@@ -174,7 +174,7 @@ DirImplPtr FatFSImpl::openDir(const char* path) {
     }
     // TODO -can this ever happen?
     //    if (!dirFile) {
-    //        DEBUGV("FatFSImpl::openDir: path=`%s`\n", path);
+    //        DEBUGV("FatFSImpl::openDir: path=`%s`", path);
     //        return DirImplPtr();
     //    }
     auto sharedDir = std::make_shared<DIR>(dirFile);

--- a/libraries/FatFS/src/FatFS.h
+++ b/libraries/FatFS/src/FatFS.h
@@ -90,7 +90,7 @@ public:
 
     bool info(FSInfo& info) override {
         if (!_mounted) {
-            DEBUGV("FatFS::info: FS not mounted\n");
+            DEBUGV("FatFS::info: FS not mounted");
             return false;
         }
         FATFS *fs = nullptr;
@@ -139,7 +139,7 @@ public:
 
     bool setConfig(const FSConfig &cfg) override {
         if ((cfg._type != FatFSConfig::FSId) || _mounted) {
-            DEBUGV("FatFS::setConfig: invalid config or already mounted\n");
+            DEBUGV("FatFS::setConfig: invalid config or already mounted");
             return false;
         }
         _cfg = *static_cast<const FatFSConfig *>(&cfg);
@@ -267,7 +267,7 @@ public:
             return FR_OK == f_lseek(_fd.get(), f_tell(_fd.get()) + pos);
         default:
             // Should not be hit, we've got an invalid seek mode
-            DEBUGV("FatFSFileImpl::seek: invalid seek mode %d\n", mode);
+            DEBUGV("FatFSFileImpl::seek: invalid seek mode %d", mode);
             assert((mode == SeekSet) || (mode == SeekEnd) || (mode == SeekCur)); // Will fail and give meaningful assert message
             return false;
         }
@@ -283,7 +283,7 @@ public:
 
     bool truncate(uint32_t size) override {
         if (!_opened) {
-            DEBUGV("FatFSFileImpl::truncate: file not opened\n");
+            DEBUGV("FatFSFileImpl::truncate: file not opened");
             return false;
         }
         if (FR_OK == f_lseek(_fd.get(), size)) {
@@ -302,7 +302,7 @@ public:
 
     const char* name() const override {
         if (!_opened) {
-            DEBUGV("FatFSFileImpl::name: file not opened\n");
+            DEBUGV("FatFSFileImpl::name: file not opened");
             return nullptr;
         } else {
             const char *p = _name.get();
@@ -391,7 +391,7 @@ public:
 
     const char* fileName() override {
         if (!_valid) {
-            DEBUGV("FatFSDirImpl::fileName: directory not valid\n");
+            DEBUGV("FatFSDirImpl::fileName: directory not valid");
             return nullptr;
         }
         return (const char*) _lfn; //_dirent.name;

--- a/libraries/LittleFS/src/LittleFS.cpp
+++ b/libraries/LittleFS/src/LittleFS.cpp
@@ -43,15 +43,15 @@ namespace littlefs_impl {
 
 FileImplPtr LittleFSImpl::open(const char* path, OpenMode openMode, AccessMode accessMode) {
     if (!_mounted) {
-        DEBUGV("LittleFSImpl::open() called on unmounted FS\n");
+        DEBUGV("LittleFSImpl::open() called on unmounted FS");
         return FileImplPtr();
     }
     if (!path || !path[0]) {
-        DEBUGV("LittleFSImpl::open() called with invalid filename\n");
+        DEBUGV("LittleFSImpl::open() called with invalid filename");
         return FileImplPtr();
     }
     if (!LittleFSImpl::pathValid(path)) {
-        DEBUGV("LittleFSImpl::open() called with too long filename\n");
+        DEBUGV("LittleFSImpl::open() called with too long filename");
         return FileImplPtr();
     }
 
@@ -96,7 +96,7 @@ FileImplPtr LittleFSImpl::open(const char* path, OpenMode openMode, AccessMode a
         lfs_file_sync(&_lfs, fd.get());
         return std::make_shared<LittleFSFileImpl>(this, path, fd, flags, creation);
     } else {
-        DEBUGV("LittleFSDirImpl::openFile: rc=%d fd=%p path=`%s` openMode=%d accessMode=%d err=%d\n",
+        DEBUGV("LittleFSDirImpl::openFile: rc=%d fd=%p path=`%s` openMode=%d accessMode=%d err=%d",
                rc, fd.get(), path, openMode, accessMode, rc);
         return FileImplPtr();
     }
@@ -156,7 +156,7 @@ DirImplPtr LittleFSImpl::openDir(const char *path) {
         }
     }
     if (rc < 0) {
-        DEBUGV("LittleFSImpl::openDir: path=`%s` err=%d\n", path, rc);
+        DEBUGV("LittleFSImpl::openDir: path=`%s` err=%d", path, rc);
         free(pathStr);
         return DirImplPtr();
     }

--- a/libraries/LittleFS/src/LittleFS.h
+++ b/libraries/LittleFS/src/LittleFS.h
@@ -96,7 +96,7 @@ public:
         }
         int rc = lfs_rename(&_lfs, pathFrom, pathTo);
         if (rc != 0) {
-            DEBUGV("lfs_rename: rc=%d, from=`%s`, to=`%s`\n", rc, pathFrom, pathTo);
+            DEBUGV("lfs_rename: rc=%d, from=`%s`, to=`%s`", rc, pathFrom, pathTo);
             return false;
         }
         return true;
@@ -121,7 +121,7 @@ public:
         }
         int rc = lfs_remove(&_lfs, path);
         if (rc != 0) {
-            DEBUGV("lfs_remove: rc=%d path=`%s`\n", rc, path);
+            DEBUGV("lfs_remove: rc=%d path=`%s`", rc, path);
             return false;
         }
         // Now try and remove any empty subdirs this makes, silently
@@ -148,7 +148,7 @@ public:
             // Add metadata with creation time to the directory marker
             rc = lfs_setattr(&_lfs, path, 'c', (const void *)&now, sizeof(now));
             if (rc < 0) {
-                DEBUGV("Unable to set creation time on '%s' to %ld\n", path, (long)now);
+                DEBUGV("Unable to set creation time on '%s' to %ld", path, (long)now);
             }
         }
         return (rc == 0);
@@ -193,7 +193,7 @@ public:
 
     bool format() override {
         if (_size == 0) {
-            DEBUGV("lfs size is zero\n");
+            DEBUGV("lfs size is zero");
             return false;
         }
 
@@ -206,7 +206,7 @@ public:
         memset(&_lfs, 0, sizeof(_lfs));
         int rc = lfs_format(&_lfs, &_lfs_cfg);
         if (rc != 0) {
-            DEBUGV("lfs_format: rc=%d\n", rc);
+            DEBUGV("lfs_format: rc=%d", rc);
             return false;
         }
 
@@ -216,13 +216,13 @@ public:
             time_t t = _timeCallback();
             rc = lfs_setattr(&_lfs, "/", 'c', &t, 8);
             if (rc != 0) {
-                DEBUGV("lfs_format, lfs_setattr 'c': rc=%d\n", rc);
+                DEBUGV("lfs_format, lfs_setattr 'c': rc=%d", rc);
                 return false;
             }
 
             rc = lfs_setattr(&_lfs, "/", 't', &t, 8);
             if (rc != 0) {
-                DEBUGV("lfs_format, lfs_setattr 't': rc=%d\n", rc);
+                DEBUGV("lfs_format, lfs_setattr 't': rc=%d", rc);
                 return false;
             }
 
@@ -382,7 +382,7 @@ public:
         }
         int result = lfs_file_write(_fs->getFS(), _getFD(), (void*) buf, size);
         if (result < 0) {
-            DEBUGV("lfs_write rc=%d\n", result);
+            DEBUGV("lfs_write rc=%d", result);
             return 0;
         }
         return result;
@@ -394,7 +394,7 @@ public:
         }
         int result = lfs_file_read(_fs->getFS(), _getFD(), (void*) buf, size);
         if (result < 0) {
-            DEBUGV("lfs_read rc=%d\n", result);
+            DEBUGV("lfs_read rc=%d", result);
             return 0;
         }
 
@@ -407,7 +407,7 @@ public:
         }
         int rc = lfs_file_sync(_fs->getFS(), _getFD());
         if (rc < 0) {
-            DEBUGV("lfs_file_sync rc=%d\n", rc);
+            DEBUGV("lfs_file_sync rc=%d", rc);
         }
     }
 
@@ -419,7 +419,7 @@ public:
         auto lastPos = position();
         int rc = lfs_file_seek(_fs->getFS(), _getFD(), offset, (int)mode); // NB. SeekMode === LFS_SEEK_TYPES
         if (rc < 0) {
-            DEBUGV("lfs_file_seek rc=%d\n", rc);
+            DEBUGV("lfs_file_seek rc=%d", rc);
             return false;
         }
         if (position() > size()) {
@@ -435,7 +435,7 @@ public:
         }
         int result = lfs_file_tell(_fs->getFS(), _getFD());
         if (result < 0) {
-            DEBUGV("lfs_file_tell rc=%d\n", result);
+            DEBUGV("lfs_file_tell rc=%d", result);
             return 0;
         }
 
@@ -452,7 +452,7 @@ public:
         }
         int rc = lfs_file_truncate(_fs->getFS(), _getFD(), size);
         if (rc < 0) {
-            DEBUGV("lfs_file_truncate rc=%d\n", rc);
+            DEBUGV("lfs_file_truncate rc=%d", rc);
             return false;
         }
         return true;
@@ -467,14 +467,14 @@ public:
                 if (_creation) {
                     int rc = lfs_setattr(_fs->getFS(), _name.get(), 'c', (const void *)&_creation, sizeof(_creation));
                     if (rc < 0) {
-                        DEBUGV("Unable to set creation time on '%s' to %lld\n", _name.get(), _creation);
+                        DEBUGV("Unable to set creation time on '%s' to %lld", _name.get(), _creation);
                     }
                 }
                 // Add metadata with last write time
                 time_t now = _timeCallback();
                 int rc = lfs_setattr(_fs->getFS(), _name.get(), 't', (const void *)&now, sizeof(now));
                 if (rc < 0) {
-                    DEBUGV("Unable to set last write time on '%s' to %lld\n", _name.get(), now);
+                    DEBUGV("Unable to set last write time on '%s' to %lld", _name.get(), now);
                 }
             }
         }

--- a/libraries/PWMAudio/src/PWMAudio.cpp
+++ b/libraries/PWMAudio/src/PWMAudio.cpp
@@ -135,7 +135,7 @@ bool PWMAudio::begin() {
 
     if (_stereo && (_pin & 1)) {
         // Illegal, need to have consecutive pins on the same PWM slice
-        DEBUGV("ERROR: PWMAudio stereo mode requires pin be even\n");
+        DEBUGV("ERROR: PWMAudio stereo mode requires pin be even");
         return false;
     }
 

--- a/libraries/SDFS/src/SDFS.cpp
+++ b/libraries/SDFS/src/SDFS.cpp
@@ -41,11 +41,11 @@ time_t (*__sdfs_timeCallback)(void) = nullptr;
 
 FileImplPtr SDFSImpl::open(const char* path, OpenMode openMode, AccessMode accessMode) {
     if (!_mounted) {
-        DEBUGV("SDFSImpl::open() called on unmounted FS\n");
+        DEBUGV("SDFSImpl::open() called on unmounted FS");
         return FileImplPtr();
     }
     if (!path || !path[0]) {
-        DEBUGV("SDFSImpl::open() called with invalid filename\n");
+        DEBUGV("SDFSImpl::open() called with invalid filename");
         return FileImplPtr();
     }
     int flags = _getFlags(openMode, accessMode);
@@ -130,7 +130,7 @@ DirImplPtr SDFSImpl::openDir(const char* path) {
         }
     }
     if (!dirFile) {
-        DEBUGV("SDFSImpl::openDir: path=`%s`\n", path);
+        DEBUGV("SDFSImpl::openDir: path=`%s`", path);
         return DirImplPtr();
     }
     auto sharedDir = std::make_shared<FsFile>(dirFile);

--- a/libraries/SDFS/src/SDFS.h
+++ b/libraries/SDFS/src/SDFS.h
@@ -99,7 +99,7 @@ public:
 
     bool info(FSInfo& info) override {
         if (!_mounted) {
-            DEBUGV("SDFS::info: FS not mounted\n");
+            DEBUGV("SDFS::info: FS not mounted");
             return false;
         }
         info.maxOpenFiles = 999; // TODO - not valid
@@ -125,7 +125,7 @@ public:
 
     bool setConfig(const FSConfig &cfg) override {
         if ((cfg._type != SDFSConfig::FSId) || _mounted) {
-            DEBUGV("SDFS::setConfig: invalid config or already mounted\n");
+            DEBUGV("SDFS::setConfig: invalid config or already mounted");
             return false;
         }
         _cfg = *static_cast<const SDFSConfig *>(&cfg);
@@ -328,7 +328,7 @@ public:
             return _fd->seekCur(pos);
         default:
             // Should not be hit, we've got an invalid seek mode
-            DEBUGV("SDFSFileImpl::seek: invalid seek mode %d\n", mode);
+            DEBUGV("SDFSFileImpl::seek: invalid seek mode %d", mode);
             assert((mode == SeekSet) || (mode == SeekEnd) || (mode == SeekCur)); // Will fail and give meaningful assert message
             return false;
         }
@@ -344,7 +344,7 @@ public:
 
     bool truncate(uint32_t size) override {
         if (!_opened) {
-            DEBUGV("SDFSFileImpl::truncate: file not opened\n");
+            DEBUGV("SDFSFileImpl::truncate: file not opened");
             return false;
         }
         return _fd->truncate(size);
@@ -359,7 +359,7 @@ public:
 
     const char* name() const override {
         if (!_opened) {
-            DEBUGV("SDFSFileImpl::name: file not opened\n");
+            DEBUGV("SDFSFileImpl::name: file not opened");
             return nullptr;
         } else {
             const char *p = _name.get();
@@ -439,7 +439,7 @@ public:
 
     const char* fileName() override {
         if (!_valid) {
-            DEBUGV("SDFSDirImpl::fileName: directory not valid\n");
+            DEBUGV("SDFSDirImpl::fileName: directory not valid");
             return nullptr;
         }
         return (const char*) _lfn; //_dirent.name;

--- a/libraries/SPI/src/SPI.cpp
+++ b/libraries/SPI/src/SPI.cpp
@@ -83,11 +83,11 @@ uint8_t SPIClassRP2040::transfer(uint8_t data) {
         return 0;
     }
     data = (_spis.getBitOrder() == MSBFIRST) ? data : _helper.reverseByte(data);
-    DEBUGSPI("SPI::transfer(%02x), cpol=%d, cpha=%d\n", data, _helper.cpol(_spis), _helper.cpha(_spis));
+    DEBUGSPI("SPI::transfer(%02x), cpol=%d, cpha=%d", data, _helper.cpol(_spis), _helper.cpha(_spis));
     hw_write_masked(&spi_get_hw(_spi)->cr0, (8 - 1) << SPI_SSPCR0_DSS_LSB, SPI_SSPCR0_DSS_BITS); // Fast set to 8-bits
     spi_write_read_blocking(_spi, &data, &ret, 1);
     ret = (_spis.getBitOrder() == MSBFIRST) ? ret : _helper.reverseByte(ret);
-    DEBUGSPI("SPI: read back %02x\n", ret);
+    DEBUGSPI("SPI: read back %02x", ret);
     return ret;
 }
 
@@ -97,22 +97,22 @@ uint16_t SPIClassRP2040::transfer16(uint16_t data) {
         return 0;
     }
     data = (_spis.getBitOrder() == MSBFIRST) ? data : _helper.reverse16Bit(data);
-    DEBUGSPI("SPI::transfer16(%04x), cpol=%d, cpha=%d\n", data, _helper.cpol(_spis), _helper.cpha(_spis));
+    DEBUGSPI("SPI::transfer16(%04x), cpol=%d, cpha=%d", data, _helper.cpol(_spis), _helper.cpha(_spis));
     hw_write_masked(&spi_get_hw(_spi)->cr0, (16 - 1) << SPI_SSPCR0_DSS_LSB, SPI_SSPCR0_DSS_BITS); // Fast set to 16-bits
     spi_write16_read16_blocking(_spi, &data, &ret, 1);
     ret = (_spis.getBitOrder() == MSBFIRST) ? ret : _helper.reverse16Bit(ret);
-    DEBUGSPI("SPI: read back %02x\n", ret);
+    DEBUGSPI("SPI: read back %02x", ret);
     return ret;
 }
 
 void SPIClassRP2040::transfer(void *buf, size_t count) {
-    DEBUGSPI("SPI::transfer(%p, %d)\n", buf, count);
+    DEBUGSPI("SPI::transfer(%p, %d)", buf, count);
     uint8_t *buff = reinterpret_cast<uint8_t *>(buf);
     for (size_t i = 0; i < count; i++) {
         *buff = transfer(*buff);
         buff++;
     }
-    DEBUGSPI("SPI::transfer completed\n");
+    DEBUGSPI("SPI::transfer completed");
 }
 
 void SPIClassRP2040::transfer(const void *txbuf, void *rxbuf, size_t count) {
@@ -122,7 +122,7 @@ void SPIClassRP2040::transfer(const void *txbuf, void *rxbuf, size_t count) {
 
     hw_write_masked(&spi_get_hw(_spi)->cr0, (8 - 1) << SPI_SSPCR0_DSS_LSB, SPI_SSPCR0_DSS_BITS); // Fast set to 8-bits
 
-    DEBUGSPI("SPI::transfer(%p, %p, %d)\n", txbuf, rxbuf, count);
+    DEBUGSPI("SPI::transfer(%p, %p, %d)", txbuf, rxbuf, count);
     const uint8_t *txbuff = reinterpret_cast<const uint8_t *>(txbuf);
     uint8_t *rxbuff = reinterpret_cast<uint8_t *>(rxbuf);
 
@@ -148,23 +148,23 @@ void SPIClassRP2040::transfer(const void *txbuf, void *rxbuf, size_t count) {
         txbuff++;
         rxbuff++;
     }
-    DEBUGSPI("SPI::transfer completed\n");
+    DEBUGSPI("SPI::transfer completed");
 }
 
 void SPIClassRP2040::beginTransaction(SPISettings settings) {
-    DEBUGSPI("SPI::beginTransaction(clk=%lu, bo=%s)\n", settings.getClockFreq(), (settings.getBitOrder() == MSBFIRST) ? "MSB" : "LSB");
+    DEBUGSPI("SPI::beginTransaction(clk=%lu, bo=%s)", settings.getClockFreq(), (settings.getBitOrder() == MSBFIRST) ? "MSB" : "LSB");
     if (_initted && settings == _spis) {
-        DEBUGSPI("SPI: Reusing existing initted SPI\n");
+        DEBUGSPI("SPI: Reusing existing initted SPI");
     } else {
         /* Only de-init if the clock changes frequency */
         if (settings.getClockFreq() != _spis.getClockFreq()) {
             if (_initted) {
-                DEBUGSPI("SPI: deinitting currently active SPI\n");
+                DEBUGSPI("SPI: deinitting currently active SPI");
                 spi_deinit(_spi);
             }
-            DEBUGSPI("SPI: initting SPI\n");
+            DEBUGSPI("SPI: initting SPI");
             spi_init(_spi, settings.getClockFreq());
-            DEBUGSPI("SPI: actual baudrate=%u\n", spi_get_baudrate(_spi));
+            DEBUGSPI("SPI: actual baudrate=%u", spi_get_baudrate(_spi));
         }
         _spis = settings;
         spi_set_format(_spi, 8, _helper.cpol(_spis), _helper.cpha(_spis), SPI_MSB_FIRST);
@@ -174,12 +174,12 @@ void SPIClassRP2040::beginTransaction(SPISettings settings) {
 }
 
 void SPIClassRP2040::endTransaction(void) {
-    DEBUGSPI("SPI::endTransaction()\n");
+    DEBUGSPI("SPI::endTransaction()");
     _helper.unmaskInterrupts();
 }
 
 bool SPIClassRP2040::transferAsync(const void *send, void *recv, size_t bytes) {
-    DEBUGSPI("SPI::transferAsync(%p, %p, %d)\n", send, recv, bytes);
+    DEBUGSPI("SPI::transferAsync(%p, %p, %d)", send, recv, bytes);
     const uint8_t *txbuff = reinterpret_cast<const uint8_t *>(send);
     uint8_t *rxbuff = reinterpret_cast<uint8_t *>(recv);
     _dummy = 0xffffffff;
@@ -446,7 +446,7 @@ bool SPIClassRP2040::setTX(pin_size_t pin) {
 }
 
 void SPIClassRP2040::begin(bool hwCS) {
-    DEBUGSPI("SPI::begin(%d), rx=%d, cs=%d, sck=%d, tx=%d\n", hwCS, _RX, _CS, _SCK, _TX);
+    DEBUGSPI("SPI::begin(%d), rx=%d, cs=%d, sck=%d, tx=%d", hwCS, _RX, _CS, _SCK, _TX);
 
     if ((_RX == NOPIN) && (_TX == NOPIN)) {
         panic("SPI%s: TX and RX assigned to NOPIN", spi_get_index(_spi) ? "1" : "");
@@ -469,9 +469,9 @@ void SPIClassRP2040::begin(bool hwCS) {
 }
 
 void SPIClassRP2040::end() {
-    DEBUGSPI("SPI::end()\n");
+    DEBUGSPI("SPI::end()");
     if (_initted) {
-        DEBUGSPI("SPI: deinitting currently active SPI\n");
+        DEBUGSPI("SPI: deinitting currently active SPI");
         _initted = false;
         spi_deinit(_spi);
     }

--- a/libraries/SPI/src/SPIHelper.h
+++ b/libraries/SPI/src/SPIHelper.h
@@ -114,7 +114,7 @@ public:
         noInterrupts(); // Avoid possible race conditions if IRQ comes in while main app is in middle of this
         // Disable any IRQs that are being used for SPI
         io_bank0_irq_ctrl_hw_t *irq_ctrl_base = get_core_num() ? &iobank0_hw->proc1_irq_ctrl : &iobank0_hw->proc0_irq_ctrl;
-        DEBUGSPI("SPI: IRQ masks before = %08x %08x %08x %08x %08x %08x\n", (unsigned)irq_ctrl_base->inte[0],
+        DEBUGSPI("SPI: IRQ masks before = %08x %08x %08x %08x %08x %08x", (unsigned)irq_ctrl_base->inte[0],
                  (unsigned)irq_ctrl_base->inte[1], (unsigned)irq_ctrl_base->inte[2], (unsigned)irq_ctrl_base->inte[3],
                  (GPIOIRQREGS > 4) ? (unsigned)irq_ctrl_base->inte[4] : 0, (GPIOIRQREGS > 5) ? (unsigned)irq_ctrl_base->inte[5] : 0);
         for (auto entry : _usingIRQs) {
@@ -124,10 +124,10 @@ public:
             io_rw_32 *en_reg = &irq_ctrl_base->inte[gpio / 8];
             uint32_t val = ((*en_reg) >> (4 * (gpio % 8))) & 0xf;
             _usingIRQs.insert_or_assign(gpio, val);
-            DEBUGSPI("SPI: GPIO %d = %lu\n", gpio, val);
+            DEBUGSPI("SPI: GPIO %d = %lu", gpio, val);
             (*en_reg) ^= val << (4 * (gpio % 8));
         }
-        DEBUGSPI("SPI: IRQ masks after = %08x %08x %08x %08x %08x %08x\n", (unsigned)irq_ctrl_base->inte[0],
+        DEBUGSPI("SPI: IRQ masks after = %08x %08x %08x %08x %08x %08x", (unsigned)irq_ctrl_base->inte[0],
                  (unsigned)irq_ctrl_base->inte[1], (unsigned)irq_ctrl_base->inte[2], (unsigned)irq_ctrl_base->inte[3],
                  (GPIOIRQREGS > 4) ? (unsigned)irq_ctrl_base->inte[4] : 0, (GPIOIRQREGS > 5) ? (unsigned)irq_ctrl_base->inte[5] : 0);
         interrupts();
@@ -141,7 +141,7 @@ public:
             return;
         }
         noInterrupts(); // Avoid race condition so the GPIO IRQs won't come back until all state is restored
-        DEBUGSPI("SPI::endTransaction()\n");
+        DEBUGSPI("SPI::endTransaction()");
         // Re-enable IRQs
         for (auto entry : _usingIRQs) {
             int gpio = entry.first;
@@ -150,7 +150,7 @@ public:
         }
         io_bank0_irq_ctrl_hw_t *irq_ctrl_base = get_core_num() ? &iobank0_hw->proc1_irq_ctrl : &iobank0_hw->proc0_irq_ctrl;
         (void) irq_ctrl_base;
-        DEBUGSPI("SPI: IRQ masks = %08x %08x %08x %08x %08x %08x\n", (unsigned)irq_ctrl_base->inte[0], (unsigned)irq_ctrl_base->inte[1],
+        DEBUGSPI("SPI: IRQ masks = %08x %08x %08x %08x %08x %08x", (unsigned)irq_ctrl_base->inte[0], (unsigned)irq_ctrl_base->inte[1],
                  (unsigned)irq_ctrl_base->inte[2], (unsigned)irq_ctrl_base->inte[3], (GPIOIRQREGS > 4) ? (unsigned)irq_ctrl_base->inte[4] : 0,
                  (GPIOIRQREGS > 5) ? (unsigned)irq_ctrl_base->inte[5] : 0);
         interrupts();

--- a/libraries/SPISlave/src/SPISlave.cpp
+++ b/libraries/SPISlave/src/SPISlave.cpp
@@ -218,18 +218,18 @@ void SPISlaveClass::setData(const uint8_t *data, size_t len) {
 
 
 void SPISlaveClass::begin(SPISettings spis) {
-    DEBUGSPI("SPISlave::begin(), rx=%d, cs=%d, sck=%d, tx=%d\n", _RX, _CS, _SCK, _TX);
+    DEBUGSPI("SPISlave::begin(), rx=%d, cs=%d, sck=%d, tx=%d", _RX, _CS, _SCK, _TX);
     gpio_set_function(_RX, GPIO_FUNC_SPI);
     gpio_set_function(_CS, GPIO_FUNC_SPI);
     gpio_set_function(_SCK, GPIO_FUNC_SPI);
     gpio_set_function(_TX, GPIO_FUNC_SPI);
     if (_initted) {
-        DEBUGSPI("SPISlave: deinitting currently active SPI\n");
+        DEBUGSPI("SPISlave: deinitting currently active SPI");
         spi_deinit(_spi);
     }
-    DEBUGSPI("SPISlave: initting SPI\n");
+    DEBUGSPI("SPISlave: initting SPI");
     spi_init(_spi, _spis.getClockFreq());
-    DEBUGSPI("SPISlave: actual baudrate=%u\n", spi_get_baudrate(_spi));
+    DEBUGSPI("SPISlave: actual baudrate=%u", spi_get_baudrate(_spi));
     spi_set_slave(_spi, true);
     spi_set_format(_spi, 8, _helper.cpol(spis),	_helper.cpha(spis), SPI_MSB_FIRST);
 
@@ -247,9 +247,9 @@ void SPISlaveClass::begin(SPISettings spis) {
 }
 
 void SPISlaveClass::end() {
-    DEBUGSPI("SPISlave::end()\n");
+    DEBUGSPI("SPISlave::end()");
     if (_initted) {
-        DEBUGSPI("SPISlave: deinitting currently active SPI\n");
+        DEBUGSPI("SPISlave: deinitting currently active SPI");
         if (_spi == spi0) {
             irq_remove_handler(SPI0_IRQ, _irq0);
         } else {

--- a/libraries/SoftwareSPI/src/SoftwareSPI.cpp
+++ b/libraries/SoftwareSPI/src/SoftwareSPI.cpp
@@ -71,7 +71,7 @@ uint8_t SoftwareSPI::transfer(uint8_t data) {
         return 0;
     }
     data = (_spis.getBitOrder() == MSBFIRST) ? data : _helper.reverseByte(data);
-    DEBUGSPI("SoftwareSPI::transfer(%02x), cpol=%d, cpha=%d\n", data, _helper.cpol(_spis), _helper.cpha(_spis));
+    DEBUGSPI("SoftwareSPI::transfer(%02x), cpol=%d, cpha=%d", data, _helper.cpol(_spis), _helper.cpha(_spis));
     _adjustPIO(8);
     io_rw_8 *txfifo = (io_rw_8 *) &_pio->txf[_sm];
     io_rw_8 *rxfifo = (io_rw_8 *) &_pio->rxf[_sm];
@@ -80,7 +80,7 @@ uint8_t SoftwareSPI::transfer(uint8_t data) {
     while (pio_sm_is_rx_fifo_empty(_pio, _sm)) { /* noop wait for in data */ }
     ret = *rxfifo;
     ret = (_spis.getBitOrder() == MSBFIRST) ? ret : _helper.reverseByte(ret);
-    DEBUGSPI("SoftwareSPI: read back %02x\n", ret);
+    DEBUGSPI("SoftwareSPI: read back %02x", ret);
     return ret;
 }
 
@@ -90,7 +90,7 @@ uint16_t SoftwareSPI::transfer16(uint16_t data) {
         return 0;
     }
     data = (_spis.getBitOrder() == MSBFIRST) ? data : _helper.reverse16Bit(data);
-    DEBUGSPI("SoftwareSPI::transfer16(%04x), cpol=%d, cpha=%d\n", data, _helper.cpol(_spis), _helper.cpha(_spis));
+    DEBUGSPI("SoftwareSPI::transfer16(%04x), cpol=%d, cpha=%d", data, _helper.cpol(_spis), _helper.cpha(_spis));
     _adjustPIO(16);
     io_rw_16 *txfifo = (io_rw_16 *) &_pio->txf[_sm];
     io_rw_16 *rxfifo = (io_rw_16 *) &_pio->rxf[_sm];
@@ -99,7 +99,7 @@ uint16_t SoftwareSPI::transfer16(uint16_t data) {
     while (pio_sm_is_rx_fifo_empty(_pio, _sm)) { /* noop wait for in data */ }
     ret = *rxfifo;
     ret = (_spis.getBitOrder() == MSBFIRST) ? ret : _helper.reverse16Bit(ret);
-    DEBUGSPI("SoftwareSPI: read back %04x\n", ret);
+    DEBUGSPI("SoftwareSPI: read back %04x", ret);
     return ret;
 }
 
@@ -111,7 +111,7 @@ void SoftwareSPI::transfer(const void *csrc, void *cdest, size_t count) {
     if (!_initted) {
         return;
     }
-    DEBUGSPI("SoftwareSPI::transfer(%p, %p %d)\n", csrc, cdest, count);
+    DEBUGSPI("SoftwareSPI::transfer(%p, %p %d)", csrc, cdest, count);
     const uint8_t *src = reinterpret_cast<const uint8_t *>(csrc);
     uint8_t *dest = reinterpret_cast<uint8_t *>(cdest);
     _adjustPIO(8);
@@ -146,21 +146,21 @@ void SoftwareSPI::transfer(const void *csrc, void *cdest, size_t count) {
             dest[i] = _helper.reverseByte(dest[i]);
         }
     }
-    DEBUGSPI("SoftwareSPI::transfer completed\n");
+    DEBUGSPI("SoftwareSPI::transfer completed");
 }
 
 void SoftwareSPI::beginTransaction(SPISettings settings) {
-    DEBUGSPI("SoftwareSPI::beginTransaction(clk=%lu, bo=%s)\n", settings.getClockFreq(), (settings.getBitOrder() == MSBFIRST) ? "MSB" : "LSB");
+    DEBUGSPI("SoftwareSPI::beginTransaction(clk=%lu, bo=%s)", settings.getClockFreq(), (settings.getBitOrder() == MSBFIRST) ? "MSB" : "LSB");
     if (_initted && settings == _spis) {
-        DEBUGSPI("SoftwareSPI: Reusing existing initted SPI\n");
+        DEBUGSPI("SoftwareSPI: Reusing existing initted SPI");
     } else {
         /* Only de-init if the clock changes frequency */
         if (settings.getClockFreq() != _spis.getClockFreq()) {
-            DEBUGSPI("SoftwareSPI: initting SPI\n");
+            DEBUGSPI("SoftwareSPI: initting SPI");
             float divider = (float)rp2040.f_cpu() / (float)settings.getClockFreq();
             divider /= _hwCS ? 4.0f : 4.0f;
             pio_sm_set_clkdiv(_pio, _sm, divider);
-            DEBUGSPI("SoftwareSPI: divider=%f\n", divider);
+            DEBUGSPI("SoftwareSPI: divider=%f", divider);
         }
         _spis = settings;
         // Note we can only change frequency, not CPOL/CPHA (which would be physically not too useful anyway)
@@ -170,7 +170,7 @@ void SoftwareSPI::beginTransaction(SPISettings settings) {
 }
 
 void SoftwareSPI::endTransaction(void) {
-    DEBUGSPI("SoftwareSPI::endTransaction()\n");
+    DEBUGSPI("SoftwareSPI::endTransaction()");
     _helper.unmaskInterrupts();
 }
 
@@ -213,9 +213,9 @@ bool SoftwareSPI::setMOSI(pin_size_t pin) {
 }
 
 void SoftwareSPI::begin(bool hwCS) {
-    DEBUGSPI("SoftwareSPI::begin(%d), rx=%d, cs=%d, sck=%d, tx=%d\n", hwCS, _miso, _cs, _sck, _mosi);
+    DEBUGSPI("SoftwareSPI::begin(%d), rx=%d, cs=%d, sck=%d, tx=%d", hwCS, _miso, _cs, _sck, _mosi);
     float divider = (float)rp2040.f_cpu() / (float)_spis.getClockFreq();
-    DEBUGSPI("SoftwareSPI: divider=%f\n", divider);
+    DEBUGSPI("SoftwareSPI: divider=%f", divider);
     if (!hwCS) {
         _spi = new PIOProgram(_helper.cpha(_spis) == SPI_CPHA_0 ? &spi_cpha0_program : &spi_cpha1_program);
         if (!_spi->prepare(&_pio, &_sm, &_off, _sck, 1)) {
@@ -243,9 +243,9 @@ void SoftwareSPI::begin(bool hwCS) {
 }
 
 void SoftwareSPI::end() {
-    DEBUGSPI("SoftwareSPI::end()\n");
+    DEBUGSPI("SoftwareSPI::end()");
     if (_initted) {
-        DEBUGSPI("SoftwareSPI: deinitting currently active SPI\n");
+        DEBUGSPI("SoftwareSPI: deinitting currently active SPI");
         _initted = false;
         pio_sm_set_enabled(_pio, _sm, false);
         // TODO - We don't have a good PIOProgram reclamation method so this will possibly leak an SM

--- a/libraries/WiFi/src/WiFiMulti.cpp
+++ b/libraries/WiFi/src/WiFiMulti.cpp
@@ -53,7 +53,7 @@ bool WiFiMulti::addAP(const char *ssid, const char *pass) {
     } else {
         ap.pass = nullptr;
     }
-    DEBUGV("[WIFIMULTI] Adding: '%s' '%s' to list\n", ap.ssid, ap.pass);
+    DEBUGV("[WIFIMULTI] Adding: '%s' '%s' to list", ap.ssid, ap.pass);
     _list.push_front(ap);
     return true;
 }
@@ -81,7 +81,7 @@ uint8_t WiFiMulti::run(uint32_t to) {
         return WL_CONNECTED;
     }
 
-    DEBUGV("[WIFIMULTI] Rescanning to build new list of APs\n");
+    DEBUGV("[WIFIMULTI] Rescanning to build new list of APs");
     int cnt = WiFi.scanNetworks();
     if (!cnt) {
         return WL_DISCONNECTED;
@@ -105,13 +105,13 @@ uint8_t WiFiMulti::run(uint32_t to) {
         return a.rssi > b.rssi;
     });
     for (auto j = _scanList.begin(); j != _scanList.end(); j++) {
-        DEBUGV("[WIFIMULTI] scanList: SSID: '%s' -- BSSID: '%02X%02X%02X%02X%02X%02X' -- RSSI: %d\n", j->ssid,
+        DEBUGV("[WIFIMULTI] scanList: SSID: '%s' -- BSSID: '%02X%02X%02X%02X%02X%02X' -- RSSI: %d", j->ssid,
                j->bssid[0], j->bssid[1], j->bssid[2], j->bssid[3], j->bssid[4], j->bssid[5], j->rssi);
     }
 
     // Attempt to connect to each (will be in order of decreasing RSSI)
     for (auto j = _scanList.begin(); j != _scanList.end(); j++) {
-        DEBUGV("[WIFIMULTI] Connecting to: SSID: '%s' -- BSSID: '%02X%02X%02X%02X%02X%02X' -- RSSI: %d\n", j->ssid,
+        DEBUGV("[WIFIMULTI] Connecting to: SSID: '%s' -- BSSID: '%02X%02X%02X%02X%02X%02X' -- RSSI: %d", j->ssid,
                j->bssid[0], j->bssid[1], j->bssid[2], j->bssid[3], j->bssid[4], j->bssid[5], j->rssi);
         uint32_t start = millis();
         if (j->psk) {

--- a/libraries/WiFi/src/WiFiServer.cpp
+++ b/libraries/WiFi/src/WiFiServer.cpp
@@ -138,7 +138,7 @@ WiFiClient WiFiServer::accept() {
 
         _unclaimed = _unclaimed->next();
         result.setNoDelay(getNoDelay());
-        DEBUGV("WS:av status=%d WCav=%d\r\n", result.status(), result.available());
+        DEBUGV("WS:av status=%d WCav=%d", result.status(), result.available());
         return result;
     }
     return WiFiClient();
@@ -190,7 +190,7 @@ T* slist_append_tail(T* head, T* item) {
 
 err_t WiFiServer::_accept(tcp_pcb* apcb, err_t err) {
     (void) err;
-    DEBUGV("WS:ac\r\n");
+    DEBUGV("WS:ac");
 
     // always accept new PCB so incoming data can be stored in our buffers even before
     // user calls ::available()
@@ -211,7 +211,7 @@ err_t WiFiServer::_accept(tcp_pcb* apcb, err_t err) {
 void WiFiServer::_discard(ClientContext* client) {
     (void) client;
     // _discarded = slist_append_tail(_discarded, client);
-    DEBUGV("WS:dis\r\n");
+    DEBUGV("WS:dis");
 }
 
 err_t WiFiServer::_s_accept(void *arg, tcp_pcb* newpcb, err_t err) {

--- a/libraries/WiFi/src/WiFiServerSecureBearSSL.cpp
+++ b/libraries/WiFi/src/WiFiServerSecureBearSSL.cpp
@@ -85,17 +85,17 @@ WiFiClientSecure WiFiServerSecure::accept() {
             WiFiClientSecure result(_unclaimed, _chain, _sk, _iobuf_in_size, _iobuf_out_size, _cache, _client_CA_ta, _tls_min, _tls_max);
             _unclaimed = _unclaimed->next();
             result.setNoDelay(_noDelay);
-            DEBUGV("WS:av\r\n");
+            DEBUGV("WS:av");
             return result;
         } else if (_sk && _sk->isEC()) {
             WiFiClientSecure result(_unclaimed, _chain, _cert_issuer_key_type, _sk, _iobuf_in_size, _iobuf_out_size, _cache, _client_CA_ta, _tls_min, _tls_max);
             _unclaimed = _unclaimed->next();
             result.setNoDelay(_noDelay);
-            DEBUGV("WS:av\r\n");
+            DEBUGV("WS:av");
             return result;
         } else {
             // No key was defined, so we can't actually accept and attempt accept() and SSL handshake.
-            DEBUGV("WS:nokey\r\n");
+            DEBUGV("WS:nokey");
         }
     }
 

--- a/libraries/WiFi/src/WiFiUdp.cpp
+++ b/libraries/WiFi/src/WiFiUdp.cpp
@@ -274,7 +274,7 @@ uint16_t WiFiUDP::localPort() const {
 
 void WiFiUDP::stopAll() {
     for (WiFiUDP* it = _s_first; it; it = it->_next) {
-        DEBUGV("%s %p %p\n", __func__, it, _s_first);
+        DEBUGV("%s %p %p", __func__, it, _s_first);
         it->stop();
     }
 }
@@ -282,7 +282,7 @@ void WiFiUDP::stopAll() {
 void WiFiUDP::stopAllExcept(WiFiUDP * exC) {
     for (WiFiUDP* it = _s_first; it; it = it->_next) {
         if (it->_ctx != exC->_ctx) {
-            DEBUGV("%s %p %p\n", __func__, it, _s_first);
+            DEBUGV("%s %p %p", __func__, it, _s_first);
             it->stop();
         }
     }

--- a/libraries/WiFi/src/include/ClientContext.h
+++ b/libraries/WiFi/src/include/ClientContext.h
@@ -65,7 +65,7 @@ public:
 
     err_t abort() {
         if (_pcb) {
-            DEBUGV(":abort\r\n");
+            DEBUGV(":abort");
             tcp_arg(_pcb, nullptr);
             tcp_sent(_pcb, nullptr);
             tcp_recv(_pcb, nullptr);
@@ -80,7 +80,7 @@ public:
     err_t close() {
         err_t err = ERR_OK;
         if (_pcb) {
-            DEBUGV(":close\r\n");
+            DEBUGV(":close");
             tcp_arg(_pcb, nullptr);
             tcp_sent(_pcb, nullptr);
             tcp_recv(_pcb, nullptr);
@@ -88,7 +88,7 @@ public:
             tcp_poll(_pcb, nullptr, 0);
             err = tcp_close(_pcb);
             if (err != ERR_OK) {
-                DEBUGV(":tc err %d\r\n", (int) err);
+                DEBUGV(":tc err %d", (int) err);
                 tcp_abort(_pcb);
                 err = ERR_ABRT;
             }
@@ -111,18 +111,18 @@ public:
 
     void ref() {
         ++_refcnt;
-        DEBUGV(":ref %d\r\n", _refcnt);
+        DEBUGV(":ref %d", _refcnt);
     }
 
     void unref() {
-        DEBUGV(":ur %d\r\n", _refcnt);
+        DEBUGV(":ur %d", _refcnt);
         if (--_refcnt == 0) {
             discard_received();
             close();
             if (_discard_cb) {
                 _discard_cb(_discard_cb_arg, this);
             }
-            DEBUGV(":del\r\n");
+            DEBUGV(":del");
             delete this;
         }
     }
@@ -150,11 +150,11 @@ public:
         }, 1);
         _connect_pending = false;
         if (!_pcb) {
-            DEBUGV(":cabrt\r\n");
+            DEBUGV(":cabrt");
             return 0;
         }
         if (state() != ESTABLISHED) {
-            DEBUGV(":ctmo\r\n");
+            DEBUGV(":ctmo");
             abort();
             return 0;
         }
@@ -253,12 +253,12 @@ public:
         size_t max_size = _rx_buf->tot_len - _rx_buf_offset;
         size = (size < max_size) ? size : max_size;
 
-        DEBUGV(":rd %d, %d, %d\r\n", size, _rx_buf->tot_len, _rx_buf_offset);
+        DEBUGV(":rd %d, %d, %d", size, _rx_buf->tot_len, _rx_buf_offset);
         size_t size_read = 0;
         while (size) {
             size_t buf_size = _rx_buf->len - _rx_buf_offset;
             size_t copy_size = (size < buf_size) ? size : buf_size;
-            DEBUGV(":rdi %d, %d\r\n", buf_size, copy_size);
+            DEBUGV(":rdi %d, %d", buf_size, copy_size);
             memcpy(dst, reinterpret_cast<char*>(_rx_buf->payload) + _rx_buf_offset, copy_size);
             dst += copy_size;
             _consume(copy_size);
@@ -284,16 +284,16 @@ public:
         size_t max_size = _rx_buf->tot_len - _rx_buf_offset;
         size = (size < max_size) ? size : max_size;
 
-        DEBUGV(":pd %d, %d, %d\r\n", size, _rx_buf->tot_len, _rx_buf_offset);
+        DEBUGV(":pd %d, %d, %d", size, _rx_buf->tot_len, _rx_buf_offset);
         size_t buf_size = _rx_buf->len - _rx_buf_offset;
         size_t copy_size = (size < buf_size) ? size : buf_size;
-        DEBUGV(":rpi %d, %d\r\n", buf_size, copy_size);
+        DEBUGV(":rpi %d, %d", buf_size, copy_size);
         memcpy(dst, reinterpret_cast<char*>(_rx_buf->payload) + _rx_buf_offset, copy_size);
         return copy_size;
     }
 
     void discard_received() {
-        DEBUGV(":dsrcv %d\n", _rx_buf ? _rx_buf->tot_len : 0);
+        DEBUGV(":dsrcv %d", _rx_buf ? _rx_buf->tot_len : 0);
         if (!_rx_buf) {
             return;
         }
@@ -322,7 +322,7 @@ public:
             if (millis() - last_sent > (uint32_t) max_wait_ms) {
 #ifdef DEBUGV
                 // wait until sent: timeout
-                DEBUGV(":wustmo\n");
+                DEBUGV(":wustmo");
 #endif
                 // All data was not flushed, timeout hit
                 return false;
@@ -484,7 +484,7 @@ protected:
 
             if (_written == _datalen || _is_timeout() || state() == CLOSED) {
                 if (_is_timeout()) {
-                    DEBUGV(":wtmo\r\n");
+                    DEBUGV(":wtmo");
                 }
                 _datasource = nullptr;
                 _datalen = 0;
@@ -512,7 +512,7 @@ protected:
             return false;
         }
 
-        DEBUGV(":wr %d %d\r\n", _datalen - _written, _written);
+        DEBUGV(":wr %d %d", _datalen - _written, _written);
 
         bool has_written = false;
         int scale = 0;
@@ -560,7 +560,7 @@ protected:
             }
             err_t err = tcp_write(_pcb, buf, next_chunk_size, flags);
 
-            DEBUGV(":wrc %d %d %d\r\n", next_chunk_size, remaining, (int)err);
+            DEBUGV(":wrc %d %d %d", next_chunk_size, remaining, (int)err);
 
             if (err == ERR_OK) {
                 _written += next_chunk_size;
@@ -600,7 +600,7 @@ protected:
     err_t _acked(tcp_pcb* pcb, uint16_t len) {
         (void) pcb;
         (void) len;
-        DEBUGV(":ack %d\r\n", len);
+        DEBUGV(":ack %d", len);
         _write_some_from_cb();
         return ERR_OK;
     }
@@ -610,13 +610,13 @@ protected:
         if (left > 0) {
             _rx_buf_offset += size;
         } else if (!_rx_buf->next) {
-            DEBUGV(":c0 %d, %d\r\n", size, _rx_buf->tot_len);
+            DEBUGV(":c0 %d, %d", size, _rx_buf->tot_len);
             auto head = _rx_buf;
             _rx_buf = 0;
             _rx_buf_offset = 0;
             pbuf_free(head);
         } else {
-            DEBUGV(":c %d, %d, %d\r\n", size, _rx_buf->len, _rx_buf->tot_len);
+            DEBUGV(":c %d, %d, %d", size, _rx_buf->len, _rx_buf->tot_len);
             auto head = _rx_buf;
             _rx_buf = _rx_buf->next;
             _rx_buf_offset = 0;
@@ -633,7 +633,7 @@ protected:
         (void) err;
         if (pb == 0) {
             // connection closed by peer
-            DEBUGV(":rcl pb=%p sz=%d\r\n", _rx_buf, _rx_buf ? _rx_buf->tot_len : -1);
+            DEBUGV(":rcl pb=%p sz=%d", _rx_buf, _rx_buf ? _rx_buf->tot_len : -1);
             _notify_error();
             if (_rx_buf && _rx_buf->tot_len) {
                 // there is still something to read
@@ -648,10 +648,10 @@ protected:
         }
 
         if (_rx_buf) {
-            DEBUGV(":rch %d, %d\r\n", _rx_buf->tot_len, pb->tot_len);
+            DEBUGV(":rch %d, %d", _rx_buf->tot_len, pb->tot_len);
             pbuf_cat(_rx_buf, pb);
         } else {
-            DEBUGV(":rn %d\r\n", pb->tot_len);
+            DEBUGV(":rn %d", pb->tot_len);
             _rx_buf = pb;
             _rx_buf_offset = 0;
         }
@@ -660,7 +660,7 @@ protected:
 
     void _error(err_t err) {
         (void) err;
-        DEBUGV(":er %d 0x%08lx\r\n", (int) err, (uint32_t) _datasource);
+        DEBUGV(":er %d 0x%08lx", (int) err, (uint32_t) _datasource);
         tcp_arg(_pcb, nullptr);
         tcp_sent(_pcb, nullptr);
         tcp_recv(_pcb, nullptr);

--- a/libraries/WiFi/src/include/UdpContext.h
+++ b/libraries/WiFi/src/include/UdpContext.h
@@ -85,7 +85,7 @@ public:
     }
 
     void unref() {
-        DEBUGV(":ur %d\r\n", _refcnt);
+        DEBUGV(":ur %d", _refcnt);
         if (--_refcnt == 0) {
             delete this;
         }
@@ -183,7 +183,7 @@ public:
             pb = pb->next;
         }
         l += snprintf(&buf[l], sizeof(buf) - l, "(end)");
-        DEBUGV("%s\n", buf);
+        DEBUGV("%s", buf);
     }
 #else
     void printChain(const pbuf* pb, const char* msg) const {
@@ -307,7 +307,7 @@ public:
 
         size_t max_size = _rx_buf_size - _rx_buf_offset;
         size = (size < max_size) ? size : max_size;
-        DEBUGV(":urd %d, %d, %d\r\n", size, _rx_buf_size, _rx_buf_offset);
+        DEBUGV(":urd %d, %d, %d", size, _rx_buf_size, _rx_buf_offset);
 
         void* buf = pbuf_get_contiguous(_rx_buf, dst, size, size, _rx_buf_offset);
         if (!buf) {
@@ -424,7 +424,7 @@ private:
 
         err_t err = udp_sendto(_pcb, tx_copy, addr, port);
         if (err != ERR_OK) {
-            DEBUGV(":ust rc=%d\r\n", (int) err);
+            DEBUGV(":ust rc=%d", (int) err);
         }
 
         pbuf_free(tx_copy);
@@ -494,7 +494,7 @@ private:
             if (p) {
                 // pbuf chain too deep, dropping
                 pbuf_free(pb);
-                DEBUGV(":udr\r\n");
+                DEBUGV(":udr");
                 return;
             }
         }
@@ -528,7 +528,7 @@ private:
             pbuf_cat(_rx_buf, pb_helper);
 
             // now chain the new data pbuf
-            DEBUGV(":urch %d, %d\r\n", _rx_buf->tot_len, pb->tot_len);
+            DEBUGV(":urch %d, %d", _rx_buf->tot_len, pb->tot_len);
             pbuf_cat(_rx_buf, pb);
         } else {
             _currentAddr.srcaddr = srcaddr;
@@ -536,7 +536,7 @@ private:
             _currentAddr.srcport = srcport;
             _currentAddr.input_netif = ip_current_input_netif();
 
-            DEBUGV(":urn %d\r\n", pb->tot_len);
+            DEBUGV(":urn %d", pb->tot_len);
             _first_buf_taken = false;
             _rx_buf = pb;
             _rx_buf_offset = 0;

--- a/libraries/lwIP_Ethernet/src/LwipIntf.cpp
+++ b/libraries/lwIP_Ethernet/src/LwipIntf.cpp
@@ -141,7 +141,7 @@ bool LwipIntf::hostname(const char* aHostname) {
     if (len == 0 || len > 32) {
         // nonos-sdk limit is 32
         // (dhcp hostname option minimum size is ~60)
-        //        DEBUGV("WiFi.(set)hostname(): empty or large(>32) name\n");
+        //        DEBUGV("WiFi.(set)hostname(): empty or large(>32) name");
         return false;
     }
 
@@ -156,7 +156,7 @@ bool LwipIntf::hostname(const char* aHostname) {
     }
 
     if (!compliant) {
-        //       DEBUGV("hostname '%s' is not compliant with RFC952\n", aHostname);
+        //       DEBUGV("hostname '%s' is not compliant with RFC952", aHostname);
     }
 
     bool ret = true;
@@ -174,7 +174,7 @@ bool LwipIntf::hostname(const char* aHostname) {
             // renew already started DHCP leases
             err_t lwipret = dhcp_renew(intf);
             if (lwipret != ERR_OK) {
-                //                DEBUGV("WiFi.hostname(%s): lwIP error %d on interface %c%c (index %d)\n",
+                //                DEBUGV("WiFi.hostname(%s): lwIP error %d on interface %c%c (index %d)",
                 //                       intf->hostname, (int)lwipret, intf->name[0], intf->name[1], intf->num);
                 ret = false;
             }

--- a/libraries/lwIP_Ethernet/src/LwipIntfCB.cpp
+++ b/libraries/lwIP_Ethernet/src/LwipIntfCB.cpp
@@ -41,7 +41,7 @@ extern "C" void netif_status_changed(struct netif* netif) {
 bool LwipIntf::stateChangeSysCB(LwipIntf::CBType&& cb) {
     if (netifStatusChangeListLength >= NETIF_STATUS_CB_SIZE) {
 #if defined(DEBUG_RP2040_CORE)
-        DEBUGV("NETIF_STATUS_CB_SIZE is too low\n");
+        DEBUGV("NETIF_STATUS_CB_SIZE is too low");
 #endif
         return false;
     }

--- a/libraries/lwIP_Ethernet/src/LwipIntfDev.h
+++ b/libraries/lwIP_Ethernet/src/LwipIntfDev.h
@@ -297,7 +297,7 @@ bool LwipIntfDev<RawDev>::config(const IPAddress& localIP, const IPAddress& gate
                                  const IPAddress& netmask, const IPAddress& dns1,
                                  const IPAddress& dns2) {
     if (_started) {
-        DEBUGV("LwipIntfDev: use config() then begin()\n");
+        DEBUGV("LwipIntfDev: use config() then begin()");
         return false;
     }
 
@@ -430,7 +430,7 @@ bool LwipIntfDev<RawDev>::begin(const uint8_t* macAddress, const uint16_t mtu) {
 #if LWIP_IPV6_DHCP6_STATELESS
     err_t __res = dhcp6_enable_stateless(&_netif);
     (void) __res; // Not used except for debug
-    DEBUGV("LwipIntfDev: Enabled DHCP6 stateless: %d\n", __res);
+    DEBUGV("LwipIntfDev: Enabled DHCP6 stateless: %d", __res);
 #endif
 
     _started = true;


### PR DESCRIPTION
Fixes #3510.

`DEBUGV`, `DEBUGCORE`, `DEBUGWIRE`, `DEBUGSPI` (in `debug_internal.h`) and `DEBUGBLE` (in `BLEDebug.h`) now concatenate `"\r\n"` onto the format string:

```cpp
#define DEBUGV(fmt, ...) do { DEBUG_RP2040_PORT.printf(fmt "\r\n", ## __VA_ARGS__); DEBUG_RP2040_PORT.flush(); } while (0)
```

This requires the format argument to be a string literal, which it already was at every one of the ~350 call sites (a few use `"..." PRIu32 "..."`, which is still a literal after preprocessing). The line ending is a single write, so the other core can't interleave between the text and the newline. `\r\n` matches `Print::println()`.

**Mechanical changes:** every call site has its trailing `\n` or `\r\n` stripped (the tree was a mix of both). The six call sites that had no line ending at all (`FS::begin`, `FatFSImpl::openFile`, `LittleFS` size check, `SDFSImpl::openFile`, two in `UdpContext`) now get one for free.

**Hand-edited call sites, worth a look:**
- `BluetoothHCI::setBLEName()` printed the ATTDB hex dump as `"ATTDB: "` + a loop of `"%02X "` + `"\n"`. It now builds the hex into a `String` and prints it with one `DEBUGV`, under `#if defined(DEBUG_RP2040_PORT)` so no work is done when debugging is off.
- `A2DPSource::connect()` and `BluetoothHIDMaster::connectBLE()` printed `"Scan connecting %s at %s ... "` and then `"Connection established\n"` or `"Failed\n"` on the same line. These are now separate lines, and the bare `"Failed"` was renamed `"Connection failed"` so it reads sensibly on its own.
- `A2DPSink.cpp` had `DEBUGV("\n\n")` after the supported-notifications list, and `A2DPSource.cpp` had `"A2DP Source: Signaling released.\n\n"`. Both now emit one line rather than one line plus a blank one. `BluetoothMediaConfigurationSBC::dump()` ends with `DEBUGV("")`, which still produces a single blank separator line.
- Two format strings had a stray space before the newline (`"... a2dp_cid 0x%02x \n"`, `"bitpool_value [%d, %d] \n"`); the space was dropped too.

**Not touched:** `DEBUG_HTTPCLIENT` (HTTPClient.h) and `DEBUG_BSSL` (WiFiClientSecureBearSSL.cpp, CertStoreBearSSL.cpp) are separate library-local macros with their own conventions and are left alone.

**Verification:** every remaining format-string expression was extracted and compiled on the host as `const char *f = <expr> "\r\n";` with `-Wall -Werror`, plus a check that no `\n` or `\r` remains in any of them. I don't have `arduino-cli` or `astyle` locally, so I'm relying on CI for the full build and style check. Anyone outside the core using `DEBUGV` with their own trailing newline will now get a blank line between messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sobzdo3ykmeJJRdKSMtMn7
