### PR TITLE
uf2conv.py: run udisksctl non-interactively so it can't hang on a password prompt

### DIFF
--- a/tools/uf2conv.py
+++ b/tools/uf2conv.py
@@ -272,8 +272,13 @@ def get_drives():
             rpidisk = glob.glob(globexpr)
             if len(rpidisk) > 0:
                 try:
-                    cmd = ["udisksctl", "mount", "--block-device", os.path.realpath(rpidisk[0])]
-                    proc_out = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                    # this runs deep in the Arduino build framework; use
+                    # --no-user-interaction to avoid getting stuck at a prompt
+                    cmd = ["udisksctl", "mount", "--no-user-interaction",
+                           "--block-device", os.path.realpath(rpidisk[0])]
+                    proc_out = subprocess.run(cmd, stdin=subprocess.DEVNULL,
+                                              stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+                                              timeout=30)
                     if proc_out.returncode == 0:
                         stdoutput = proc_out.stdout.decode("UTF-8")
                         match = re.search(r'Mounted\s+.*\s+at\s+([^\.\r\n]*)', stdoutput)


### PR DESCRIPTION
On Linux, `uf2conv.py` tries `udisksctl mount` on the RPI-RP2 partition if it isn't mounted yet ("heroic attempt"). When the caller isn't in an active local session (for me: logged in over ssh while the console sits at a lock screen, so GNOME doesn't automount), polkit requires admin authentication for that mount, and udisksctl's text agent prompts for a password directly on `/dev/tty`:

```
Scanning for RP2040 devices
==== AUTHENTICATING FOR org.freedesktop.udisks2.filesystem-mount ====
Authentication is required to mount RPI RP2 (/dev/sdb1)
Authenticating as: Daniel Egnor,,, (egnor)
Password:
```

Nothing can answer that prompt: udisksctl is running several processes below arduino-cli, outside the terminal's foreground process group, so typing just echoes to the shell. The journal shows `pam_unix(polkit-1:auth): conversation failed`, and the upload hangs until interrupted. `pluggable_discovery.py` calls the same code every two seconds from a background thread, so `==== AUTHENTICATION FAILED ====` also gets scribbled on the terminal after `arduino-cli` has already exited.

This passes `--no-user-interaction`, so udisks fails immediately with `NotAuthorizedCanObtain` in that situation and `uf2conv.py` falls through to scanning the usual mount directories as before. It also detaches stdin and adds a generous timeout so the attempt can never block an upload indefinitely.

Verified on Ubuntu 26.04 (udisks 2.10.91, polkit 127) with a Feather RP2040:
- over ssh with the drive unmounted, the mount attempt now returns in ~0.1 s with no prompt, with or without a controlling tty;
- an already-mounted drive is still found through the "already mounted at" message;
- from an active local session the mount still succeeds and the drive is flashed as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CgLNvxZYmDN3w3SuQw9uu
