### PR TITLE
uf2conv.py: don't flash the same UF2 drive twice via different paths

### DIFF
--- a/tools/uf2conv.py
+++ b/tools/uf2conv.py
@@ -300,6 +300,8 @@ def get_drives():
             possibly_any("/var/run/media", drives, u)
             # Add from udisksctl info?
             # Add from /proc/mounts?
+            # avoid uploading twice due to symlinks (eg. /var/run => /run)
+            drives = list(set(os.path.realpath(d) for d in drives))
 
     def has_info(d):
         try:


### PR DESCRIPTION
`uf2conv.py` scans several directories for mounted UF2 drives, and on most Linux systems more than one of them leads to the same mount point, since `/var/run` is a symlink to `/run`. The drive then gets flashed twice:

```
Flashing /run/media/egnor/RPI-RP2 (RPI-RP2)
Wrote 184320 bytes to /run/media/egnor/RPI-RP2/NEW.UF2
Flashing /var/run/media/egnor/RPI-RP2 (RPI-RP2)
Wrote 184320 bytes to /var/run/media/egnor/RPI-RP2/NEW.UF2
```

The second write only works because the board hasn't finished rebooting yet; if it has, the write fails with an I/O error after the upload actually succeeded.

This deduplicates the Linux drive list by `os.path.realpath()`. The Windows and macOS branches aren't touched.

Verified with a Feather RP2040 on Ubuntu 26.04: with the drive mounted at `/media/RPI-RP2` and a symlink `/mnt/RPI-RP2` pointing at it, `uf2conv.py --list` shows both paths before and only `/media/RPI-RP2` after; the udisks case above (`/run/media` + `/var/run/media`) collapses to one entry the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017CgLNvxZYmDN3w3SuQw9uu
