### PR TITLE
Fix swapped D13/D15 pins on Seeed XIAO RP2040 Plus

### DIFF
--- a/variants/seeed_xiao_rp2040_plus/pins_arduino.h
+++ b/variants/seeed_xiao_rp2040_plus/pins_arduino.h
@@ -37,10 +37,10 @@ static const uint8_t D10 = (3u);   // GPIO3  / MOSI
 // D11: not pinned out as GPIO (used internally)
 
 // D12-D27: new pins on XIAO RP2040 Plus
-static const uint8_t D12 = (18u);  // GPIO18 / SDA1
-static const uint8_t D13 = (19u);  // GPIO19 / SCL1
-static const uint8_t D14 = (20u);  // GPIO20
-static const uint8_t D15 = (21u);  // GPIO21
+static const uint8_t D12 = (18u);  // GPIO18
+static const uint8_t D13 = (21u);  // GPIO21 / SCL1
+static const uint8_t D14 = (20u);  // GPIO20 / SDA1
+static const uint8_t D15 = (19u);  // GPIO19
 static const uint8_t D16 = (22u);  // GPIO22
 static const uint8_t D17 = (23u);  // GPIO23
 // D18: not defined on this schematic
@@ -105,7 +105,7 @@ static const uint8_t SCK  = PIN_SPI0_SCK;
 // ------------------------------------
 #define __WIRE1_DEVICE  (i2c0)
 #define PIN_WIRE1_SDA   (20u)  // GPIO20 / D14
-#define PIN_WIRE1_SCL   (21u)  // GPIO21 / D15
+#define PIN_WIRE1_SCL   (21u)  // GPIO21 / D13
 
 // Interface counts
 #define SERIAL_HOWMANY  (1u)


### PR DESCRIPTION
Fixes the swapped `D13`/`D15` mapping in the `seeed_xiao_rp2040_plus` variant (introduced in #3428).

The variant mapped the Plus-only pads sequentially (`GPIO18,19,20,21` -> `D12..D15`), but per the official Seeed Studio wiki pin map and the board schematic the actual pad order is **18, 21, 20, 19**:

| Pin | Should be | Was |
| --- | --- | --- |
| D13 | **GPIO21** (SCL1) | GPIO19 |
| D14 | GPIO20 (SDA1) | GPIO20 (correct) |
| D15 | **GPIO19** | GPIO21 |

Evidence:

- Official wiki pin map (https://wiki.seeedstudio.com/XIAO-RP2040/, "Pin Map"): `D13 | SCL1 | GPIO21 | Plus-only I2C1 clock`, `D14 | SDA1 | GPIO20`, `D15 | GPIO | GPIO19`
- Board schematic net labels: `GPIO21/SCL1/D13`, `GPIO20/SDA1/D14`, `GPIO19/D15`
- MicroPython had the identical bug, fixed in https://github.com/micropython/micropython/pull/19695

Impact: sketches referencing `D13`/`D15` by number drove the opposite pad. `Wire1` users were unaffected (`PIN_WIRE1_SCL=21` / `PIN_WIRE1_SDA=20` were already correct), which is probably why this went unnoticed.

Also tidies the neighboring comments to match the board labels (SDA1 is on D14; `PIN_WIRE1_SCL` / GPIO21 is D13). `PIN_NEOPIXEL` / `NEOPIXEL_POWER` / `BAT_EN` are correct as-is (#3441).